### PR TITLE
Diff view improvements + DB connection fix

### DIFF
--- a/src/actor/db.py
+++ b/src/actor/db.py
@@ -22,6 +22,15 @@ class Database:
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
 
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> Database:
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
     @classmethod
     def open(cls, path: str) -> Database:
         if path == ":memory:":

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -284,22 +284,45 @@ class ActorWatchApp(App):
         try:
             is_dark = self.current_theme.dark if self.current_theme else True
             from rich.console import Group
+            import difflib
             parts = []
+            total_added = 0
+            total_removed = 0
             for fd in result.files:
                 parts.append(render_edit_diff(fd.file_path, fd.old_content, fd.new_content, dark=is_dark, style="diff"))
-            self.call_from_thread(self._set_diff_widget, Static(Group(*parts)))
+                for line in difflib.unified_diff(fd.old_content.splitlines(), fd.new_content.splitlines(), lineterm=""):
+                    if line.startswith("+") and not line.startswith("+++"):
+                        total_added += 1
+                    elif line.startswith("-") and not line.startswith("---"):
+                        total_removed += 1
+            self.call_from_thread(self._set_diff_widget, Static(Group(*parts)), total_added, total_removed)
         except Exception as e:
             self.call_from_thread(self._set_diff_text, f"Diff error: {e}")
+
+    def _update_diff_tab_label(self, added: int = 0, removed: int = 0) -> None:
+        tabs = self.query_one("#tabs", TabbedContent)
+        tab = tabs.get_tab("diff")
+        if added or removed:
+            parts = []
+            if added:
+                parts.append(f"+{added}")
+            if removed:
+                parts.append(f"-{removed}")
+            tab.label = f"Diff ({', '.join(parts)})"
+        else:
+            tab.label = "Diff"
 
     def _set_diff_text(self, text: str) -> None:
         scroll = self.query_one("#diff-scroll", VerticalScroll)
         scroll.remove_children()
         scroll.mount(Static(text))
+        self._update_diff_tab_label()
 
-    def _set_diff_widget(self, dv: object) -> None:
+    def _set_diff_widget(self, dv: object, added: int = 0, removed: int = 0) -> None:
         scroll = self.query_one("#diff-scroll", VerticalScroll)
         scroll.remove_children()
         scroll.mount(dv)
+        self._update_diff_tab_label(added, removed)
 
     # -- Runs ----------------------------------------------------------------
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -286,7 +286,7 @@ class ActorWatchApp(App):
             from rich.console import Group
             parts = []
             for fd in result.files:
-                parts.append(render_edit_diff(fd.file_path, fd.old_content, fd.new_content, dark=is_dark))
+                parts.append(render_edit_diff(fd.file_path, fd.old_content, fd.new_content, dark=is_dark, style="diff"))
             self.call_from_thread(self._set_diff_widget, Static(Group(*parts)))
         except Exception as e:
             self.call_from_thread(self._set_diff_text, f"Diff error: {e}")

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -277,19 +277,17 @@ class ActorWatchApp(App):
 
         result = compute_diff(actor)
 
-        if result.data is None:
+        if result.files is None:
             self.call_from_thread(self._set_diff_text, result.reason)
-            return
-
-        path_orig, path_mod, orig, mod = result.data
-        if orig == mod:
-            self.call_from_thread(self._set_diff_text, "Working tree clean")
             return
 
         try:
             is_dark = self.current_theme.dark if self.current_theme else True
-            renderable = render_edit_diff(path_mod, orig, mod, dark=is_dark)
-            self.call_from_thread(self._set_diff_widget, Static(renderable))
+            from rich.console import Group
+            parts = []
+            for fd in result.files:
+                parts.append(render_edit_diff(fd.file_path, fd.old_content, fd.new_content, dark=is_dark))
+            self.call_from_thread(self._set_diff_widget, Static(Group(*parts)))
         except Exception as e:
             self.call_from_thread(self._set_diff_text, f"Diff error: {e}")
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -303,12 +303,7 @@ class ActorWatchApp(App):
         tabs = self.query_one("#tabs", TabbedContent)
         tab = tabs.get_tab("diff")
         if added or removed:
-            parts = []
-            if added:
-                parts.append(f"+{added}")
-            if removed:
-                parts.append(f"-{removed}")
-            tab.label = f"Diff ({', '.join(parts)})"
+            tab.label = f"Diff ±{added + removed}"
         else:
             tab.label = "Diff"
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -152,13 +152,13 @@ class ActorWatchApp(App):
 
     @staticmethod
     def _fetch_actors() -> tuple[list[Actor], dict[str, Status]]:
-        db = Database.open(_db_path())
-        pm = RealProcessManager()
-        actors = db.list_actors()
-        statuses = {}
-        for a in actors:
-            statuses[a.name] = db.resolve_actor_status(a.name, pm)
-        return actors, statuses
+        with Database.open(_db_path()) as db:
+            pm = RealProcessManager()
+            actors = db.list_actors()
+            statuses = {}
+            for a in actors:
+                statuses[a.name] = db.resolve_actor_status(a.name, pm)
+            return actors, statuses
 
     @work(thread=True)
     def _poll_actors_async(self) -> None:
