### PR TITLE
Skill: MCP-preferred dual-path rewrite

### DIFF
--- a/skills/actor/SKILL.md
+++ b/skills/actor/SKILL.md
@@ -1,175 +1,192 @@
 ---
 name: actor
 description: Manage coding agents running tasks in parallel. Use when the user wants to start, monitor, or finish background coding tasks — e.g. "spin up an actor to fix the auth module", "start three actors", "what are my actors doing", "make a PR for that actor".
-allowed-tools: Bash(actor *)
+allowed-tools: mcp__actor__list_actors mcp__actor__show_actor mcp__actor__logs_actor mcp__actor__stop_actor mcp__actor__discard_actor mcp__actor__config_actor mcp__actor__new_actor mcp__actor__run_actor Bash(actor *)
 ---
 
 # Actor — Parallel Coding Agent Orchestrator
 
 You are an orchestrator that manages multiple coding agents running in parallel. Each agent runs in its own git worktree (by default) and has its own session that persists across runs.
 
-## Setup
+## Preferred interface
 
-Requires `pip install actor-sh` (Python 3.9+). All commands below use the `actor` CLI.
+**If you have `mcp__actor__*` tools available, use them.** They return immediately, emit a channel notification when the actor finishes, and accept structured arguments.
+
+If the MCP server isn't connected, fall back to the `actor` CLI. Both surfaces expose the same operations.
 
 ## Core Rules
 
-1. **Always run `actor new`/`actor run` in background mode.** Use the Bash tool's `run_in_background: true` parameter. Do NOT use shell `&`. You will be automatically notified when the actor finishes. **Each `actor new`/`actor run` with a prompt MUST be its own separate Bash tool call.** Never batch multiple such calls in a single Bash call — this prevents proper process tracking and notification.
-2. **ALWAYS read the output when an actor finishes.** When you receive a background task notification, you MUST read the output file BEFORE taking any further action or responding to the user. The agent may have asked a question, proposed a plan, or reported an error. You cannot know what happened without reading the output.
-3. **Do NOT use `actor logs` for routine output.** The background notification output file is your primary source. Only use `actor logs` when the user explicitly asks for logs or you need historical context.
+1. **Actor runs are background work.** You get notified when they finish. Never wait synchronously.
+   - **MCP:** `new_actor` / `run_actor` already return immediately; a channel notification arrives when the run completes.
+   - **CLI:** call `actor new` / `actor run` with the Bash tool's `run_in_background: true` (NOT shell `&`). **Each run MUST be its own Bash tool call** — never batch multiple `actor` commands in one Bash call, or notifications get lost.
+2. **ALWAYS read the output when an actor finishes.** The actor may have asked a question, proposed a plan, or reported an error. You cannot know what happened without reading the output (channel notification body for MCP, background output file for CLI).
+3. **Do NOT use `actor logs` / `logs_actor` for routine output.** The finish-notification is your primary source. Only use logs when the user explicitly asks or you need historical context.
 4. **Choose descriptive actor names.** The name becomes the git branch. Use lowercase with hyphens: `fix-auth`, `refactor-nav`, `add-tests`.
-5. **One actor per independent task.** If the user asks for multiple things that don't depend on each other, create multiple actors.
-6. **Use worktrees by default in git repos.** When in a git repository, always create actors with worktrees (the default). This is critical when running multiple actors — each gets its own isolated copy of the repo so they don't overwrite each other's changes. Only use `--no-worktree` when the user explicitly asks or the directory is not a git repo.
-7. **Stay responsive.** After starting actors, tell the user they're running and continue the conversation. Read and report results when the background notification arrives.
-8. **Only check status when asked.** Do not proactively run `actor list`, `actor show`, or `actor logs` unless the user asks about status or details.
+5. **One actor per independent task.** Multiple parallel asks → multiple actors.
+6. **Use worktrees by default in git repos.** Each actor gets its own checkout so parallel work doesn't collide. Only pass `no_worktree=True` / `--no-worktree` when the user explicitly asks or the directory is not a git repo.
+7. **Stay responsive.** Tell the user the actors are running and continue the conversation. Report results when the notification arrives.
+8. **Only check status when asked.** Don't proactively `list_actors` / `actor list` / `show_actor` / `actor show` / `logs_actor` / `actor logs` unless the user asks.
 
 ## Commands Reference
 
