### PR TITLE
Add --no-animation flag to actor watch

### DIFF
--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -181,6 +181,7 @@ Examples:
         help="Open real-time dashboard (browser + terminal)",
     )
     p_watch.add_argument("--serve", action="store_true", help="Serve in browser via textual-serve on port 2204")
+    p_watch.add_argument("--no-animation", action="store_true", help="Disable splash animation (lighter over SSH/slow links)")
 
     # -- discard --
     p_discard = sub.add_parser(
@@ -211,7 +212,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     if args.command == "watch":
         from .watch import run_watch
-        run_watch(serve=args.serve)
+        run_watch(serve=args.serve, animate=not args.no_animation)
         return
 
     try:

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -114,6 +114,10 @@ class ActorWatchApp(App):
     _diff_loaded_for: str | None = None
     _splash_active: bool = False
 
+    def __init__(self, animate: bool = True) -> None:
+        super().__init__()
+        self._animate = animate
+
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         if self._splash_active and action != "quit":
             return False
@@ -135,7 +139,7 @@ class ActorWatchApp(App):
                             Static("Select an actor", id="info-content"),
                             DataTable(id="runs-table"),
                         )
-        yield Splash(id="splash")
+        yield Splash(id="splash", animate=self._animate)
         yield Static("Loading...", id="status-bar")
         yield Footer(show_command_palette=False)
 
@@ -505,18 +509,21 @@ class ActorWatchApp(App):
                 focused.scroll_down()
 
 
-def run_watch(serve: bool = False) -> None:
+def run_watch(serve: bool = False, animate: bool = True) -> None:
     """Entry point for `actor watch`."""
     if serve:
         try:
             from textual_serve.server import Server
-            server = Server("uv run python -m actor.watch --no-serve", port=2204)
+            cmd = "uv run python -m actor.watch --no-serve"
+            if not animate:
+                cmd += " --no-animation"
+            server = Server(cmd, port=2204)
             server.serve()
         except ImportError:
-            app = ActorWatchApp()
+            app = ActorWatchApp(animate=animate)
             app.run()
     else:
-        app = ActorWatchApp()
+        app = ActorWatchApp(animate=animate)
         app.run()
 
 
@@ -524,4 +531,5 @@ def main() -> None:
     """Direct entry point when run as module."""
     import sys
     serve = "--no-serve" not in sys.argv
-    run_watch(serve=serve)
+    animate = "--no-animation" not in sys.argv
+    run_watch(serve=serve, animate=animate)

--- a/src/actor/watch/splash.py
+++ b/src/actor/watch/splash.py
@@ -87,8 +87,9 @@ class Splash(Widget):
     }
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, animate: bool = True, **kwargs) -> None:
         super().__init__(**kwargs)
+        self._animate = animate
         self._start = time.monotonic()
         self._cached_size: tuple[int, int] | None = None
         self._grids: list[list[list[float]]] | None = None
@@ -103,7 +104,8 @@ class Splash(Widget):
         self._geometry_size: tuple[int, int] | None = None
 
     def on_mount(self) -> None:
-        self.set_interval(1 / 15, self._tick)
+        if self._animate:
+            self.set_interval(1 / 15, self._tick)
 
     def _tick(self) -> None:
         self._frame_dirty = True
@@ -262,7 +264,7 @@ class Splash(Widget):
         self._ensure_geometry(rows, cols)
         self._ensure_box_segments()
 
-        t = time.monotonic() - self._start
+        t = (time.monotonic() - self._start) if self._animate else 0.0
         idx = int(t / CYCLE_SECONDS) % len(STATES)
         nxt = (idx + 1) % len(STATES)
         local = (t / CYCLE_SECONDS) - math.floor(t / CYCLE_SECONDS)


### PR DESCRIPTION
## Summary

Adds a \`--no-animation\` flag to \`actor watch\` for SSH and bandwidth-limited environments. When set, the splash skips the 15 FPS timer and pins the frame to t=0 — resizes still re-render but the animation stays frozen on the ground state with no crossfade.

The \`--serve\` subprocess path forwards the flag to the child process.

## Test plan

- [ ] \`actor watch --no-animation\` with no actors → static splash, no visible animation
- [ ] Resize the window with \`--no-animation\` → no animation progresses
- [ ] \`actor watch --serve --no-animation\` → subprocess gets the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)