### PR TITLE
Split new/run/config responsibilities

### DIFF
--- a/skills/actor/SKILL.md
+++ b/skills/actor/SKILL.md
@@ -14,7 +14,7 @@ Requires `pip install actor-sh` (Python 3.9+). All commands below use the `actor
 
 ## Core Rules
 
-1. **Always run `actor run` in background mode.** Use the Bash tool's `run_in_background: true` parameter. Do NOT use shell `&`. You will be automatically notified when the actor finishes. **Each `actor run` MUST be its own separate Bash tool call.** Never batch multiple `actor run` commands in a single Bash call — this prevents proper process tracking and notification.
+1. **Always run `actor new`/`actor run` in background mode.** Use the Bash tool's `run_in_background: true` parameter. Do NOT use shell `&`. You will be automatically notified when the actor finishes. **Each `actor new`/`actor run` with a prompt MUST be its own separate Bash tool call.** Never batch multiple such calls in a single Bash call — this prevents proper process tracking and notification.
 2. **ALWAYS read the output when an actor finishes.** When you receive a background task notification, you MUST read the output file BEFORE taking any further action or responding to the user. The agent may have asked a question, proposed a plan, or reported an error. You cannot know what happened without reading the output.
 3. **Do NOT use `actor logs` for routine output.** The background notification output file is your primary source. Only use `actor logs` when the user explicitly asks for logs or you need historical context.
 4. **Choose descriptive actor names.** The name becomes the git branch. Use lowercase with hyphens: `fix-auth`, `refactor-nav`, `add-tests`.
@@ -25,31 +25,53 @@ Requires `pip install actor-sh` (Python 3.9+). All commands below use the `actor
 
 ## Commands Reference
 
-### Run an actor
+### Create and run an actor
+
+Use `actor new` to create a new actor. If you pass a prompt, it also runs immediately.
+
 ```bash
-actor run <name> -c "<prompt>"            # create and run (worktree from current repo)
-actor run <name> "<prompt>"               # run existing actor (resumes session)
-actor run <name> -c --model opus "<prompt>"       # create with specific model
-actor run <name> -c --agent codex "<prompt>"      # create with Codex agent
-actor run <name> -c --base develop "<prompt>"     # create from specific branch
-actor run <name> -c --dir /path/to/repo "<prompt>"  # create from another repo
-actor run <name> -c --no-worktree "<prompt>"      # create without worktree
-actor run <name> -i                       # resume interactively (not for skill use)
+actor new <name> "<prompt>"                       # create and run (worktree from current repo)
+actor new <name>                                   # create without running
+actor new <name> --model opus "<prompt>"           # create with specific model
+actor new <name> --agent codex "<prompt>"          # create with Codex agent
+actor new <name> --base develop "<prompt>"         # create from specific branch
+actor new <name> --dir /path/to/repo "<prompt>"    # create from another repo
+actor new <name> --no-worktree "<prompt>"          # create without worktree
+echo "fix it" | actor new <name>                   # prompt from stdin
 ```
 
-The `-c` flag creates the actor before running. Without `-c`, the actor must already exist.
+### Run an existing actor
 
-**Prompt:** Pass as an argument or pipe via stdin (`echo "fix it" | actor run name -c`).
+Use `actor run` to run an actor that already exists (resumes its session).
+
+```bash
+actor run <name> "<prompt>"                                # run with a prompt
+actor run <name> --config model=opus "<prompt>"            # one-off per-run config override (not saved)
+actor run <name> -i                                        # resume interactively (not for skill use)
+echo "fix it" | actor run <name>                           # prompt from stdin
+```
 
 **Flags:**
-- `--model` sets the model. On `-c` it's saved for all runs; without `-c` it overrides this run only.
-- `--agent` selects the coding agent: `claude` (default), `codex`. Requires `-c`.
-- `--strip-api-keys` (default: on) strips API keys from the environment so agents use subscription auth. Use `--no-strip-api-keys` to pass keys through.
-- `--config key=value` sets agent-specific options. Bare keys (no `=`) are boolean flags. See the config reference for your agent:
-  - [Claude config](claude-config.md)
-  - [Codex config](codex-config.md)
+- `--config key=value ...` — per-run config overrides. NOT saved to the actor's defaults. Use `actor config` to change defaults.
+
+### Change actor configuration
+
+Config set at creation (`actor new --model ...`) becomes the actor's defaults. To change defaults later, use `actor config`.
+
+```bash
+actor config <name>                                # view config
+actor config <name> model=opus                     # update one key
+actor config <name> model=sonnet effort=max        # update multiple
+```
+
+Config changes apply to the **next** run — they don't affect an in-flight run. Structural properties (agent, worktree, dir, base branch) are set at creation and can't be changed via `config`.
+
+**Config reference by agent:**
+- [Claude config](claude-config.md)
+- [Codex config](codex-config.md)
 
 ### Monitor actors