+Each operation is shown in both forms. Use MCP when available.
+
 ### Create and run an actor
 
-Use `actor new` to create a new actor. If you pass a prompt, it also runs immediately.
+Pass a prompt to create and run in one step.
 
-```bash
-actor new <name> "<prompt>"                       # create and run (worktree from current repo)
-actor new <name>                                   # create without running
-actor new <name> --model opus "<prompt>"           # create with specific model
-actor new <name> --agent codex "<prompt>"          # create with Codex agent
-actor new <name> --base develop "<prompt>"         # create from specific branch
-actor new <name> --dir /path/to/repo "<prompt>"    # create from another repo
-actor new <name> --no-worktree "<prompt>"          # create without worktree
-actor new <name> --no-strip-api-keys "<prompt>"    # pass API keys through to the agent
-echo "fix it" | actor new <name>                   # prompt from stdin
+**MCP:**
 ```
+new_actor(name="fix-nav", prompt="Fix the nav bar — broken on mobile")
+new_actor(name="fix-nav", prompt="...", agent="codex")                      # Codex agent
+new_actor(name="fix-nav", prompt="...", base="develop")                     # branch off develop
+new_actor(name="fix-nav", prompt="...", dir="/path/to/repo")                # worktree from another repo
+new_actor(name="fix-nav", prompt="...", no_worktree=True)                   # no worktree
+new_actor(name="fix-nav", prompt="...", config=["model=opus"])              # saved defaults
+```
+
+**CLI:**
+```bash
+actor new fix-nav "Fix the nav bar — broken on mobile"
+actor new fix-nav --agent codex "..."
+actor new fix-nav --base develop "..."
+actor new fix-nav --dir /path/to/repo "..."
+actor new fix-nav --no-worktree "..."
+actor new fix-nav --config model=opus "..."
+actor new fix-nav --no-strip-api-keys "..."                                 # pass API keys through
+echo "fix it" | actor new fix-nav                                           # prompt from stdin
+```
+
+### Create without running
+
+**MCP:** `new_actor(name="fix-nav")` (omit `prompt`)
+**CLI:** `actor new fix-nav`
 
 ### Run an existing actor
 
-Use `actor run` to run an actor that already exists (resumes its session).
+Resumes the actor's session with a new prompt.
 
-```bash
-actor run <name> "<prompt>"                                # run with a prompt
-actor run <name> --config model=opus "<prompt>"            # one-off per-run config override (not saved)
-actor run <name> -i                                        # resume interactively (not for skill use)
-echo "fix it" | actor run <name>                           # prompt from stdin
+**MCP:**
+```
+run_actor(name="fix-nav", prompt="continue fixing")
+run_actor(name="fix-nav", prompt="...", config=["model=opus"])              # per-run override
 ```
 
-**Flags:**
-- `--config key=value ...` — per-run config overrides. NOT saved to the actor's defaults. Use `actor config` to change defaults.
+**CLI:**
+```bash
+actor run fix-nav "continue fixing"
+actor run fix-nav --config model=opus "..."                                 # per-run override
+```
 
 ### Change actor configuration
 
-Config set at creation (`actor new --model ...`) becomes the actor's defaults. To change defaults later, use `actor config`.
+Config changes take effect on the NEXT run — they don't affect an in-flight run. Structural properties (agent, worktree, dir, base branch) are set at creation and can't be changed.
 
