### PR TITLE
Splash screen + clear detail pane when no actor is selected

### DIFF
--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -23,6 +23,7 @@ from ..process import RealProcessManager
 from ..types import Actor, Status
 from ..cli import _db_path
 from .patches import apply_patches
+from .splash import Splash
 from .themes import CLAUDE_DARK, CLAUDE_LIGHT
 from .tree import ActorTree
 from .helpers import read_log_entries, compute_diff
@@ -87,6 +88,12 @@ class ActorWatchApp(App):
         padding: 0 1;
         color: $text-muted;
     }
+    #splash, #main-layout {
+        display: none;
+    }
+    #splash.-active, #main-layout.-active {
+        display: block;
+    }
     """
 
     BINDINGS = [
@@ -105,9 +112,15 @@ class ActorWatchApp(App):
     _prev_statuses: dict[str, Status] = {}
     _current_actors: list[Actor] = []
     _diff_loaded_for: str | None = None
+    _splash_active: bool = False
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        if self._splash_active and action != "quit":
+            return False
+        return True
 
     def compose(self) -> ComposeResult:
-        with Horizontal():
+        with Horizontal(id="main-layout"):
             with Vertical(id="actor-panel"):
                 yield Static(" ★ ACTOR.SH", id="actor-title")
                 yield ActorTree()
@@ -122,6 +135,7 @@ class ActorWatchApp(App):
                             Static("Select an actor", id="info-content"),
                             DataTable(id="runs-table"),
                         )
+        yield Splash(id="splash")
         yield Static("Loading...", id="status-bar")
         yield Footer(show_command_palette=False)
 
@@ -198,6 +212,19 @@ class ActorWatchApp(App):
 
         actor_list = self.query_one(ActorTree)
         actor_list.update_actors(actors, statuses)
+
+        main = self.query_one("#main-layout")
+        splash = self.query_one("#splash")
+        was_splash = self._splash_active
+        self._splash_active = not actors
+        if self._splash_active:
+            main.set_class(False, "-active")
+            splash.set_class(True, "-active")
+        else:
+            main.set_class(True, "-active")
+            splash.set_class(False, "-active")
+        if was_splash != self._splash_active:
+            self.refresh_bindings()
 
         running = sum(1 for s in statuses.values() if s == Status.RUNNING)
         done = sum(1 for s in statuses.values() if s == Status.DONE)

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -215,6 +215,7 @@ class ActorWatchApp(App):
         actor_list = self.query_one(ActorTree)
         actor = actor_list.selected_actor
         if actor is None:
+            self._clear_detail()
             return
 
         status = self._prev_statuses.get(actor.name, Status.IDLE)
@@ -235,6 +236,24 @@ class ActorWatchApp(App):
 
         self._refresh_runs(actor)
         self._refresh_logs(actor)
+
+    def _clear_detail(self) -> None:
+        info = self.query_one("#info-content", Static)
+        info.update("Select an actor")
+
+        table = self.query_one("#runs-table", DataTable)
+        table.clear(columns=True)
+
+        log = self.query_one("#logs-content", RichLog)
+        log.clear()
+        self._last_log_actor = None
+        self._last_log_count = 0
+        self._last_log_entries = []
+
+        scroll = self.query_one("#diff-scroll", VerticalScroll)
+        scroll.remove_children()
+        self._diff_loaded_for = None
+        self._update_diff_tab_label()
 
     # -- Logs ----------------------------------------------------------------
 

--- a/src/actor/watch/splash.py
+++ b/src/actor/watch/splash.py
@@ -49,7 +49,6 @@ SPATIAL_RANGE = 3.0
 # → amp² threshold for bucket k is (k / (N_TEX-1))^(1/0.65) / 18
 _INV_EXP = 1.0 / 0.65
 _AMP_SQ_THRESHOLDS = [((k / (N_TEX - 1)) ** _INV_EXP) / 18.0 for k in range(N_TEX)]
-_BOLD_FROM = int(0.75 * (N_TEX - 1)) + 1  # buckets 16..21 are bold
 
 
 def _factorial(n: int) -> float:
@@ -101,9 +100,22 @@ class Splash(Widget):
         self._cached_size: tuple[int, int] | None = None
         self._grids: list[list[list[float]]] | None = None
         self._style_cache: dict[str, Style] = {}
+        # Per-frame cache — populated by _prepare_frame, used by render_line
+        self._frame_dirty = True
+        self._frame: dict | None = None
+        # Theme-dependent cache
+        self._theme_key: str | None = None
+        self._styles: dict[str, Style] | None = None
+        # Size-dependent cache (box layout)
+        self._geometry: dict | None = None
+        self._geometry_size: tuple[int, int] | None = None
 
     def on_mount(self) -> None:
-        self.set_interval(1 / 20, self.refresh)
+        self.set_interval(1 / 15, self._tick)
+
+    def _tick(self) -> None:
+        self._frame_dirty = True
+        self.refresh()
 
     def _get_style(self, spec: str) -> Style:
         cached = self._style_cache.get(spec)
@@ -137,42 +149,28 @@ class Splash(Widget):
             return t.secondary, t.primary, t.foreground, t.panel
         return "#D77757", "#B1B9F9", "#FFFFFF", "#2C323E"
 
-    def _compute_frame_params(self) -> tuple[float, float, int, int] | None:
-        """Return (s, 1-s, idx, nxt) for the current time, or None if size is zero."""
-        rows = self.size.height
-        cols = self.size.width
-        if rows <= 0 or cols <= 0:
-            return None
-        self._ensure_grids(rows, cols)
-
-        t = time.monotonic() - self._start
-        idx = int(t / CYCLE_SECONDS) % len(STATES)
-        nxt = (idx + 1) % len(STATES)
-        local = (t / CYCLE_SECONDS) - math.floor(t / CYCLE_SECONDS)
-        s = 0.5 - 0.5 * math.cos(local * math.pi)
-        return s, 1.0 - s, idx, nxt
-
-    def render_line(self, y: int) -> Strip:
-        params = self._compute_frame_params()
-        if params is None or self._grids is None:
-            return Strip.blank(self.size.width)
-        s, one_minus_s, idx, nxt = params
-
-        rows = self.size.height
-        cols = self.size.width
-        a_row = self._grids[idx][y]
-        b_row = self._grids[nxt][y]
-
+    def _ensure_styles(self) -> None:
+        t = self.app.current_theme
+        key = t.name if t is not None else "_default"
+        if self._styles is not None and self._theme_key == key:
+            return
         logo_color, anim_color, border_color, panel_color = self._theme_colors()
-        anim_plain_style = self._get_style(anim_color)
-        anim_bold_style = self._get_style(f"bold {anim_color}")
-        box_bg_style = self._get_style(f"on {panel_color}")
-        border_style = self._get_style(f"{border_color} on {panel_color}")
-        logo_style = self._get_style(f"bold {logo_color} on {panel_color}")
-        tagline_style = self._get_style(f"{logo_color} on {panel_color}")
-        hint_style = self._get_style(f"dim {anim_color} on {panel_color}")
+        self._styles = {
+            "anim": self._get_style(anim_color),
+            "border": self._get_style(f"{border_color} on {panel_color}"),
+            "box_bg": self._get_style(f"on {panel_color}"),
+            "logo": self._get_style(f"bold {logo_color} on {panel_color}"),
+            "tagline": self._get_style(f"{logo_color} on {panel_color}"),
+            "hint": self._get_style(f"dim {anim_color} on {panel_color}"),
+        }
+        self._theme_key = key
+        # Box segments depend on styles — invalidate
+        if self._geometry is not None:
+            self._geometry["box_segments"] = None
 
-        # Box geometry: border + padding + content
+    def _ensure_geometry(self, rows: int, cols: int) -> None:
+        if self._geometry is not None and self._geometry_size == (rows, cols):
+            return
         overlay_lines = LOGO + ["", TAGLINE, "", HINT]
         overlay_h = len(overlay_lines)
         overlay_w = max(len(line) for line in overlay_lines)
@@ -182,77 +180,161 @@ class Splash(Widget):
         box_r0 = max(0, (rows - box_h) // 2)
         box_c0 = max(0, (cols - box_w) // 2)
 
-        br = y - box_r0
-        in_box = 0 <= br < box_h
-
-        # Build the per-column content for columns inside the box
-        box_chars: list[str] = []
-        box_styles: list[Style] = []
-        if in_box:
+        # Precompute per-box-row contents: (chars, style_keys) — style lookup happens later
+        rows_content: list[tuple[list[str], list[str]]] = []
+        for br in range(box_h):
             if br == 0:
-                box_chars = ["╭"] + ["─"] * (box_w - 2) + ["╮"]
-                box_styles = [border_style] * box_w
+                chars = ["╭"] + ["─"] * (box_w - 2) + ["╮"]
+                keys = ["border"] * box_w
             elif br == box_h - 1:
-                box_chars = ["╰"] + ["─"] * (box_w - 2) + ["╯"]
-                box_styles = [border_style] * box_w
+                chars = ["╰"] + ["─"] * (box_w - 2) + ["╯"]
+                keys = ["border"] * box_w
             else:
-                box_chars = ["│"] + [" "] * (box_w - 2) + ["│"]
-                box_styles = [border_style] + [box_bg_style] * (box_w - 2) + [border_style]
+                chars = ["│"] + [" "] * (box_w - 2) + ["│"]
+                keys = ["border"] + ["box_bg"] * (box_w - 2) + ["border"]
                 content_row = br - 1 - pad_v
                 if 0 <= content_row < overlay_h:
                     line = overlay_lines[content_row]
                     if line:
                         if content_row < LOGO_H:
-                            line_style = logo_style
+                            line_key = "logo"
                         elif line == HINT:
-                            line_style = hint_style
+                            line_key = "hint"
                         else:
-                            line_style = tagline_style
-                        # Center the content line within the inner box area
+                            line_key = "tagline"
                         inner_start = 1 + pad_h
                         offset = inner_start + (overlay_w - len(line)) // 2
                         for i, ch in enumerate(line):
                             pos = offset + i
                             if 0 <= pos < box_w - 1 and ch != " ":
-                                box_chars[pos] = ch
-                                box_styles[pos] = line_style
+                                chars[pos] = ch
+                                keys[pos] = line_key
+            rows_content.append((chars, keys))
 
-        texture = TEXTURE
+        self._geometry = {
+            "box_w": box_w,
+            "box_h": box_h,
+            "box_r0": box_r0,
+            "box_c0": box_c0,
+            "box_c1": box_c0 + box_w,
+            "rows_content": rows_content,
+            "box_segments": None,  # built lazily once styles are available
+        }
+        self._geometry_size = (rows, cols)
+
+    def _ensure_box_segments(self) -> None:
+        assert self._geometry is not None and self._styles is not None
+        if self._geometry["box_segments"] is not None:
+            return
+        styles = self._styles
+        per_row: list[list[Segment]] = []
+        for chars, keys in self._geometry["rows_content"]:
+            segs: list[Segment] = []
+            run_chars: list[str] = []
+            run_key: str | None = None
+            for i in range(len(chars)):
+                k = keys[i]
+                if k != run_key:
+                    if run_chars:
+                        segs.append(Segment("".join(run_chars), styles[run_key]))
+                        run_chars = []
+                    run_key = k
+                run_chars.append(chars[i])
+            if run_chars:
+                segs.append(Segment("".join(run_chars), styles[run_key]))
+            per_row.append(segs)
+        self._geometry["box_segments"] = per_row
+
+    def _prepare_frame(self) -> None:
+        rows = self.size.height
+        cols = self.size.width
+        if rows <= 0 or cols <= 0:
+            self._frame = None
+            return
+        self._ensure_grids(rows, cols)
+        self._ensure_styles()
+        self._ensure_geometry(rows, cols)
+        self._ensure_box_segments()
+
+        t = time.monotonic() - self._start
+        idx = int(t / CYCLE_SECONDS) % len(STATES)
+        nxt = (idx + 1) % len(STATES)
+        local = (t / CYCLE_SECONDS) - math.floor(t / CYCLE_SECONDS)
+        s = 0.5 - 0.5 * math.cos(local * math.pi)
+
+        self._frame = {
+            "s": s,
+            "one_minus_s": 1.0 - s,
+            "a_grid": self._grids[idx],
+            "b_grid": self._grids[nxt],
+            "rows": rows,
+            "cols": cols,
+        }
+
+    def _anim_segment(
+        self,
+        start: int,
+        end: int,
+        a_row: list[float],
+        b_row: list[float],
+        s: float,
+        one_minus_s: float,
+        style: Style,
+    ) -> Segment:
         thresholds = _AMP_SQ_THRESHOLDS
+        texture = TEXTURE
+        n_tex_m1 = N_TEX - 1
+        chars: list[str] = []
+        for c in range(start, end):
+            amp = one_minus_s * a_row[c] + s * b_row[c]
+            amp_sq = amp * amp
+            bucket = bisect_right(thresholds, amp_sq) - 1
+            if bucket < 0:
+                bucket = 0
+            elif bucket > n_tex_m1:
+                bucket = n_tex_m1
+            chars.append(texture[bucket])
+        return Segment("".join(chars), style)
+
+    def render_line(self, y: int) -> Strip:
+        if self._frame_dirty:
+            self._prepare_frame()
+            self._frame_dirty = False
+
+        frame = self._frame
+        if frame is None:
+            return Strip.blank(self.size.width)
+
+        cols = frame["cols"]
+        a_row = frame["a_grid"][y]
+        b_row = frame["b_grid"][y]
+        s = frame["s"]
+        one_minus_s = frame["one_minus_s"]
+        anim_style = self._styles["anim"]
+
+        geom = self._geometry
+        box_r0 = geom["box_r0"]
+        box_h = geom["box_h"]
+        box_c0 = geom["box_c0"]
+        box_c1 = geom["box_c1"]
+        br = y - box_r0
+        in_box = 0 <= br < box_h
+
+        if not in_box:
+            return Strip(
+                [self._anim_segment(0, cols, a_row, b_row, s, one_minus_s, anim_style)],
+                cols,
+            )
 
         segments: list[Segment] = []
-        run_chars: list[str] = []
-        run_style: Style | None = None
-
-        def flush() -> None:
-            if run_chars:
-                segments.append(Segment("".join(run_chars), run_style))
-
-        box_c1 = box_c0 + box_w
-        for c in range(cols):
-            if in_box and box_c0 <= c < box_c1:
-                bc = c - box_c0
-                ch = box_chars[bc]
-                style = box_styles[bc]
-            else:
-                amp = one_minus_s * a_row[c] + s * b_row[c]
-                amp_sq = amp * amp
-                bucket = bisect_right(thresholds, amp_sq) - 1
-                if bucket < 0:
-                    bucket = 0
-                elif bucket >= N_TEX:
-                    bucket = N_TEX - 1
-                ch = texture[bucket]
-                style = anim_bold_style if bucket >= _BOLD_FROM else anim_plain_style
-
-            if style is not run_style:
-                flush()
-                run_chars = []
-                run_style = style
-            run_chars.append(ch)
-
-        flush()
+        if box_c0 > 0:
+            segments.append(self._anim_segment(0, box_c0, a_row, b_row, s, one_minus_s, anim_style))
+        segments.extend(geom["box_segments"][br])
+        if box_c1 < cols:
+            segments.append(self._anim_segment(box_c1, cols, a_row, b_row, s, one_minus_s, anim_style))
         return Strip(segments, cols)
 
     def on_resize(self) -> None:
         self._cached_size = None
+        self._geometry = None
+        self._frame_dirty = True

--- a/src/actor/watch/splash.py
+++ b/src/actor/watch/splash.py
@@ -1,0 +1,258 @@
+"""Full-screen splash with QHO animation shown when no actors exist."""
+
+from __future__ import annotations
+
+import math
+import time
+from bisect import bisect_right
+
+from rich.segment import Segment
+from rich.style import Style
+from textual.strip import Strip
+from textual.widget import Widget
+
+
+# -- ASCII logo ------------------------------------------------------------
+
+LOGO = [
+    r" █████╗  ██████╗████████╗ ██████╗ ██████╗    ███████╗██╗  ██╗",
+    r"██╔══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗   ██╔════╝██║  ██║",
+    r"███████║██║        ██║   ██║   ██║██████╔╝   ███████╗███████║",
+    r"██╔══██║██║        ██║   ██║   ██║██╔══██╗   ╚════██║██╔══██║",
+    r"██║  ██║╚██████╗   ██║   ╚██████╔╝██║  ██║██╗███████║██║  ██║",
+    r"╚═╝  ╚═╝ ╚═════╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝╚═╝╚══════╝╚═╝  ╚═╝",
+]
+LOGO_H = len(LOGO)
+
+TAGLINE = "Autonomous actor command center."
+HINT = "Spawn one from Claude Code and it will appear here."
+
+
+# -- QHO physics -----------------------------------------------------------
+#
+# 2D Quantum Harmonic Oscillator: ψ_{nx,ny}(x,y) = ψ_nx(x) · ψ_ny(y)
+# with ψ_n(x) = e^{−x²/2} · H_n(x) / sqrt(2^n · n! · √π)
+# Animate by crossfading amplitudes between 8 (nx, ny) pairs.
+
+TEXTURE = " .,:;-~=+*x!tiLC0O8%#@"
+N_TEX = len(TEXTURE)
+
+STATES: list[tuple[int, int]] = [
+    (0, 0), (1, 3), (2, 4), (4, 2), (3, 5), (6, 1), (4, 4), (2, 7),
+]
+
+CYCLE_SECONDS = 7.5
+SPATIAL_RANGE = 3.0
+
+# Threshold of amp² at which each bucket 0..N_TEX-1 becomes active.
+# Derived from: intensity = (amp² * 18)^0.65, bucket = int(intensity * (N_TEX-1))
+# → amp² threshold for bucket k is (k / (N_TEX-1))^(1/0.65) / 18
+_INV_EXP = 1.0 / 0.65
+_AMP_SQ_THRESHOLDS = [((k / (N_TEX - 1)) ** _INV_EXP) / 18.0 for k in range(N_TEX)]
+_BOLD_FROM = int(0.75 * (N_TEX - 1)) + 1  # buckets 16..21 are bold
+
+
+def _factorial(n: int) -> float:
+    f = 1.0
+    for i in range(2, n + 1):
+        f *= i
+    return f
+
+
+def _hermite(n: int, x: float) -> float:
+    if n == 0:
+        return 1.0
+    if n == 1:
+        return 2.0 * x
+    hm2 = 1.0
+    hm1 = 2.0 * x
+    for k in range(2, n + 1):
+        h = 2.0 * x * hm1 - 2.0 * (k - 1) * hm2
+        hm2, hm1 = hm1, h
+    return hm1
+
+
+def _psi1d(n: int, x: float) -> float:
+    norm = 1.0 / math.sqrt((2 ** n) * _factorial(n) * math.sqrt(math.pi))
+    return norm * math.exp(-0.5 * x * x) * _hermite(n, x)
+
+
+def _psi2d(nx: int, ny: int, x: float, y: float) -> float:
+    return _psi1d(nx, x) * _psi1d(ny, y)
+
+
+# -- Widget ----------------------------------------------------------------
+
+
+class Splash(Widget):
+    """Full-screen QHO animation with ACTOR.SH logo overlay."""
+
+    DEFAULT_CSS = """
+    Splash {
+        width: 1fr;
+        height: 1fr;
+        background: ansi_default;
+    }
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._start = time.monotonic()
+        self._cached_size: tuple[int, int] | None = None
+        self._grids: list[list[list[float]]] | None = None
+        self._style_cache: dict[str, Style] = {}
+
+    def on_mount(self) -> None:
+        self.set_interval(1 / 20, self.refresh)
+
+    def _get_style(self, spec: str) -> Style:
+        cached = self._style_cache.get(spec)
+        if cached is None:
+            cached = Style.parse(spec)
+            self._style_cache[spec] = cached
+        return cached
+
+    def _ensure_grids(self, rows: int, cols: int) -> None:
+        if self._cached_size == (rows, cols):
+            return
+        aspect = cols / max(1, rows) * 0.5  # terminal cells ~2x taller than wide
+        grids: list[list[list[float]]] = []
+        for (nx, ny) in STATES:
+            grid = [[0.0] * cols for _ in range(rows)]
+            for r in range(rows):
+                y_norm = ((r + 0.5) / rows) * 2 - 1
+                y = y_norm * SPATIAL_RANGE / aspect
+                for c in range(cols):
+                    x_norm = ((c + 0.5) / cols) * 2 - 1
+                    x = x_norm * SPATIAL_RANGE
+                    grid[r][c] = _psi2d(nx, ny, x, y)
+            grids.append(grid)
+        self._grids = grids
+        self._cached_size = (rows, cols)
+
+    def _theme_colors(self) -> tuple[str, str, str, str]:
+        """(logo, anim, border, box_bg)."""
+        t = self.app.current_theme
+        if t is not None:
+            return t.secondary, t.primary, t.foreground, t.panel
+        return "#D77757", "#B1B9F9", "#FFFFFF", "#2C323E"
+
+    def _compute_frame_params(self) -> tuple[float, float, int, int] | None:
+        """Return (s, 1-s, idx, nxt) for the current time, or None if size is zero."""
+        rows = self.size.height
+        cols = self.size.width
+        if rows <= 0 or cols <= 0:
+            return None
+        self._ensure_grids(rows, cols)
+
+        t = time.monotonic() - self._start
+        idx = int(t / CYCLE_SECONDS) % len(STATES)
+        nxt = (idx + 1) % len(STATES)
+        local = (t / CYCLE_SECONDS) - math.floor(t / CYCLE_SECONDS)
+        s = 0.5 - 0.5 * math.cos(local * math.pi)
+        return s, 1.0 - s, idx, nxt
+
+    def render_line(self, y: int) -> Strip:
+        params = self._compute_frame_params()
+        if params is None or self._grids is None:
+            return Strip.blank(self.size.width)
+        s, one_minus_s, idx, nxt = params
+
+        rows = self.size.height
+        cols = self.size.width
+        a_row = self._grids[idx][y]
+        b_row = self._grids[nxt][y]
+
+        logo_color, anim_color, border_color, panel_color = self._theme_colors()
+        anim_plain_style = self._get_style(anim_color)
+        anim_bold_style = self._get_style(f"bold {anim_color}")
+        box_bg_style = self._get_style(f"on {panel_color}")
+        border_style = self._get_style(f"{border_color} on {panel_color}")
+        logo_style = self._get_style(f"bold {logo_color} on {panel_color}")
+        tagline_style = self._get_style(f"{logo_color} on {panel_color}")
+        hint_style = self._get_style(f"dim {anim_color} on {panel_color}")
+
+        # Box geometry: border + padding + content
+        overlay_lines = LOGO + ["", TAGLINE, "", HINT]
+        overlay_h = len(overlay_lines)
+        overlay_w = max(len(line) for line in overlay_lines)
+        pad_v, pad_h = 1, 2
+        box_w = min(cols, overlay_w + 2 * pad_h + 2)
+        box_h = min(rows, overlay_h + 2 * pad_v + 2)
+        box_r0 = max(0, (rows - box_h) // 2)
+        box_c0 = max(0, (cols - box_w) // 2)
+
+        br = y - box_r0
+        in_box = 0 <= br < box_h
+
+        # Build the per-column content for columns inside the box
+        box_chars: list[str] = []
+        box_styles: list[Style] = []
+        if in_box:
+            if br == 0:
+                box_chars = ["╭"] + ["─"] * (box_w - 2) + ["╮"]
+                box_styles = [border_style] * box_w
+            elif br == box_h - 1:
+                box_chars = ["╰"] + ["─"] * (box_w - 2) + ["╯"]
+                box_styles = [border_style] * box_w
+            else:
+                box_chars = ["│"] + [" "] * (box_w - 2) + ["│"]
+                box_styles = [border_style] + [box_bg_style] * (box_w - 2) + [border_style]
+                content_row = br - 1 - pad_v
+                if 0 <= content_row < overlay_h:
+                    line = overlay_lines[content_row]
+                    if line:
+                        if content_row < LOGO_H:
+                            line_style = logo_style
+                        elif line == HINT:
+                            line_style = hint_style
+                        else:
+                            line_style = tagline_style
+                        # Center the content line within the inner box area
+                        inner_start = 1 + pad_h
+                        offset = inner_start + (overlay_w - len(line)) // 2
+                        for i, ch in enumerate(line):
+                            pos = offset + i
+                            if 0 <= pos < box_w - 1 and ch != " ":
+                                box_chars[pos] = ch
+                                box_styles[pos] = line_style
+
+        texture = TEXTURE
+        thresholds = _AMP_SQ_THRESHOLDS
+
+        segments: list[Segment] = []
+        run_chars: list[str] = []
+        run_style: Style | None = None
+
+        def flush() -> None:
+            if run_chars:
+                segments.append(Segment("".join(run_chars), run_style))
+
+        box_c1 = box_c0 + box_w
+        for c in range(cols):
+            if in_box and box_c0 <= c < box_c1:
+                bc = c - box_c0
+                ch = box_chars[bc]
+                style = box_styles[bc]
+            else:
+                amp = one_minus_s * a_row[c] + s * b_row[c]
+                amp_sq = amp * amp
+                bucket = bisect_right(thresholds, amp_sq) - 1
+                if bucket < 0:
+                    bucket = 0
+                elif bucket >= N_TEX:
+                    bucket = N_TEX - 1
+                ch = texture[bucket]
+                style = anim_bold_style if bucket >= _BOLD_FROM else anim_plain_style
+
+            if style is not run_style:
+                flush()
+                run_chars = []
+                run_style = style
+            run_chars.append(ch)
+
+        flush()
+        return Strip(segments, cols)
+
+    def on_resize(self) -> None:
+        self._cached_size = None

--- a/src/actor/watch/splash.py
+++ b/src/actor/watch/splash.py
@@ -12,8 +12,6 @@ from textual.strip import Strip
 from textual.widget import Widget
 
 
-# -- ASCII logo ------------------------------------------------------------
-
 LOGO = [
     r" █████╗  ██████╗████████╗ ██████╗ ██████╗    ███████╗██╗  ██╗",
     r"██╔══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗   ██╔════╝██║  ██║",
@@ -28,11 +26,9 @@ TAGLINE = "Autonomous actor command center."
 HINT = "Spawn one from Claude Code and it will appear here."
 
 
-# -- QHO physics -----------------------------------------------------------
-#
 # 2D Quantum Harmonic Oscillator: ψ_{nx,ny}(x,y) = ψ_nx(x) · ψ_ny(y)
 # with ψ_n(x) = e^{−x²/2} · H_n(x) / sqrt(2^n · n! · √π)
-# Animate by crossfading amplitudes between 8 (nx, ny) pairs.
+# Animated by crossfading amplitudes between 8 (nx, ny) pairs.
 
 TEXTURE = " .,:;-~=+*x!tiLC0O8%#@"
 N_TEX = len(TEXTURE)
@@ -80,9 +76,6 @@ def _psi2d(nx: int, ny: int, x: float, y: float) -> float:
     return _psi1d(nx, x) * _psi1d(ny, y)
 
 
-# -- Widget ----------------------------------------------------------------
-
-
 class Splash(Widget):
     """Full-screen QHO animation with ACTOR.SH logo overlay."""
 
@@ -100,13 +93,12 @@ class Splash(Widget):
         self._cached_size: tuple[int, int] | None = None
         self._grids: list[list[list[float]]] | None = None
         self._style_cache: dict[str, Style] = {}
-        # Per-frame cache — populated by _prepare_frame, used by render_line
+        # Three caches with different invalidation axes: _frame per tick,
+        # _styles per theme change, _geometry per resize.
         self._frame_dirty = True
         self._frame: dict | None = None
-        # Theme-dependent cache
         self._theme_key: str | None = None
         self._styles: dict[str, Style] | None = None
-        # Size-dependent cache (box layout)
         self._geometry: dict | None = None
         self._geometry_size: tuple[int, int] | None = None
 
@@ -180,7 +172,21 @@ class Splash(Widget):
         box_r0 = max(0, (rows - box_h) // 2)
         box_c0 = max(0, (cols - box_w) // 2)
 
-        # Precompute per-box-row contents: (chars, style_keys) — style lookup happens later
+        # Terminal too small for a box — skip the overlay entirely.
+        # Min viable: 2 border cols + 1 interior + border = 4 wide, 2 tall.
+        if box_w < 4 or box_h < 2:
+            self._geometry = {
+                "box_w": 0,
+                "box_h": 0,
+                "box_r0": 0,
+                "box_c0": 0,
+                "box_c1": 0,
+                "rows_content": [],
+                "box_segments": [],
+            }
+            self._geometry_size = (rows, cols)
+            return
+
         rows_content: list[tuple[list[str], list[str]]] = []
         for br in range(box_h):
             if br == 0:

--- a/src/actor/watch/splash.py
+++ b/src/actor/watch/splash.py
@@ -166,7 +166,7 @@ class Splash(Widget):
         overlay_lines = LOGO + ["", TAGLINE, "", HINT]
         overlay_h = len(overlay_lines)
         overlay_w = max(len(line) for line in overlay_lines)
-        pad_v, pad_h = 1, 2
+        pad_v, pad_h = 2, 3
         box_w = min(cols, overlay_w + 2 * pad_h + 2)
         box_h = min(rows, overlay_h + 2 * pad_v + 2)
         box_r0 = max(0, (rows - box_h) // 2)

--- a/tests/test_splash.py
+++ b/tests/test_splash.py
@@ -1,0 +1,107 @@
+"""Tests for the QHO splash widget — pure-function tests and tiny-terminal guards."""
+from __future__ import annotations
+
+import math
+import unittest
+
+from actor.watch.splash import (
+    LOGO,
+    LOGO_H,
+    N_TEX,
+    TAGLINE,
+    HINT,
+    _AMP_SQ_THRESHOLDS,
+    _factorial,
+    _hermite,
+    _psi1d,
+    _psi2d,
+    Splash,
+)
+
+
+class QHOMathTests(unittest.TestCase):
+    def test_factorial(self):
+        self.assertEqual(_factorial(0), 1)
+        self.assertEqual(_factorial(1), 1)
+        self.assertEqual(_factorial(5), 120)
+
+    def test_hermite_physicists_polynomials(self):
+        # H_0(x) = 1, H_1(x) = 2x, H_2(x) = 4x^2 - 2, H_3(x) = 8x^3 - 12x
+        for x in [-1.0, 0.0, 0.5, 2.0]:
+            self.assertAlmostEqual(_hermite(0, x), 1.0)
+            self.assertAlmostEqual(_hermite(1, x), 2.0 * x)
+            self.assertAlmostEqual(_hermite(2, x), 4.0 * x * x - 2.0)
+            self.assertAlmostEqual(_hermite(3, x), 8.0 * x**3 - 12.0 * x)
+
+    def test_psi1d_symmetry(self):
+        # Ground state is even, first excited is odd.
+        for x in [0.1, 0.7, 1.5]:
+            self.assertAlmostEqual(_psi1d(0, x), _psi1d(0, -x))
+            self.assertAlmostEqual(_psi1d(1, x), -_psi1d(1, -x))
+
+    def test_psi2d_factorizes(self):
+        self.assertAlmostEqual(_psi2d(2, 3, 0.4, -0.7), _psi1d(2, 0.4) * _psi1d(3, -0.7))
+
+
+class ThresholdTableTests(unittest.TestCase):
+    def test_monotonic_increasing(self):
+        self.assertEqual(len(_AMP_SQ_THRESHOLDS), N_TEX)
+        for a, b in zip(_AMP_SQ_THRESHOLDS, _AMP_SQ_THRESHOLDS[1:]):
+            self.assertLess(a, b)
+
+    def test_zero_at_lowest_bucket(self):
+        self.assertEqual(_AMP_SQ_THRESHOLDS[0], 0.0)
+
+    def test_highest_threshold_is_amp_sq_1_over_18(self):
+        # bucket = N_TEX-1 corresponds to intensity = 1, i.e. amp²·18 = 1
+        self.assertAlmostEqual(_AMP_SQ_THRESHOLDS[-1], 1.0 / 18.0)
+
+
+class GeometryTests(unittest.TestCase):
+    """_ensure_geometry must produce consistent chars/keys lengths or skip the box."""
+
+    @staticmethod
+    def _splash_for_geometry() -> Splash:
+        # Bypass Widget.__init__ (which needs an app context) — we only exercise
+        # _ensure_geometry, which only touches self._geometry / _geometry_size.
+        s = Splash.__new__(Splash)
+        s._geometry = None
+        s._geometry_size = None
+        return s
+
+    def test_normal_size_produces_consistent_lengths(self):
+        s = self._splash_for_geometry()
+        s._ensure_geometry(40, 120)
+        geom = s._geometry
+        self.assertGreater(geom["box_w"], 0)
+        self.assertGreater(geom["box_h"], 0)
+        self.assertEqual(len(geom["rows_content"]), geom["box_h"])
+        for chars, keys in geom["rows_content"]:
+            self.assertEqual(len(chars), geom["box_w"])
+            self.assertEqual(len(keys), geom["box_w"])
+
+    def test_tiny_terminal_skips_box(self):
+        # cols=1 previously produced box_w=1 with a length-2 chars list and
+        # length-1 keys list, which crashed in _ensure_box_segments.
+        for rows, cols in [(10, 1), (10, 2), (10, 3), (1, 120), (0, 120), (10, 0)]:
+            with self.subTest(rows=rows, cols=cols):
+                s = self._splash_for_geometry()
+                s._ensure_geometry(rows, cols)
+                geom = s._geometry
+                self.assertEqual(geom["box_w"], 0)
+                self.assertEqual(geom["box_h"], 0)
+                self.assertEqual(geom["rows_content"], [])
+                self.assertEqual(geom["box_segments"], [])
+
+    def test_cache_respects_size(self):
+        s = self._splash_for_geometry()
+        s._ensure_geometry(40, 120)
+        first = s._geometry
+        s._ensure_geometry(40, 120)
+        self.assertIs(s._geometry, first)
+        s._ensure_geometry(30, 80)
+        self.assertIsNot(s._geometry, first)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fix: clear the detail pane (logs, diff, info, runs) when no actor is selected — previously the previous actor's content lingered as ghost state.
- Add a full-screen splash with QHO (Quantum Harmonic Oscillator) animation + ACTOR.SH ASCII logo, shown when no actors exist. The main layout and splash both start hidden so the wrong UI never flashes on startup; on splash, `check_action` hides all keybindings except Quit and blocks the command palette.
- Optimize splash rendering: per-frame state computed once per tick via a `_frame_dirty` flag, precomputed box Segments per theme+size, single-style animation rows (1 Segment each), 15 FPS.

## Test plan

- [ ] `actor watch` with no actors → splash shown, only Quit in footer
- [ ] Create an actor → splash disappears, main layout appears
- [ ] Discard all actors → splash reappears, no ghost log content
- [ ] Switch themes (dark/light) → splash colors update
- [ ] Resize window → splash box stays centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)