+
 ```bash
 actor list                                # all actors and their status
 actor list --status running               # only running actors
@@ -59,13 +81,13 @@ actor logs <name> --verbose               # full output with tool calls, thinkin
 ```
 
 ### Manage actors
+
 ```bash
 actor stop <name>                         # kill a running actor
-actor config <name>                       # view config
-actor config <name> model=opus            # update config
 ```
 
 ### Finish actors
+
 ```bash
 actor discard <name>                      # remove actor from DB (worktree stays on disk)
 ```
@@ -74,14 +96,14 @@ actor discard <name>                      # remove actor from DB (worktree stays
 
 ### User: "spin up an actor to refactor the auth module"
 ```bash
-actor run refactor-auth -c "Refactor the auth module. Simplify the token validation logic, remove dead code, and make sure all tests pass."
+actor new refactor-auth "Refactor the auth module. Simplify the token validation logic, remove dead code, and make sure all tests pass."
 ```
 
 ### User: "start three actors: fix the nav, update the tests, and rewrite the README"
 ```bash
-actor run fix-nav -c "Fix the navigation bar — it's broken on mobile viewports"
-actor run update-tests -c "Update all test files to use the new test utilities"
-actor run rewrite-readme -c "Rewrite the README with proper setup instructions and examples"
+actor new fix-nav "Fix the navigation bar — it's broken on mobile viewports"
+actor new update-tests "Update all test files to use the new test utilities"
+actor new rewrite-readme "Rewrite the README with proper setup instructions and examples"
 ```
 
 ### User: "what are my actors doing?"
@@ -121,17 +143,17 @@ actor run feature "Commit all your changes with a descriptive message."
 ```
 After the actor commits:
 ```bash
-actor run feature-v2 -c --base feature "Take a different approach to..."
+actor new feature-v2 --base feature "Take a different approach to..."
 ```
 
 ### User: "start a codex actor to fix the API"
 ```bash
-actor run fix-api -c --agent codex "Fix the /users API endpoint — it returns 500 on missing email field"
+actor new fix-api --agent codex "Fix the /users API endpoint — it returns 500 on missing email field"
 ```
 
 ### User: "start an actor on the backend repo to fix the API"
 ```bash
-actor run fix-api -c --dir /path/to/backend-repo "Fix the /users API endpoint — it returns 500 on missing email field"
+actor new fix-api --dir /path/to/backend-repo "Fix the /users API endpoint — it returns 500 on missing email field"
 ```
 
 ## Crafting Prompts for Actors
@@ -149,4 +171,4 @@ Choose based on context. If the user gave clear requirements, tell the actor to 
 - Each actor gets its own git worktree by default, so multiple actors can work on the same repo without conflicts.
 - Actor sessions persist — you can `actor run` multiple prompts against the same actor and it remembers context.
 - If an actor errors, check `actor logs <name> --verbose` to see what went wrong, then `actor run <name> "fix the issue"` to retry.
-- When the user says something like "kick off", "spin up", "start", "launch", or "create an actor" — that means `actor run -c`.
+- When the user says something like "kick off", "spin up", "start", "launch", or "create an actor" — that means `actor new <name> "<prompt>"`.

--- a/skills/actor/SKILL.md
+++ b/skills/actor/SKILL.md
@@ -37,6 +37,7 @@ actor new <name> --agent codex "<prompt>"          # create with Codex agent
 actor new <name> --base develop "<prompt>"         # create from specific branch
 actor new <name> --dir /path/to/repo "<prompt>"    # create from another repo
 actor new <name> --no-worktree "<prompt>"          # create without worktree
+actor new <name> --no-strip-api-keys "<prompt>"    # pass API keys through to the agent
 echo "fix it" | actor new <name>                   # prompt from stdin
 ```
 

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -51,19 +51,22 @@ def _build_parser() -> argparse.ArgumentParser:
     # -- new --
     p_new = sub.add_parser(
         "new",
-        help="Create a new actor",
+        help="Create a new actor (optionally run a prompt immediately)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
-  actor new my-feature                              Worktree from current repo
+  actor new my-feature                              Create (worktree from current repo)
+  actor new my-feature "fix the nav bar"            Create and run with a prompt
   actor new my-feature --model sonnet               Use a specific model
   actor new my-feature --no-strip-api-keys          Pass API keys to the agent
   actor new my-feature --no-worktree                Use current directory directly
   actor new my-feature --dir /path/to/repo          Worktree from another repo
   actor new my-feature --base develop               Branch off develop
-  actor new my-feature --config effort=max          Set agent config at creation""",
+  actor new my-feature --config effort=max          Set agent config at creation
+  echo "fix it" | actor new my-feature              Create and run with piped prompt""",
     )
     p_new.add_argument("name", help="Actor name")