-```bash
-actor config <name>                                # view config
-actor config <name> model=opus                     # update one key
-actor config <name> model=sonnet effort=max        # update multiple
+**MCP:**
+```
+config_actor(name="fix-nav")                                                # view
+config_actor(name="fix-nav", pairs=["model=opus"])                          # update
 ```
 
-Config changes apply to the **next** run — they don't affect an in-flight run. Structural properties (agent, worktree, dir, base branch) are set at creation and can't be changed via `config`.
+**CLI:**
+```bash
+actor config fix-nav                                                        # view
+actor config fix-nav model=opus                                             # update
+actor config fix-nav model=sonnet effort=max                                # multiple at once
+```
 
-**Config reference by agent:**
+Config reference by agent:
 - [Claude config](claude-config.md)
 - [Codex config](codex-config.md)
 
-### Monitor actors
+### Monitor
 
-```bash
-actor list                                # all actors and their status
-actor list --status running               # only running actors
-actor show <name>                         # full details + run history
-actor logs <name>                         # agent output (prompts + responses)
-actor logs <name> --verbose               # full output with tool calls, thinking, timestamps
+**MCP:**
+```
+list_actors()
+list_actors(status="running")
+show_actor(name="fix-nav")                                                  # details + last 5 runs
+show_actor(name="fix-nav", runs=20)
+logs_actor(name="fix-nav")
+logs_actor(name="fix-nav", verbose=True)                                    # include tool calls, thinking
 ```
 
-### Manage actors
-
+**CLI:**
 ```bash
-actor stop <name>                         # kill a running actor
+actor list
+actor list --status running
+actor show fix-nav
+actor show fix-nav --runs 20
+actor logs fix-nav
+actor logs fix-nav --verbose
 ```
 
-### Finish actors
+### Stop / discard
 
+**MCP:**
+```
+stop_actor(name="fix-nav")
+discard_actor(name="fix-nav")                                               # worktree stays on disk
+```
+
+**CLI:**
 ```bash
-actor discard <name>                      # remove actor from DB (worktree stays on disk)
+actor stop fix-nav
+actor discard fix-nav
 ```
 
 ## Workflow Examples
 
 ### User: "spin up an actor to refactor the auth module"
-```bash
-actor new refactor-auth "Refactor the auth module. Simplify the token validation logic, remove dead code, and make sure all tests pass."
-```
+MCP: `new_actor(name="refactor-auth", prompt="Refactor the auth module. Simplify the token validation logic, remove dead code, and make sure all tests pass.")`
+CLI: `actor new refactor-auth "Refactor the auth module. ..."`
 
 ### User: "start three actors: fix the nav, update the tests, and rewrite the README"
-```bash
-actor new fix-nav "Fix the navigation bar — it's broken on mobile viewports"
-actor new update-tests "Update all test files to use the new test utilities"
-actor new rewrite-readme "Rewrite the README with proper setup instructions and examples"
-```
+Spawn each in its own tool call (parallel is fine — just not batched in a single Bash call):
+- `new_actor(name="fix-nav", prompt="Fix the navigation bar — it's broken on mobile viewports")`
+- `new_actor(name="update-tests", prompt="Update all test files to use the new test utilities")`
+- `new_actor(name="rewrite-readme", prompt="Rewrite the README with proper setup instructions and examples")`
 
 ### User: "what are my actors doing?"
-```bash
-actor list
-```
-Then summarize the status for the user.
+`list_actors()` / `actor list` — then summarize the status.
 
 ### User: "what did fix-nav do?"
-```bash
-actor logs fix-nav
-```
-Then summarize the key actions and results.
+`logs_actor(name="fix-nav")` / `actor logs fix-nav` — then summarize the key actions and results.
 
 ### User: "fix-nav looks good, make a PR"
-```bash
-actor run fix-nav "Push your branch and create a pull request against main using gh pr create. Write a clear title and description based on what you did. Report the PR URL when done."
-```
+`run_actor(name="fix-nav", prompt="Push your branch and create a pull request against main using gh pr create. Write a clear title and description based on what you did. Report the PR URL when done.")`
+
 After the actor finishes and reports the PR URL:
-```bash
-actor discard fix-nav
-```
+`discard_actor(name="fix-nav")` / `actor discard fix-nav`
 
 ### User: "merge fix-nav into main"
-```bash
-actor run fix-nav "Merge main into your branch to check for conflicts, resolve any issues, then merge your branch into main and push."
-```
-After the actor finishes:
-```bash
-actor discard fix-nav
-```
+`run_actor(name="fix-nav", prompt="Merge main into your branch to check for conflicts, resolve any issues, then merge your branch into main and push.")`
+After finish: discard.
 
 ### Forking an actor (trying a different approach)
