### PR TITLE
Bump splash animation to 30 FPS

### DIFF
--- a/src/actor/watch/splash.py
+++ b/src/actor/watch/splash.py
@@ -105,7 +105,7 @@ class Splash(Widget):
 
     def on_mount(self) -> None:
         if self._animate:
-            self.set_interval(1 / 15, self._tick)
+            self.set_interval(1 / 30, self._tick)
 
     def _tick(self) -> None:
         self._frame_dirty = True


### PR DESCRIPTION
Now that grid rebuilds are ~33x cheaper, double the framerate for smoother motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)