+    p_new.add_argument("prompt", nargs="?", default=None, help="Optional prompt to run immediately after creation")
     p_new.add_argument("--dir", default=None, help="Base directory (defaults to CWD)")
     p_new.add_argument("--no-worktree", action="store_true", help="Skip worktree creation, run in the directory directly")
     p_new.add_argument("--base", default=None, help="Branch to create the worktree from (defaults to current branch)")
@@ -76,32 +79,21 @@ Examples:
     # -- run --
     p_run = sub.add_parser(
         "run",
-        help="Create and/or run an actor",
+        help="Run an existing actor with a prompt",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
-  actor run fix-nav -c "fix the nav bar"             Create actor and run
-  actor run fix-nav "continue fixing"                Resume existing actor
-  actor run fix-nav -c --model opus "fix it"         Create with specific model
-  actor run fix-nav -c --agent codex "fix it"        Create with Codex agent
-  actor run fix-nav --model opus "one-off override"  Override model for this run
+  actor run fix-nav "continue fixing"                Run with a prompt
+  actor run fix-nav --config model=opus "one-off"    Temporary config override for this run
   actor run fix-nav -i                               Resume interactively
-  echo "fix it" | actor run fix-nav -c               Prompt from stdin""",
+  echo "fix it" | actor run fix-nav                  Prompt from stdin
+
+To create an actor, use 'actor new'. To change actor defaults, use 'actor config'.""",
     )
     p_run.add_argument("name", help="Actor name")
     p_run.add_argument("prompt", nargs="?", default=None, help="Prompt (reads stdin if omitted and not interactive)")
-    p_run.add_argument("-c", "--create", action="store_true", help="Create the actor first (worktree from current repo)")
     p_run.add_argument("-i", "--interactive", action="store_true", help="Resume the actor in interactive mode")
-    # Shared flags (used for both creation and run overrides)
-    p_run.add_argument("--model", default=None, help="Model for the agent to use")
-    p_run.add_argument("--strip-api-keys", action="store_true", default=None, dest="strip_api_keys", help="Strip API keys from environment (default)")
-    p_run.add_argument("--no-strip-api-keys", action="store_false", dest="strip_api_keys", help="Pass API keys through to the agent")
-    p_run.add_argument("--config", dest="config", nargs="+", default=[], metavar="KEY=VALUE", help="Config key=value pairs")
-    # Creation-only flags (require -c)
-    p_run.add_argument("--agent", default="claude", help="Coding agent to use (requires -c)")
-    p_run.add_argument("--dir", default=None, help="Base directory (requires -c)")
-    p_run.add_argument("--base", default=None, help="Branch to create worktree from (requires -c)")
-    p_run.add_argument("--no-worktree", action="store_true", help="Skip worktree creation (requires -c)")
+    p_run.add_argument("--config", dest="config", nargs="+", default=[], metavar="KEY=VALUE", help="Per-run config overrides (not saved to actor)")
 
     # -- list --
     p_list = sub.add_parser(
@@ -246,34 +238,20 @@ def main(argv: Optional[List[str]] = None) -> None:
             )
             print(f"{actor.name} created ({actor.dir})")
 