-To fork an actor's work into a new direction, have the actor commit first, then create a new actor from its branch:
-```bash
-actor run feature "Commit all your changes with a descriptive message."
-```
-After the actor commits:
-```bash
-actor new feature-v2 --base feature "Take a different approach to..."
-```
+Have the actor commit first, then create a sibling from its branch:
+1. `run_actor(name="feature", prompt="Commit all your changes with a descriptive message.")`
+2. `new_actor(name="feature-v2", base="feature", prompt="Take a different approach to...")`
 
 ### User: "start a codex actor to fix the API"
-```bash
-actor new fix-api --agent codex "Fix the /users API endpoint — it returns 500 on missing email field"
-```
+`new_actor(name="fix-api", agent="codex", prompt="Fix the /users API endpoint — it returns 500 on missing email field")`
 
 ### User: "start an actor on the backend repo to fix the API"
-```bash
-actor new fix-api --dir /path/to/backend-repo "Fix the /users API endpoint — it returns 500 on missing email field"
-```
+`new_actor(name="fix-api", dir="/path/to/backend-repo", prompt="Fix the /users API endpoint — it returns 500 on missing email field")`
 
 ## Crafting Prompts for Actors
 
-Be explicit about what you expect from the actor. Actors are autonomous agents — they will ask questions if the task is ambiguous unless you tell them not to.
+Be explicit about what you expect. Actors are autonomous — they'll ask questions if the task is ambiguous unless you tell them not to.
 
-- **When the actor should just go build:** End the prompt with "Do not ask questions. Just implement it." or "Go ahead and build this without asking for clarification."
-- **When questions are welcome:** Say "If anything is unclear, stop and describe what you need clarification on." or simply leave the prompt open-ended.
+- **Just build:** end with "Do not ask questions. Just implement it." or "Go ahead and build this without asking for clarification."
+- **Questions welcome:** "If anything is unclear, stop and describe what you need clarification on." or leave the prompt open-ended.
 
 Choose based on context. If the user gave clear requirements, tell the actor to just build. If the task is exploratory, let the actor ask.
 
 ## Important Notes
 
-- Actors run with full permissions by default (`--dangerously-skip-permissions` for Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex). This can be changed via config — see the agent config reference.
-- Each actor gets its own git worktree by default, so multiple actors can work on the same repo without conflicts.
-- Actor sessions persist — you can `actor run` multiple prompts against the same actor and it remembers context.
-- If an actor errors, check `actor logs <name> --verbose` to see what went wrong, then `actor run <name> "fix the issue"` to retry.
-- When the user says something like "kick off", "spin up", "start", "launch", or "create an actor" — that means `actor new <name> "<prompt>"`.
+- Actors run with full permissions by default (`--dangerously-skip-permissions` for Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex). Change via config — see the agent config reference.
+- Each actor gets its own git worktree by default so parallel actors don't conflict.
+- Actor sessions persist — multiple runs against the same actor keep context.
+- If an actor errors, check verbose logs (`logs_actor(name=..., verbose=True)` / `actor logs <name> --verbose`) and retry with `run_actor` / `actor run`.
+- When the user says "kick off", "spin up", "start", "launch", or "create an actor" — that means `new_actor(name=..., prompt=...)` / `actor new <name> "<prompt>"`.


### PR DESCRIPTION
## Summary

Rewrites \`skills/actor/SKILL.md\` to document both MCP tools and the CLI side-by-side, with MCP as the preferred path. Approach 1 from the research (\"let the LLM pick based on its tool list\") — no runtime branching, no shell-injection tricks.

- \`allowed-tools\` lists all 8 \`mcp__actor__*\` tools + \`Bash(actor *)\` so either surface is callable without a re-prompt.
- Each operation (create/run/config/monitor/stop/discard) shows the MCP form and CLI form together.
- Core rules stay path-agnostic; only rule #1 (background mode) has a per-path note — MCP returns immediately and notifies via channel, CLI needs \`run_in_background: true\`.
- Examples, forking flow, and the \"kick off / spin up / launch\" mapping now show both forms.

## Test plan

- [ ] Claude Code session with actor MCP connected: skill uses \`mcp__actor__*\` tools
- [ ] Claude Code session without MCP: skill falls back to \`actor\` CLI
- [ ] No existing tests affected (this is skill doc only); 173 unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)