@@ -306,8 +306,8 @@ class ActorWatchApp(App):
     # -- Runs ----------------------------------------------------------------
 
     def _refresh_runs(self, actor: Actor) -> None:
-        db = Database.open(_db_path())
-        runs, _total = db.list_runs(actor.name, limit=50)
+        with Database.open(_db_path()) as db:
+            runs, _total = db.list_runs(actor.name, limit=50)
         table = self.query_one("#runs-table", DataTable)
         table.clear(columns=True)
         table.add_columns("#", "Status", "Exit", "Prompt", "Started", "Duration")

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -303,7 +303,7 @@ class ActorWatchApp(App):
         tabs = self.query_one("#tabs", TabbedContent)
         tab = tabs.get_tab("diff")
         if added or removed:
-            tab.label = f"Diff ±{added + removed}"
+            tab.label = f"Diff (±{added + removed})"
         else:
             tab.label = "Diff"
 

--- a/src/actor/watch/diff_render.py
+++ b/src/actor/watch/diff_render.py
@@ -213,13 +213,14 @@ def render_edit_diff(
 
     for line in diff:
         if line.startswith('@@'):
-            # Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
-            match = re.match(r'^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@', line)
+            match = re.match(r'^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)', line)
             if match:
                 old_num = int(match.group(1))
                 new_num = int(match.group(2))
-                if entries:  # Add ellipsis between hunks
-                    entries.append({"type": "ellipsis"})
+                if entries:
+                    entries.append({"type": "hunk", "header": line})
+                else:
+                    entries.append({"type": "hunk", "header": line})
             continue
         if line.startswith('---') or line.startswith('+++'):
             continue
@@ -301,12 +302,19 @@ def render_edit_diff(
     table.add_column(ratio=1)                              # code
 
     for i, entry in enumerate(entries):
-        if entry["type"] == "ellipsis":
-            table.add_row(
-                Text("", style="dim"),
-                Text("", style="dim"),
-                Text("...", style="dim"),
-            )
+        if entry["type"] == "hunk":
+            if style == "diff":
+                table.add_row(
+                    Text("", style="dim"),
+                    Text("", style="dim"),
+                    Text(entry["header"], style="dim cyan"),
+                )
+            else:
+                table.add_row(
+                    Text("", style="dim"),
+                    Text("", style="dim"),
+                    Text("...", style="dim"),
+                )
             continue
 
         num = entry["num"]

--- a/src/actor/watch/diff_render.py
+++ b/src/actor/watch/diff_render.py
@@ -182,8 +182,14 @@ def render_edit_diff(
     new_string: str,
     dark: bool = True,
     context_lines: int = 3,
+    style: str = "log",
 ) -> Group:
-    """Render a file edit diff as a Rich Group renderable."""
+    """Render a file edit diff as a Rich Group renderable.
+
+    Args:
+        style: "log" for Claude Code tool call style (⏺ Edit header),
+               "diff" for magit-style (file status + path).
+    """
     colors = DARK_COLORS if dark else LIGHT_COLORS
     lexer = _get_lexer(file_path)
 
@@ -253,22 +259,35 @@ def render_edit_diff(
     # Build output
     output: list = []
 
-    # Header
-    header = Text()
-    header.append("⏺ ", style="bold")
-    header.append("Edit", style="bold")
-    header.append(f"({file_path})", style="dim")
-    output.append(header)
+    if style == "log":
+        # Claude Code tool call style
+        header = Text()
+        header.append("⏺ ", style="bold")
+        header.append("Edit", style="bold")
+        header.append(f"({file_path})", style="dim")
+        output.append(header)
 
-    # Summary
-    summary = Text("  ⎿  ", style="dim")
-    if added and removed:
-        summary.append(f"Added {added}, removed {removed} lines", style="dim")
-    elif added:
-        summary.append(f"Added {added} lines", style="dim")
-    elif removed:
-        summary.append(f"Removed {removed} lines", style="dim")
-    output.append(summary)
+        summary = Text("  ⎿  ", style="dim")
+        if added and removed:
+            summary.append(f"Added {added}, removed {removed} lines", style="dim")
+        elif added:
+            summary.append(f"Added {added} lines", style="dim")
+        elif removed:
+            summary.append(f"Removed {removed} lines", style="dim")
+        output.append(summary)
+    else:
+        # Magit-style file header
+        file_status = "new file" if not old_string else "deleted" if not new_string else "modified"
+        header = Text()
+        header.append(f"{file_status}   ", style="bold")
+        header.append(file_path)
+        stats = Text()
+        if added:
+            stats.append(f" +{added}", style=f"{colors.added_marker}")
+        if removed:
+            stats.append(f" -{removed}", style=f"{colors.removed_marker}")
+        header.append_text(stats)
+        output.append(header)
 
     # Diff table
     table = Table(

--- a/src/actor/watch/diff_render.py
+++ b/src/actor/watch/diff_render.py
@@ -304,11 +304,13 @@ def render_edit_diff(
     for i, entry in enumerate(entries):
         if entry["type"] == "hunk":
             if style == "diff":
-                table.add_row(
-                    Text("", style="dim"),
-                    Text("", style="dim"),
-                    Text(entry["header"], style="dim cyan"),
-                )
+                if table.row_count:
+                    output.append(table)
+                    table = Table(show_header=False, box=None, padding=0, expand=True)
+                    table.add_column(width=num_width + 2, no_wrap=True)
+                    table.add_column(width=1, no_wrap=True)
+                    table.add_column(ratio=1)
+                output.append(Text(entry["header"], style="#D77757"))
             else:
                 table.add_row(
                     Text("", style="dim"),

--- a/src/actor/watch/diff_render.py
+++ b/src/actor/watch/diff_render.py
@@ -310,7 +310,8 @@ def render_edit_diff(
                     table.add_column(width=num_width + 2, no_wrap=True)
                     table.add_column(width=1, no_wrap=True)
                     table.add_column(ratio=1)
-                output.append(Text(entry["header"], style="#D77757"))
+                output.append(Text(entry["header"], style=f"{colors.dim}"))
+                output.append(Text(""))
             else:
                 table.add_row(
                     Text("", style="dim"),

--- a/src/actor/watch/helpers.py
+++ b/src/actor/watch/helpers.py
@@ -79,10 +79,18 @@ def read_log_entries(actor: Actor) -> list:
 
 # -- Compute git diff --------------------------------------------------------
 
+class FileDiff:
+    """Diff for a single file."""
+    def __init__(self, file_path: str, old_content: str, new_content: str) -> None:
+        self.file_path = file_path
+        self.old_content = old_content
+        self.new_content = new_content
+
+
 class DiffResult:
     """Result of compute_diff."""
-    def __init__(self, data: tuple[str, str, str, str] | None = None, reason: str = "") -> None:
-        self.data = data
+    def __init__(self, files: list[FileDiff] | None = None, reason: str = "") -> None:
+        self.files = files
         self.reason = reason
 
 
@@ -131,27 +139,26 @@ def compute_diff(actor: Actor) -> DiffResult:
         if not files:
             return DiffResult(reason="working tree clean")
 
-        orig_parts = []
-        mod_parts = []
+        file_diffs = []
         for f in files:
             orig_result = subprocess.run(
                 ["git", "show", f"{diff_ref}:{f}"],
                 capture_output=True, text=True, cwd=worktree_dir,
             )
-            orig_parts.append(f"# {f}\n" + (orig_result.stdout if orig_result.returncode == 0 else ""))
+            old_content = orig_result.stdout if orig_result.returncode == 0 else ""
 
             file_path = Path(worktree_dir) / f
             try:
-                mod_content = file_path.read_text()
+                new_content = file_path.read_text()
             except (FileNotFoundError, OSError):
-                mod_content = ""
-            mod_parts.append(f"# {f}\n" + mod_content)
+                new_content = ""
 
-        return DiffResult(data=(
-            diff_ref[:12],
-            f"{actor.name} (working tree)",
-            "\n".join(orig_parts),
-            "\n".join(mod_parts),
-        ))
+            if old_content != new_content:
+                file_diffs.append(FileDiff(f, old_content, new_content))
+
+        if not file_diffs:
+            return DiffResult(reason="working tree clean")
+
+        return DiffResult(files=file_diffs)
     except Exception:
         return DiffResult(reason="error")


### PR DESCRIPTION
## Summary

- Fix file descriptor leak — DB connections now use context managers
- Per-file diff rendering with correct syntax highlighting
- Two diff styles: `log` (Claude Code ⏺ Edit header) and `diff` (magit-style)
- Diff tab shows magit-style: file status, `@@` hunk headers, stats
- Diff tab label shows total changes: `Diff (±53)`

## Changes

- **DB leak fix**: `Database` now supports `close()` and context manager (`with Database.open(...) as db:`). Watch app closes connections after each poll instead of leaking them.
- **Per-file diffs**: `compute_diff` returns `list[FileDiff]` instead of concatenated blobs. Each file gets its own Pygments lexer for correct syntax highlighting.
- **Diff styles**: `render_edit_diff(..., style="log"|"diff")` — log view uses Claude Code tool call headers, diff tab uses magit-style with `modified`/`new file`/`deleted` status + `@@` hunk headers.
- **Tab label**: Diff tab dynamically shows `Diff (±N)` with total line changes.

## Test plan

- [ ] `actor watch` doesn't leak file descriptors on long runs
- [ ] Diff tab shows syntax-highlighted per-file diffs
- [ ] New files show `new file` header, modified show `modified`
- [ ] `@@` hunk headers appear between distant changes
- [ ] Diff tab label shows `Diff (±N)` with correct count
- [ ] Log view still shows `⏺ Edit(file)` style for tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)