-        elif args.command == "run":
-            # Validate creation-only flags
-            creation_only = {"dir": args.dir, "base": args.base}
-            if args.no_worktree:
-                creation_only["no-worktree"] = True
-            for flag, val in creation_only.items():
-                if val and not args.create:
-                    raise ActorError(f"--{flag} requires -c/--create")
-
-            # Build config pairs from flags
-            config_pairs = list(args.config)
-            if args.model is not None:
-                config_pairs.append(f"model={args.model}")
-            if args.strip_api_keys is not None:
-                config_pairs.append(f"strip-api-keys={'true' if args.strip_api_keys else 'false'}")
-
-            # Create actor if requested
-            if args.create:
-                cmd_new(
-                    db, git,
+            # If a prompt was provided (arg or stdin), run immediately.
+            prompt = args.prompt
+            if prompt is None and not sys.stdin.isatty():
+                prompt = sys.stdin.read().strip()
+            if prompt:
+                agent = agent_for(args.name)
+                cmd_run(
+                    db, agent, proc_mgr,
                     name=args.name,
-                    dir=args.dir,
-                    no_worktree=args.no_worktree,
-                    base=args.base,
-                    agent_name=args.agent,
-                    config_pairs=config_pairs,
+                    prompt=prompt,
+                    config_pairs=[],  # creation flags already saved as defaults
                 )
 
+        elif args.command == "run":
             # Interactive mode
             if args.interactive:
                 actor = db.get_actor(args.name)
@@ -305,7 +283,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 db, agent, proc_mgr,
                 name=args.name,
                 prompt=prompt,
-                config_pairs=config_pairs if not args.create else [],
+                config_pairs=list(args.config),
             )
 
         elif args.command == "list":

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -74,7 +74,7 @@ Examples:
     p_new.add_argument("--model", default=None, help="Model for the agent to use")
     p_new.add_argument("--strip-api-keys", action="store_true", default=True, dest="strip_api_keys", help="Strip API keys from environment (default)")
     p_new.add_argument("--no-strip-api-keys", action="store_false", dest="strip_api_keys", help="Pass API keys through to the agent")
-    p_new.add_argument("--config", dest="config", nargs="+", default=[], metavar="KEY=VALUE", help="Config key=value pairs")
+    p_new.add_argument("--config", dest="config", action="append", default=[], metavar="KEY=VALUE", help="Config key=value pair (repeat for multiple)")
 
     # -- run --
     p_run = sub.add_parser(
@@ -93,7 +93,7 @@ To create an actor, use 'actor new'. To change actor defaults, use 'actor config
     p_run.add_argument("name", help="Actor name")
     p_run.add_argument("prompt", nargs="?", default=None, help="Prompt (reads stdin if omitted and not interactive)")
     p_run.add_argument("-i", "--interactive", action="store_true", help="Resume the actor in interactive mode")
-    p_run.add_argument("--config", dest="config", nargs="+", default=[], metavar="KEY=VALUE", help="Per-run config overrides (not saved to actor)")
+    p_run.add_argument("--config", dest="config", action="append", default=[], metavar="KEY=VALUE", help="Per-run config override key=value (repeat for multiple, not saved to actor)")
 
     # -- list --
     p_list = sub.add_parser(
@@ -238,18 +238,26 @@ def main(argv: Optional[List[str]] = None) -> None:
             )
             print(f"{actor.name} created ({actor.dir})")
 
-            # If a prompt was provided (arg or stdin), run immediately.
             prompt = args.prompt
+            stdin_consumed = False
             if prompt is None and not sys.stdin.isatty():
                 prompt = sys.stdin.read().strip()
+                stdin_consumed = True
+            if stdin_consumed and not prompt:
+                print("error: stdin was empty — expected a prompt", file=sys.stderr)
+                sys.exit(1)
             if prompt:
-                agent = agent_for(args.name)
-                cmd_run(
-                    db, agent, proc_mgr,
-                    name=args.name,
-                    prompt=prompt,
-                    config_pairs=[],  # creation flags already saved as defaults
-                )
+                try:
+                    agent = agent_for(args.name)
+                    cmd_run(
+                        db, agent, proc_mgr,
+                        name=args.name,
+                        prompt=prompt,
+                        config_pairs=[],  # creation flags already saved as defaults
+                    )
+                except Exception as e:
+                    print(f"error: actor created but run failed: {e}", file=sys.stderr)
+                    sys.exit(2)
 
         elif args.command == "run":
             # Interactive mode

--- a/src/actor/server.py
+++ b/src/actor/server.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 import sys
 import threading
-from typing import Any, List
+import traceback
+from typing import Any, List, Literal
 
 from mcp.server.fastmcp import FastMCP, Context
 from mcp.server.stdio import stdio_server
@@ -13,6 +14,7 @@ from mcp.shared.message import SessionMessage
 from mcp.types import JSONRPCMessage, JSONRPCNotification
 
 from .db import Database
+from .errors import ActorError
 from .git import RealGit
 from .process import RealProcessManager
 from .commands import (
@@ -174,6 +176,7 @@ def _spawn_background_run(
         except Exception as e:
             output = str(e)
             print(f"[actor-mcp] run for '{name}' failed: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
 
         resolved = thread_db.resolve_actor_status(name, pm)
         status = resolved.value
@@ -198,7 +201,7 @@ def _spawn_background_run(
 def new_actor(
     name: str,
     prompt: str | None = None,
-    agent: str = "claude",
+    agent: Literal["claude", "codex"] = "claude",
     dir: str | None = None,
     base: str | None = None,
     no_worktree: bool = False,
@@ -228,8 +231,15 @@ def new_actor(
         config_pairs=config or [],
     )
 
+    if prompt is not None:
+        prompt = prompt.strip()
     if prompt:
-        _spawn_background_run(name, prompt, config_pairs=[], ctx=ctx)
+        try:
+            _spawn_background_run(name, prompt, config_pairs=[], ctx=ctx)
+        except Exception as e:
+            print(f"[actor-mcp] new_actor '{name}' run failed to start: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+            return f"Actor '{name}' created at {actor.dir}, but run failed to start: {e}"
         return f"Actor '{name}' created at {actor.dir} and is running."
     return f"Actor '{name}' created at {actor.dir}."
 
@@ -248,6 +258,9 @@ def run_actor(
         prompt: The task for the actor to work on.
         config: Per-run config overrides (e.g. ["model=opus"]). Not saved to actor defaults — use config_actor to change defaults.
     """
+    prompt = prompt.strip()
+    if not prompt:
+        raise ActorError("prompt is required")
     _spawn_background_run(name, prompt, config_pairs=config or [], ctx=ctx)
     return f"Actor '{name}' is running."
 

--- a/src/actor/server.py
+++ b/src/actor/server.py
@@ -144,53 +144,17 @@ def config_actor(name: str, pairs: List[str] | None = None) -> str:
     return cmd_config(_db(), name=name, config_pairs=pairs or [])
 
 
-@mcp.tool()
-def run_actor(
+def _spawn_background_run(
     name: str,
     prompt: str,
-    create: bool = False,
-    agent: str = "claude",
-    model: str | None = None,
-    dir: str | None = None,
-    base: str | None = None,
-    no_worktree: bool = False,
-    ctx: Context | None = None,
-) -> str:
-    """Create and/or run an actor with a prompt. Returns immediately — the actor runs in the background.
-
-    Args:
-        name: Actor name (becomes the git branch). Use lowercase with hyphens.
-        prompt: The task for the actor to work on.
-        create: If True, create the actor first (with worktree from current repo).
-        agent: Coding agent — "claude" or "codex". Only used with create=True.
-        model: Model override (e.g. "opus", "sonnet"). Saved on create, one-off override otherwise.
-        dir: Base directory for the worktree. Only used with create=True.
-        base: Branch to create the worktree from. Only used with create=True.
-        no_worktree: If True, skip worktree creation. Only used with create=True.
-    """
-    db = _db()
-    git = RealGit()
+    config_pairs: list[str],
+    ctx: Context | None,
+) -> None:
+    """Kick off a run in a background thread; send a channel notification when it finishes."""
     pm = RealProcessManager()
-
-    config_pairs: list[str] = []
-    if model is not None:
-        config_pairs.append(f"model={model}")
-
-    if create:
-        cmd_new(
-            db, git,
-            name=name,
-            dir=dir,
-            no_worktree=no_worktree,
-            base=base,
-            agent_name=agent,
-            config_pairs=config_pairs,
-        )
-
-    actor = db.get_actor(name)
+    actor = _db().get_actor(name)
     agent_impl = _create_agent(actor.agent)
 
-    # Capture session and event loop for channel notification
     session = ctx.session if ctx else None
     try:
         loop = asyncio.get_running_loop()
@@ -205,17 +169,15 @@ def run_actor(
                 thread_db, agent_impl, pm,
                 name=name,
                 prompt=prompt,
-                config_pairs=config_pairs if not create else [],
+                config_pairs=config_pairs,
             )
         except Exception as e:
             output = str(e)
-            print(f"[actor-mcp] run_actor '{name}' failed: {e}", file=sys.stderr)
+            print(f"[actor-mcp] run for '{name}' failed: {e}", file=sys.stderr)
 
-        # Read actual status from DB
         resolved = thread_db.resolve_actor_status(name, pm)
-        status = resolved.value  # "done", "error", "running", etc.
+        status = resolved.value
 
-        # Push channel notification
         if session and loop:
             body = output or f"Finished with status: {status}."
             content = f"[{name}] {body}"
@@ -229,9 +191,64 @@ def run_actor(
             except Exception as e:
                 print(f"[actor-mcp] failed to send channel notification: {e}", file=sys.stderr)
 
-    thread = threading.Thread(target=_run, daemon=True)
-    thread.start()
+    threading.Thread(target=_run, daemon=True).start()
 
+
+@mcp.tool()
+def new_actor(
+    name: str,
+    prompt: str | None = None,
+    agent: str = "claude",
+    dir: str | None = None,
+    base: str | None = None,
+    no_worktree: bool = False,
+    config: List[str] | None = None,
+    ctx: Context | None = None,
+) -> str:
+    """Create a new actor. If a prompt is given, also runs it in the background.
+
+    Args:
+        name: Actor name (becomes the git branch). Use lowercase with hyphens.
+        prompt: Optional prompt to run immediately after creation.
+        agent: Coding agent — "claude" or "codex".
+        dir: Base directory for the worktree (defaults to current working directory).
+        base: Branch to create the worktree from (defaults to current branch).
+        no_worktree: If True, skip worktree creation.
+        config: Config key=value pairs saved as actor defaults (e.g. ["model=opus", "effort=max"]).
+    """
+    db = _db()
+    git = RealGit()
+    actor = cmd_new(
+        db, git,
+        name=name,
+        dir=dir,
+        no_worktree=no_worktree,
+        base=base,
+        agent_name=agent,
+        config_pairs=config or [],
+    )
+
+    if prompt:
+        _spawn_background_run(name, prompt, config_pairs=[], ctx=ctx)
+        return f"Actor '{name}' created at {actor.dir} and is running."
+    return f"Actor '{name}' created at {actor.dir}."
+
+
+@mcp.tool()
+def run_actor(
+    name: str,
+    prompt: str,
+    config: List[str] | None = None,
+    ctx: Context | None = None,
+) -> str:
+    """Run an existing actor with a prompt. Returns immediately — the actor runs in the background.
+
+    Args:
+        name: Actor name.
+        prompt: The task for the actor to work on.
+        config: Per-run config overrides (e.g. ["model=opus"]). Not saved to actor defaults — use config_actor to change defaults.
+    """
+    _spawn_background_run(name, prompt, config_pairs=config or [], ctx=ctx)
     return f"Actor '{name}' is running."
 
 

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -1,0 +1,205 @@
+"""Tests for the CLI dispatch and MCP tool wrappers.
+
+These test the thin glue layer on top of cmd_* — argument translation,
+prompt resolution (arg vs. stdin), error handling, and the MCP tool
+signatures. The cmd_* layer itself is covered by test_actor.py.
+"""
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from actor.cli import main
+from actor.errors import ActorError
+
+
+class NewCommandTests(unittest.TestCase):
+    """`actor new` CLI dispatch."""
+
+    def _run(self, argv, stdin_text=None, stdin_is_tty=True):
+        """Invoke cli.main with argv, patching cmd_new/cmd_run/stdin/Database."""
+        fake_db = MagicMock()
+        fake_actor = MagicMock()
+        fake_actor.name = argv[1] if len(argv) > 1 else "a"
+        fake_actor.dir = "/tmp/actor"
+        fake_agent = MagicMock()
+
+        cmd_new = MagicMock(return_value=fake_actor)
+        cmd_run = MagicMock(return_value="done")
+        agent_for = MagicMock(return_value=fake_agent)
+
+        stdin = io.StringIO(stdin_text or "")
+        stdin.isatty = lambda: stdin_is_tty  # type: ignore[assignment]
+
+        with patch("actor.cli.cmd_new", cmd_new), \
+             patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.cli.Database") as db_cls, \
+             patch("sys.stdin", stdin):
+            db_cls.open.return_value = fake_db
+            # Patch agent_for inline — it's a closure in cli.main, but the
+            # database+_create_agent path is replaced by mocking cmd_run, so
+            # agent_for is only reached via _create_agent(actor.agent).
+            with patch("actor.cli._create_agent", return_value=fake_agent):
+                try:
+                    main(argv)
+                    exit_code = 0
+                except SystemExit as e:
+                    exit_code = e.code if isinstance(e.code, int) else 1
+        return cmd_new, cmd_run, exit_code
+
+    def test_new_without_prompt_creates_only(self):
+        cmd_new, cmd_run, code = self._run(["new", "foo"])
+        cmd_new.assert_called_once()
+        cmd_run.assert_not_called()
+        self.assertEqual(code, 0)
+
+    def test_new_with_prompt_arg_creates_and_runs(self):
+        cmd_new, cmd_run, code = self._run(["new", "foo", "do x"])
+        cmd_new.assert_called_once()
+        cmd_run.assert_called_once()
+        kwargs = cmd_run.call_args.kwargs
+        self.assertEqual(kwargs["name"], "foo")
+        self.assertEqual(kwargs["prompt"], "do x")
+        self.assertEqual(kwargs["config_pairs"], [])  # saved as defaults already
+        self.assertEqual(code, 0)
+
+    def test_new_with_stdin_prompt_creates_and_runs(self):
+        cmd_new, cmd_run, code = self._run(["new", "foo"], stdin_text="fix it\n", stdin_is_tty=False)
+        cmd_new.assert_called_once()
+        cmd_run.assert_called_once()
+        self.assertEqual(cmd_run.call_args.kwargs["prompt"], "fix it")
+        self.assertEqual(code, 0)
+
+    def test_new_with_empty_stdin_errors(self):
+        cmd_new, cmd_run, code = self._run(["new", "foo"], stdin_text="", stdin_is_tty=False)
+        cmd_new.assert_called_once()
+        cmd_run.assert_not_called()
+        self.assertEqual(code, 1)
+
+    def test_new_translates_model_and_strip_api_keys_to_config_pairs(self):
+        cmd_new, _cmd_run, _code = self._run([
+            "new", "foo", "--model", "sonnet", "--no-strip-api-keys",
+        ])
+        pairs = cmd_new.call_args.kwargs["config_pairs"]
+        self.assertIn("model=sonnet", pairs)
+        self.assertIn("strip-api-keys=false", pairs)
+
+    def test_new_with_prompt_run_failure_surfaces_partial_success(self):
+        fake_db = MagicMock()
+        fake_actor = MagicMock()
+        fake_actor.name = "foo"
+        fake_actor.dir = "/tmp/foo"
+
+        cmd_new = MagicMock(return_value=fake_actor)
+        cmd_run = MagicMock(side_effect=ActorError("agent binary missing"))
+
+        with patch("actor.cli.cmd_new", cmd_new), \
+             patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.cli.Database") as db_cls, \
+             patch("actor.cli._create_agent", return_value=MagicMock()):
+            db_cls.open.return_value = fake_db
+            stderr = io.StringIO()
+            with patch("sys.stderr", stderr):
+                try:
+                    main(["new", "foo", "do x"])
+                    code = 0
+                except SystemExit as e:
+                    code = e.code if isinstance(e.code, int) else 1
+        self.assertEqual(code, 2)
+        self.assertIn("actor created but run failed", stderr.getvalue())
+
+
+class RunCommandTests(unittest.TestCase):
+    def test_run_passes_config_overrides(self):
+        cmd_run = MagicMock(return_value="ok")
+        fake_db = MagicMock()
+        with patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.cli.Database") as db_cls, \
+             patch("actor.cli._create_agent", return_value=MagicMock()):
+            db_cls.open.return_value = fake_db
+            stdin = io.StringIO("")
+            stdin.isatty = lambda: True  # type: ignore[assignment]
+            with patch("sys.stdin", stdin):
+                main(["run", "foo", "--config", "model=opus", "do x"])
+        cmd_run.assert_called_once()
+        self.assertEqual(cmd_run.call_args.kwargs["config_pairs"], ["model=opus"])
+
+    def test_run_without_prompt_and_tty_exits_nonzero(self):
+        fake_db = MagicMock()
+        with patch("actor.cli.Database") as db_cls:
+            db_cls.open.return_value = fake_db
+            stdin = io.StringIO("")
+            stdin.isatty = lambda: True  # type: ignore[assignment]
+            with patch("sys.stdin", stdin), patch("sys.stderr", io.StringIO()):
+                with self.assertRaises(SystemExit) as ctx:
+                    main(["run", "foo"])
+                self.assertEqual(ctx.exception.code, 1)
+
+
+class McpToolTests(unittest.TestCase):
+    """Exercise new_actor / run_actor wrappers."""
+
+    def test_run_actor_strips_and_rejects_whitespace_prompt(self):
+        from actor.server import run_actor
+        with self.assertRaises(ActorError):
+            run_actor(name="foo", prompt="   ")
+
+    def test_new_actor_without_prompt_does_not_spawn(self):
+        from actor import server
+        with patch("actor.server.cmd_new") as cmd_new, \
+             patch("actor.server._spawn_background_run") as spawn:
+            fake_actor = MagicMock()
+            fake_actor.dir = "/tmp/foo"
+            cmd_new.return_value = fake_actor
+            msg = server.new_actor(name="foo")
+        spawn.assert_not_called()
+        self.assertIn("created", msg)
+        self.assertNotIn("running", msg)
+
+    def test_new_actor_with_whitespace_prompt_does_not_spawn(self):
+        from actor import server
+        with patch("actor.server.cmd_new") as cmd_new, \
+             patch("actor.server._spawn_background_run") as spawn:
+            fake_actor = MagicMock()
+            fake_actor.dir = "/tmp/foo"
+            cmd_new.return_value = fake_actor
+            msg = server.new_actor(name="foo", prompt="   ")
+        spawn.assert_not_called()
+        self.assertIn("created", msg)
+        self.assertNotIn("running", msg)
+
+    def test_new_actor_with_prompt_spawns_and_reports(self):
+        from actor import server
+        with patch("actor.server.cmd_new") as cmd_new, \
+             patch("actor.server._spawn_background_run") as spawn:
+            fake_actor = MagicMock()
+            fake_actor.dir = "/tmp/foo"
+            cmd_new.return_value = fake_actor
+            msg = server.new_actor(name="foo", prompt="do x")
+        spawn.assert_called_once()
+        self.assertIn("running", msg)
+
+    def test_new_actor_spawn_failure_reports_partial_success(self):
+        from actor import server
+        with patch("actor.server.cmd_new") as cmd_new, \
+             patch("actor.server._spawn_background_run", side_effect=RuntimeError("boom")):
+            fake_actor = MagicMock()
+            fake_actor.dir = "/tmp/foo"
+            cmd_new.return_value = fake_actor
+            with patch("sys.stderr", io.StringIO()):
+                msg = server.new_actor(name="foo", prompt="do x")
+        self.assertIn("created", msg)
+        self.assertIn("run failed to start", msg)
+
+    def test_run_actor_forwards_config(self):
+        from actor import server
+        with patch("actor.server._spawn_background_run") as spawn:
+            server.run_actor(name="foo", prompt="do x", config=["model=opus"])
+        args, kwargs = spawn.call_args
+        self.assertEqual(kwargs["config_pairs"], ["model=opus"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Cleaner separation: \`new\` creates, \`config\` modifies, \`run\` executes.

**CLI**
- \`actor new <name> [prompt]\` — create, and if a prompt is given, also run
- \`actor run <name> <prompt>\` — drop \`-c/--create\` and all creation flags (\`--agent\`, \`--dir\`, \`--base\`, \`--no-worktree\`, \`--model\`, \`--strip-api-keys\`). Keep \`-i\` and a \`--config KEY=VAL\` escape hatch for per-run overrides.
- \`actor config\` — canonical way to change actor defaults.

**MCP**
- New \`new_actor\` tool: creates, optionally runs a prompt immediately.
- \`run_actor\` simplified: just name, prompt, and optional per-run \`config\` override list. No more \`create\`/agent/dir/base flags.
- Both share a \`_spawn_background_run\` helper for the threaded run + channel notification.

**Skill doc** (\`skills/actor/SKILL.md\`): command reference, workflow examples, and the \"kick off / spin up / launch\" mapping all updated to \`actor new <name> \"<prompt>\"\`.

## Test plan

- [x] All 159 unit tests pass (\`cmd_*\` signatures unchanged)
- [x] \`actor new --help\`, \`actor run --help\` show expected flags
- [ ] \`actor new foo \"do x\"\` creates and runs
- [ ] \`actor run bar --config model=opus \"y\"\` applies override for this run only
- [ ] MCP \`new_actor\` / \`run_actor\` work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)