### PR TITLE
Skill: MCP-primary with CLI fallback split

### DIFF
--- a/skills/actor/SKILL.md
+++ b/skills/actor/SKILL.md
@@ -12,24 +12,25 @@ You are an orchestrator that manages multiple coding agents running in parallel.
 
 This skill is designed around the `mcp__actor__*` tools. They return immediately and emit a channel notification when the actor finishes, so you can hand off work and continue the conversation. Shell-only fallback exists but has no completion notifications — it's a last resort.
 
-**If `mcp__actor__*` tools are NOT in your tool list, set up the MCP server before proceeding:**
+**If `mcp__actor__*` tools are NOT in your tool list, stop and tell the user how to set it up.** Don't try to install or configure it yourself — the user needs to run these steps:
 
-1. Install the `actor` package if `actor --version` doesn't work yet:
-   ```
-   uv tool install actor-sh
-   ```
-   or, if the user prefers pip:
-   ```
-   pip install actor-sh
-   ```
-2. Register the MCP with the current host:
-   ```
-   actor install --for claude-code
-   ```
-   Add `--scope project` to install at the project level instead of user-wide, or `--name <id>` to register under a name other than `actor`.
-3. Ask the user to restart the session.
+> The actor MCP server isn't connected to this session. To set it up:
+>
+> 1. Install the `actor` package (skip if `actor --version` already works):
+>    ```
+>    uv tool install actor-sh
+>    ```
+>    (or `pip install actor-sh`)
+>
+> 2. Register the MCP with your coding agent:
+>    ```
+>    actor install --for claude-code
+>    ```
+>    Optional flags: `--scope project` to install at project level instead of user-wide, `--name <id>` to register under a different name.
+>
+> 3. Restart this session.
 
-Only fall back to the CLI (see [cli.md](cli.md)) if the user explicitly declines the MCP setup. When using the CLI fallback, completion is not pushed — you won't know when an actor finishes without asking.
+Only fall back to the CLI (see [cli.md](cli.md)) if the user explicitly prefers to skip MCP setup. When using the CLI fallback, completion is not pushed — you won't know when an actor finishes without asking.
 
 ## Agent compatibility
 

--- a/skills/actor/SKILL.md
+++ b/skills/actor/SKILL.md
@@ -12,27 +12,24 @@ You are an orchestrator that manages multiple coding agents running in parallel.
 
 This skill is designed around the `mcp__actor__*` tools. They return immediately and emit a channel notification when the actor finishes, so you can hand off work and continue the conversation. Shell-only fallback exists but has no completion notifications — it's a last resort.
 
-**If `mcp__actor__*` tools are NOT in your tool list, prompt the user to install the MCP server before proceeding:**
+**If `mcp__actor__*` tools are NOT in your tool list, set up the MCP server before proceeding:**
 
-> This skill works best with the actor MCP server, which isn't available in the current session.
->
-> 1. Install the `actor` CLI (provides both the CLI and the MCP server):
->    ```
->    uv tool install actor-sh
->    ```
->    or, if you prefer pip:
->    ```
->    pip install actor-sh
->    ```
-> 2. Register the MCP server with Claude Code:
->    ```
->    claude mcp add actor -- actor mcp
->    ```
-> 3. Restart this session and try again.
+1. Install the `actor` package if `actor --version` doesn't work yet:
+   ```
+   uv tool install actor-sh
+   ```
+   or, if the user prefers pip:
+   ```
+   pip install actor-sh
+   ```
+2. Register the MCP with the current host:
+   ```
+   actor install --for claude-code
+   ```
+   Add `--scope project` to install at the project level instead of user-wide, or `--name <id>` to register under a name other than `actor`.
+3. Ask the user to restart the session.
 
-If `actor` is already installed but the MCP isn't registered, skip step 1. Check with `actor --version` — if that prints a version, only run the `claude mcp add` step.
-
-Only fall back to the CLI (see [cli.md](cli.md)) if the user explicitly declines to install the MCP. When using the CLI fallback, completion is not pushed — you won't know when an actor finishes without asking.
+Only fall back to the CLI (see [cli.md](cli.md)) if the user explicitly declines the MCP setup. When using the CLI fallback, completion is not pushed — you won't know when an actor finishes without asking.
 
 ## Agent compatibility
 

--- a/skills/actor/SKILL.md
+++ b/skills/actor/SKILL.md
@@ -1,175 +1,192 @@
 ---
 name: actor
 description: Manage coding agents running tasks in parallel. Use when the user wants to start, monitor, or finish background coding tasks — e.g. "spin up an actor to fix the auth module", "start three actors", "what are my actors doing", "make a PR for that actor".
-allowed-tools: Bash(actor *)
+allowed-tools: mcp__actor__list_actors mcp__actor__show_actor mcp__actor__logs_actor mcp__actor__stop_actor mcp__actor__discard_actor mcp__actor__config_actor mcp__actor__new_actor mcp__actor__run_actor Bash(actor *)
 ---
 
 # Actor — Parallel Coding Agent Orchestrator
 
 You are an orchestrator that manages multiple coding agents running in parallel. Each agent runs in its own git worktree (by default) and has its own session that persists across runs.
 
-## Setup
+## Preferred interface
 
-Requires `pip install actor-sh` (Python 3.9+). All commands below use the `actor` CLI.
+**If you have `mcp__actor__*` tools available, use them.** They return immediately, emit a channel notification when the actor finishes, and accept structured arguments.
+
+If the MCP server isn't connected, fall back to the `actor` CLI. Both surfaces expose the same operations.
 
 ## Core Rules
 
-1. **Always run `actor new`/`actor run` in background mode.** Use the Bash tool's `run_in_background: true` parameter. Do NOT use shell `&`. You will be automatically notified when the actor finishes. **Each `actor new`/`actor run` with a prompt MUST be its own separate Bash tool call.** Never batch multiple such calls in a single Bash call — this prevents proper process tracking and notification.
-2. **ALWAYS read the output when an actor finishes.** When you receive a background task notification, you MUST read the output file BEFORE taking any further action or responding to the user. The agent may have asked a question, proposed a plan, or reported an error. You cannot know what happened without reading the output.
-3. **Do NOT use `actor logs` for routine output.** The background notification output file is your primary source. Only use `actor logs` when the user explicitly asks for logs or you need historical context.
+1. **Actor runs are background work.** You get notified when they finish. Never wait synchronously.
+   - **MCP:** `new_actor` / `run_actor` already return immediately; a channel notification arrives when the run completes.
+   - **CLI:** call `actor new` / `actor run` with the Bash tool's `run_in_background: true` (NOT shell `&`). **Each run MUST be its own Bash tool call** — never batch multiple `actor` commands in one Bash call, or notifications get lost.
+2. **ALWAYS read the output when an actor finishes.** The actor may have asked a question, proposed a plan, or reported an error. You cannot know what happened without reading the output (channel notification body for MCP, background output file for CLI).
+3. **Do NOT use `actor logs` / `logs_actor` for routine output.** The finish-notification is your primary source. Only use logs when the user explicitly asks or you need historical context.
 4. **Choose descriptive actor names.** The name becomes the git branch. Use lowercase with hyphens: `fix-auth`, `refactor-nav`, `add-tests`.
-5. **One actor per independent task.** If the user asks for multiple things that don't depend on each other, create multiple actors.
-6. **Use worktrees by default in git repos.** When in a git repository, always create actors with worktrees (the default). This is critical when running multiple actors — each gets its own isolated copy of the repo so they don't overwrite each other's changes. Only use `--no-worktree` when the user explicitly asks or the directory is not a git repo.
-7. **Stay responsive.** After starting actors, tell the user they're running and continue the conversation. Read and report results when the background notification arrives.
-8. **Only check status when asked.** Do not proactively run `actor list`, `actor show`, or `actor logs` unless the user asks about status or details.
+5. **One actor per independent task.** Multiple parallel asks → multiple actors.
+6. **Use worktrees by default in git repos.** Each actor gets its own checkout so parallel work doesn't collide. Only pass `no_worktree=True` / `--no-worktree` when the user explicitly asks or the directory is not a git repo.
+7. **Stay responsive.** Tell the user the actors are running and continue the conversation. Report results when the notification arrives.
+8. **Only check status when asked.** Don't proactively `list_actors` / `actor list` / `show_actor` / `actor show` / `logs_actor` / `actor logs` unless the user asks.
 
 ## Commands Reference
 
+Each operation is shown in both forms. Use MCP when available.
+
 ### Create and run an actor
 
-Use `actor new` to create a new actor. If you pass a prompt, it also runs immediately.
+Pass a prompt to create and run in one step.
 
-```bash
-actor new <name> "<prompt>"                       # create and run (worktree from current repo)
-actor new <name>                                   # create without running
-actor new <name> --model opus "<prompt>"           # create with specific model
-actor new <name> --agent codex "<prompt>"          # create with Codex agent
-actor new <name> --base develop "<prompt>"         # create from specific branch
-actor new <name> --dir /path/to/repo "<prompt>"    # create from another repo
-actor new <name> --no-worktree "<prompt>"          # create without worktree
-actor new <name> --no-strip-api-keys "<prompt>"    # pass API keys through to the agent
-echo "fix it" | actor new <name>                   # prompt from stdin
+**MCP:**
 ```
+new_actor(name="fix-nav", prompt="Fix the nav bar — broken on mobile")
+new_actor(name="fix-nav", prompt="...", agent="codex")                      # Codex agent
+new_actor(name="fix-nav", prompt="...", base="develop")                     # branch off develop
+new_actor(name="fix-nav", prompt="...", dir="/path/to/repo")                # worktree from another repo
+new_actor(name="fix-nav", prompt="...", no_worktree=True)                   # no worktree
+new_actor(name="fix-nav", prompt="...", config=["model=opus"])              # saved defaults
+```
+
+**CLI:**
+```bash
+actor new fix-nav "Fix the nav bar — broken on mobile"
+actor new fix-nav --agent codex "..."
+actor new fix-nav --base develop "..."
+actor new fix-nav --dir /path/to/repo "..."
+actor new fix-nav --no-worktree "..."
+actor new fix-nav --config model=opus "..."
+actor new fix-nav --no-strip-api-keys "..."                                 # pass API keys through
+echo "fix it" | actor new fix-nav                                           # prompt from stdin
+```
+
+### Create without running
+
+**MCP:** `new_actor(name="fix-nav")` (omit `prompt`)
+**CLI:** `actor new fix-nav`
 
 ### Run an existing actor
 
-Use `actor run` to run an actor that already exists (resumes its session).
+Resumes the actor's session with a new prompt.
 
-```bash
-actor run <name> "<prompt>"                                # run with a prompt
-actor run <name> --config model=opus "<prompt>"            # one-off per-run config override (not saved)
-actor run <name> -i                                        # resume interactively (not for skill use)
-echo "fix it" | actor run <name>                           # prompt from stdin
+**MCP:**
+```
+run_actor(name="fix-nav", prompt="continue fixing")
+run_actor(name="fix-nav", prompt="...", config=["model=opus"])              # per-run override
 ```
 
-**Flags:**
-- `--config key=value ...` — per-run config overrides. NOT saved to the actor's defaults. Use `actor config` to change defaults.
+**CLI:**
+```bash
+actor run fix-nav "continue fixing"
+actor run fix-nav --config model=opus "..."                                 # per-run override
+```
 
 ### Change actor configuration
 
-Config set at creation (`actor new --model ...`) becomes the actor's defaults. To change defaults later, use `actor config`.
+Config changes take effect on the NEXT run — they don't affect an in-flight run. Structural properties (agent, worktree, dir, base branch) are set at creation and can't be changed.
 
-```bash
-actor config <name>                                # view config
-actor config <name> model=opus                     # update one key
-actor config <name> model=sonnet effort=max        # update multiple
+**MCP:**
+```
+config_actor(name="fix-nav")                                                # view
+config_actor(name="fix-nav", pairs=["model=opus"])                          # update
 ```
 
-Config changes apply to the **next** run — they don't affect an in-flight run. Structural properties (agent, worktree, dir, base branch) are set at creation and can't be changed via `config`.
+**CLI:**
+```bash
+actor config fix-nav                                                        # view
+actor config fix-nav model=opus                                             # update
+actor config fix-nav model=sonnet effort=max                                # multiple at once
+```
 
-**Config reference by agent:**
+Config reference by agent:
 - [Claude config](claude-config.md)
 - [Codex config](codex-config.md)
 
-### Monitor actors
+### Monitor
 
-```bash
-actor list                                # all actors and their status
-actor list --status running               # only running actors
-actor show <name>                         # full details + run history
-actor logs <name>                         # agent output (prompts + responses)
-actor logs <name> --verbose               # full output with tool calls, thinking, timestamps
+**MCP:**
+```
+list_actors()
+list_actors(status="running")
+show_actor(name="fix-nav")                                                  # details + last 5 runs
+show_actor(name="fix-nav", runs=20)
+logs_actor(name="fix-nav")
+logs_actor(name="fix-nav", verbose=True)                                    # include tool calls, thinking
 ```
 
-### Manage actors
-
+**CLI:**
 ```bash
-actor stop <name>                         # kill a running actor
+actor list
+actor list --status running
+actor show fix-nav
+actor show fix-nav --runs 20
+actor logs fix-nav
+actor logs fix-nav --verbose
 ```
 
-### Finish actors
+### Stop / discard
 
+**MCP:**
+```
+stop_actor(name="fix-nav")
+discard_actor(name="fix-nav")                                               # worktree stays on disk
+```
+
+**CLI:**
 ```bash
-actor discard <name>                      # remove actor from DB (worktree stays on disk)
+actor stop fix-nav
+actor discard fix-nav
 ```
 
 ## Workflow Examples
 
 ### User: "spin up an actor to refactor the auth module"
-```bash
-actor new refactor-auth "Refactor the auth module. Simplify the token validation logic, remove dead code, and make sure all tests pass."
-```
+MCP: `new_actor(name="refactor-auth", prompt="Refactor the auth module. Simplify the token validation logic, remove dead code, and make sure all tests pass.")`
+CLI: `actor new refactor-auth "Refactor the auth module. ..."`
 
 ### User: "start three actors: fix the nav, update the tests, and rewrite the README"
-```bash
-actor new fix-nav "Fix the navigation bar — it's broken on mobile viewports"
-actor new update-tests "Update all test files to use the new test utilities"
-actor new rewrite-readme "Rewrite the README with proper setup instructions and examples"
-```
+Spawn each in its own tool call (parallel is fine — just not batched in a single Bash call):
+- `new_actor(name="fix-nav", prompt="Fix the navigation bar — it's broken on mobile viewports")`
+- `new_actor(name="update-tests", prompt="Update all test files to use the new test utilities")`
+- `new_actor(name="rewrite-readme", prompt="Rewrite the README with proper setup instructions and examples")`
 
 ### User: "what are my actors doing?"
-```bash
-actor list
-```
-Then summarize the status for the user.
+`list_actors()` / `actor list` — then summarize the status.
 
 ### User: "what did fix-nav do?"
-```bash
-actor logs fix-nav
-```
-Then summarize the key actions and results.
+`logs_actor(name="fix-nav")` / `actor logs fix-nav` — then summarize the key actions and results.
 
 ### User: "fix-nav looks good, make a PR"
-```bash
-actor run fix-nav "Push your branch and create a pull request against main using gh pr create. Write a clear title and description based on what you did. Report the PR URL when done."
-```
+`run_actor(name="fix-nav", prompt="Push your branch and create a pull request against main using gh pr create. Write a clear title and description based on what you did. Report the PR URL when done.")`
+
 After the actor finishes and reports the PR URL:
-```bash
-actor discard fix-nav
-```
+`discard_actor(name="fix-nav")` / `actor discard fix-nav`
 
 ### User: "merge fix-nav into main"
-```bash
-actor run fix-nav "Merge main into your branch to check for conflicts, resolve any issues, then merge your branch into main and push."
-```
-After the actor finishes:
-```bash
-actor discard fix-nav
-```
+`run_actor(name="fix-nav", prompt="Merge main into your branch to check for conflicts, resolve any issues, then merge your branch into main and push.")`
+After finish: discard.
 
 ### Forking an actor (trying a different approach)
-To fork an actor's work into a new direction, have the actor commit first, then create a new actor from its branch:
-```bash
-actor run feature "Commit all your changes with a descriptive message."
-```
-After the actor commits:
-```bash
-actor new feature-v2 --base feature "Take a different approach to..."
-```
+Have the actor commit first, then create a sibling from its branch:
+1. `run_actor(name="feature", prompt="Commit all your changes with a descriptive message.")`
+2. `new_actor(name="feature-v2", base="feature", prompt="Take a different approach to...")`
 
 ### User: "start a codex actor to fix the API"
-```bash
-actor new fix-api --agent codex "Fix the /users API endpoint — it returns 500 on missing email field"
-```
+`new_actor(name="fix-api", agent="codex", prompt="Fix the /users API endpoint — it returns 500 on missing email field")`
 
 ### User: "start an actor on the backend repo to fix the API"
-```bash
-actor new fix-api --dir /path/to/backend-repo "Fix the /users API endpoint — it returns 500 on missing email field"
-```
+`new_actor(name="fix-api", dir="/path/to/backend-repo", prompt="Fix the /users API endpoint — it returns 500 on missing email field")`
 
 ## Crafting Prompts for Actors
 
-Be explicit about what you expect from the actor. Actors are autonomous agents — they will ask questions if the task is ambiguous unless you tell them not to.
+Be explicit about what you expect. Actors are autonomous — they'll ask questions if the task is ambiguous unless you tell them not to.
 
-- **When the actor should just go build:** End the prompt with "Do not ask questions. Just implement it." or "Go ahead and build this without asking for clarification."
-- **When questions are welcome:** Say "If anything is unclear, stop and describe what you need clarification on." or simply leave the prompt open-ended.
+- **Just build:** end with "Do not ask questions. Just implement it." or "Go ahead and build this without asking for clarification."
+- **Questions welcome:** "If anything is unclear, stop and describe what you need clarification on." or leave the prompt open-ended.
 
 Choose based on context. If the user gave clear requirements, tell the actor to just build. If the task is exploratory, let the actor ask.
 
 ## Important Notes
 
-- Actors run with full permissions by default (`--dangerously-skip-permissions` for Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex). This can be changed via config — see the agent config reference.
-- Each actor gets its own git worktree by default, so multiple actors can work on the same repo without conflicts.
-- Actor sessions persist — you can `actor run` multiple prompts against the same actor and it remembers context.
-- If an actor errors, check `actor logs <name> --verbose` to see what went wrong, then `actor run <name> "fix the issue"` to retry.
-- When the user says something like "kick off", "spin up", "start", "launch", or "create an actor" — that means `actor new <name> "<prompt>"`.
+- Actors run with full permissions by default (`--dangerously-skip-permissions` for Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex). Change via config — see the agent config reference.
+- Each actor gets its own git worktree by default so parallel actors don't conflict.
+- Actor sessions persist — multiple runs against the same actor keep context.
+- If an actor errors, check verbose logs (`logs_actor(name=..., verbose=True)` / `actor logs <name> --verbose`) and retry with `run_actor` / `actor run`.
+- When the user says "kick off", "spin up", "start", "launch", or "create an actor" — that means `new_actor(name=..., prompt=...)` / `actor new <name> "<prompt>"`.

--- a/skills/actor/SKILL.md
+++ b/skills/actor/SKILL.md
@@ -8,163 +8,127 @@ allowed-tools: mcp__actor__list_actors mcp__actor__show_actor mcp__actor__logs_a
 
 You are an orchestrator that manages multiple coding agents running in parallel. Each agent runs in its own git worktree (by default) and has its own session that persists across runs.
 
-## Preferred interface
+## MCP is required for a good experience
 
-**If you have `mcp__actor__*` tools available, use them.** They return immediately, emit a channel notification when the actor finishes, and accept structured arguments.
+This skill is designed around the `mcp__actor__*` tools. They return immediately and emit a channel notification when the actor finishes, so you can hand off work and continue the conversation. Shell-only fallback exists but has no completion notifications — it's a last resort.
 
-If the MCP server isn't connected, fall back to the `actor` CLI. Both surfaces expose the same operations.
+**If `mcp__actor__*` tools are NOT in your tool list, prompt the user to install the MCP server before proceeding:**
+
+> This skill works best with the actor MCP server, which isn't available in the current session. Please install it:
+>
+> ```
+> claude mcp add actor -- actor mcp
+> ```
+>
+> Then restart this session and try again.
+
+Only fall back to the CLI (see [cli.md](cli.md)) if the user explicitly declines to install the MCP. When using the CLI fallback, completion is not pushed — you won't know when an actor finishes without asking.
+
+## Agent compatibility
+
+- **Claude Code (via MCP):** fully supported. Channel notifications flow back into the conversation on actor completion.
+- **Codex (via MCP):** **NOT currently supported.** Codex does not forward MCP server notifications into the model's conversation — tracked in [openai/codex#17543](https://github.com/openai/codex/issues/17543) and [#18056](https://github.com/openai/codex/issues/18056). Actors spawned from Codex would finish silently; the model would never know. Tell the user to use Claude Code for actor.sh, or wait until Codex ships MCP notification forwarding.
+- **Other MCP-capable agents:** works if the agent routes custom notifications to the model's conversation. Check your host's docs.
 
 ## Core Rules
 
-1. **Actor runs are background work.** You get notified when they finish. Never wait synchronously.
-   - **MCP:** `new_actor` / `run_actor` already return immediately; a channel notification arrives when the run completes.
-   - **CLI:** call `actor new` / `actor run` with the Bash tool's `run_in_background: true` (NOT shell `&`). **Each run MUST be its own Bash tool call** — never batch multiple `actor` commands in one Bash call, or notifications get lost.
-2. **ALWAYS read the output when an actor finishes.** The actor may have asked a question, proposed a plan, or reported an error. You cannot know what happened without reading the output (channel notification body for MCP, background output file for CLI).
-3. **Do NOT use `actor logs` / `logs_actor` for routine output.** The finish-notification is your primary source. Only use logs when the user explicitly asks or you need historical context.
-4. **Choose descriptive actor names.** The name becomes the git branch. Use lowercase with hyphens: `fix-auth`, `refactor-nav`, `add-tests`.
-5. **One actor per independent task.** Multiple parallel asks → multiple actors.
-6. **Use worktrees by default in git repos.** Each actor gets its own checkout so parallel work doesn't collide. Only pass `no_worktree=True` / `--no-worktree` when the user explicitly asks or the directory is not a git repo.
-7. **Stay responsive.** Tell the user the actors are running and continue the conversation. Report results when the notification arrives.
-8. **Only check status when asked.** Don't proactively `list_actors` / `actor list` / `show_actor` / `actor show` / `logs_actor` / `actor logs` unless the user asks.
+1. **Actor runs are background work.** `new_actor` and `run_actor` return immediately; a channel notification arrives when each run completes. React when it arrives.
+2. **Each actor run MUST be its own tool call.** Never batch multiple `new_actor` / `run_actor` calls in one combined tool use — completion notifications get mis-routed.
+3. **ALWAYS read the notification when an actor finishes.** The actor may have asked a question, proposed a plan, or reported an error. You cannot know what happened without reading the notification body.
+4. **Do NOT use `logs_actor` for routine output.** The finish notification is your primary source. Only call `logs_actor` when the user explicitly asks or you need historical context.
+5. **Choose descriptive actor names.** The name becomes the git branch. Use lowercase with hyphens: `fix-auth`, `refactor-nav`, `add-tests`.
+6. **One actor per independent task.** Multiple parallel asks → multiple actors.
+7. **Use worktrees by default in git repos.** Each actor gets its own checkout so parallel work doesn't collide. Only pass `no_worktree=True` when the user explicitly asks or the directory is not a git repo.
+8. **Stay responsive.** Tell the user the actors are running and continue the conversation. Report results when the notification arrives.
+9. **Only check status when asked.** Don't proactively `list_actors` / `show_actor` / `logs_actor` unless the user asks.
 
 ## Commands Reference
-
-Each operation is shown in both forms. Use MCP when available.
 
 ### Create and run an actor
 
 Pass a prompt to create and run in one step.
 
-**MCP:**
 ```
 new_actor(name="fix-nav", prompt="Fix the nav bar — broken on mobile")
-new_actor(name="fix-nav", prompt="...", agent="codex")                      # Codex agent
+new_actor(name="fix-nav", prompt="...", agent="codex")                      # Codex actor
 new_actor(name="fix-nav", prompt="...", base="develop")                     # branch off develop
 new_actor(name="fix-nav", prompt="...", dir="/path/to/repo")                # worktree from another repo
 new_actor(name="fix-nav", prompt="...", no_worktree=True)                   # no worktree
 new_actor(name="fix-nav", prompt="...", config=["model=opus"])              # saved defaults
 ```
 
-**CLI:**
-```bash
-actor new fix-nav "Fix the nav bar — broken on mobile"
-actor new fix-nav --agent codex "..."
-actor new fix-nav --base develop "..."
-actor new fix-nav --dir /path/to/repo "..."
-actor new fix-nav --no-worktree "..."
-actor new fix-nav --config model=opus "..."
-actor new fix-nav --no-strip-api-keys "..."                                 # pass API keys through
-echo "fix it" | actor new fix-nav                                           # prompt from stdin
-```
-
 ### Create without running
 
-**MCP:** `new_actor(name="fix-nav")` (omit `prompt`)
-**CLI:** `actor new fix-nav`
+```
+new_actor(name="fix-nav")
+```
 
 ### Run an existing actor
 
-Resumes the actor's session with a new prompt.
-
-**MCP:**
 ```
 run_actor(name="fix-nav", prompt="continue fixing")
 run_actor(name="fix-nav", prompt="...", config=["model=opus"])              # per-run override
 ```
 
-**CLI:**
-```bash
-actor run fix-nav "continue fixing"
-actor run fix-nav --config model=opus "..."                                 # per-run override
-```
-
 ### Change actor configuration
 
-Config changes take effect on the NEXT run — they don't affect an in-flight run. Structural properties (agent, worktree, dir, base branch) are set at creation and can't be changed.
+Config changes take effect on the NEXT run — they don't affect an in-flight run. Structural properties (agent, worktree, dir, base branch) are fixed at creation and can't be changed.
 
-**MCP:**
 ```
 config_actor(name="fix-nav")                                                # view
 config_actor(name="fix-nav", pairs=["model=opus"])                          # update
 ```
 
-**CLI:**
-```bash
-actor config fix-nav                                                        # view
-actor config fix-nav model=opus                                             # update
-actor config fix-nav model=sonnet effort=max                                # multiple at once
-```
-
-Config reference by agent:
+Config reference by actor's agent:
 - [Claude config](claude-config.md)
 - [Codex config](codex-config.md)
 
 ### Monitor
 
-**MCP:**
 ```
 list_actors()
 list_actors(status="running")
-show_actor(name="fix-nav")                                                  # details + last 5 runs
+show_actor(name="fix-nav")
 show_actor(name="fix-nav", runs=20)
 logs_actor(name="fix-nav")
 logs_actor(name="fix-nav", verbose=True)                                    # include tool calls, thinking
 ```
 
-**CLI:**
-```bash
-actor list
-actor list --status running
-actor show fix-nav
-actor show fix-nav --runs 20
-actor logs fix-nav
-actor logs fix-nav --verbose
-```
-
 ### Stop / discard
 
-**MCP:**
 ```
 stop_actor(name="fix-nav")
 discard_actor(name="fix-nav")                                               # worktree stays on disk
 ```
 
-**CLI:**
-```bash
-actor stop fix-nav
-actor discard fix-nav
-```
-
 ## Workflow Examples
 
 ### User: "spin up an actor to refactor the auth module"
-MCP: `new_actor(name="refactor-auth", prompt="Refactor the auth module. Simplify the token validation logic, remove dead code, and make sure all tests pass.")`
-CLI: `actor new refactor-auth "Refactor the auth module. ..."`
+`new_actor(name="refactor-auth", prompt="Refactor the auth module. Simplify the token validation logic, remove dead code, and make sure all tests pass.")`
 
 ### User: "start three actors: fix the nav, update the tests, and rewrite the README"
-Spawn each in its own tool call (parallel is fine — just not batched in a single Bash call):
+Spawn each in its own tool call:
 - `new_actor(name="fix-nav", prompt="Fix the navigation bar — it's broken on mobile viewports")`
 - `new_actor(name="update-tests", prompt="Update all test files to use the new test utilities")`
 - `new_actor(name="rewrite-readme", prompt="Rewrite the README with proper setup instructions and examples")`
 
 ### User: "what are my actors doing?"
-`list_actors()` / `actor list` — then summarize the status.
+`list_actors()` — then summarize the status.
 
 ### User: "what did fix-nav do?"
-`logs_actor(name="fix-nav")` / `actor logs fix-nav` — then summarize the key actions and results.
+`logs_actor(name="fix-nav")` — then summarize the key actions and results.
 
 ### User: "fix-nav looks good, make a PR"
 `run_actor(name="fix-nav", prompt="Push your branch and create a pull request against main using gh pr create. Write a clear title and description based on what you did. Report the PR URL when done.")`
 
 After the actor finishes and reports the PR URL:
-`discard_actor(name="fix-nav")` / `actor discard fix-nav`
+`discard_actor(name="fix-nav")`
 
 ### User: "merge fix-nav into main"
 `run_actor(name="fix-nav", prompt="Merge main into your branch to check for conflicts, resolve any issues, then merge your branch into main and push.")`
 After finish: discard.
 
 ### Forking an actor (trying a different approach)
-Have the actor commit first, then create a sibling from its branch:
 1. `run_actor(name="feature", prompt="Commit all your changes with a descriptive message.")`
 2. `new_actor(name="feature-v2", base="feature", prompt="Take a different approach to...")`
 
@@ -178,15 +142,15 @@ Have the actor commit first, then create a sibling from its branch:
 
 Be explicit about what you expect. Actors are autonomous — they'll ask questions if the task is ambiguous unless you tell them not to.
 
-- **Just build:** end with "Do not ask questions. Just implement it." or "Go ahead and build this without asking for clarification."
-- **Questions welcome:** "If anything is unclear, stop and describe what you need clarification on." or leave the prompt open-ended.
+- **Just build:** end with "Do not ask questions. Just implement it."
+- **Questions welcome:** "If anything is unclear, stop and describe what you need clarification on."
 
-Choose based on context. If the user gave clear requirements, tell the actor to just build. If the task is exploratory, let the actor ask.
+Choose based on context.
 
 ## Important Notes
 
 - Actors run with full permissions by default (`--dangerously-skip-permissions` for Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex). Change via config — see the agent config reference.
 - Each actor gets its own git worktree by default so parallel actors don't conflict.
 - Actor sessions persist — multiple runs against the same actor keep context.
-- If an actor errors, check verbose logs (`logs_actor(name=..., verbose=True)` / `actor logs <name> --verbose`) and retry with `run_actor` / `actor run`.
-- When the user says "kick off", "spin up", "start", "launch", or "create an actor" — that means `new_actor(name=..., prompt=...)` / `actor new <name> "<prompt>"`.
+- If an actor errors, check verbose logs (`logs_actor(name=..., verbose=True)`) and retry with `run_actor`.
+- When the user says "kick off", "spin up", "start", "launch", or "create an actor" — that means `new_actor(name=..., prompt=...)`.

--- a/skills/actor/SKILL.md
+++ b/skills/actor/SKILL.md
@@ -14,13 +14,23 @@ This skill is designed around the `mcp__actor__*` tools. They return immediately
 
 **If `mcp__actor__*` tools are NOT in your tool list, prompt the user to install the MCP server before proceeding:**
 
-> This skill works best with the actor MCP server, which isn't available in the current session. Please install it:
+> This skill works best with the actor MCP server, which isn't available in the current session.
 >
-> ```
-> claude mcp add actor -- actor mcp
-> ```
->
-> Then restart this session and try again.
+> 1. Install the `actor` CLI (provides both the CLI and the MCP server):
+>    ```
+>    uv tool install actor-sh
+>    ```
+>    or, if you prefer pip:
+>    ```
+>    pip install actor-sh
+>    ```
+> 2. Register the MCP server with Claude Code:
+>    ```
+>    claude mcp add actor -- actor mcp
+>    ```
+> 3. Restart this session and try again.
+
+If `actor` is already installed but the MCP isn't registered, skip step 1. Check with `actor --version` — if that prints a version, only run the `claude mcp add` step.
 
 Only fall back to the CLI (see [cli.md](cli.md)) if the user explicitly declines to install the MCP. When using the CLI fallback, completion is not pushed — you won't know when an actor finishes without asking.
 

--- a/skills/actor/cli.md
+++ b/skills/actor/cli.md
@@ -8,6 +8,20 @@ Use this reference only when:
 
 For Codex users: actor.sh is not currently compatible with Codex regardless of path, because Codex doesn't forward MCP notifications into the model's conversation. See [SKILL.md](SKILL.md) § Agent compatibility.
 
+## Prerequisite: install `actor`
+
+If `actor --version` fails, the CLI (and the MCP server) isn't installed. Install with:
+
+```
+uv tool install actor-sh
+```
+
+or:
+
+```
+pip install actor-sh
+```
+
 ---
 
 ## Create and run an actor

--- a/skills/actor/cli.md
+++ b/skills/actor/cli.md
@@ -1,0 +1,77 @@
+# Actor CLI Reference (fallback)
+
+This file documents the `actor` command-line interface. **If you have access to `mcp__actor__*` tools, use those instead** — see [SKILL.md](SKILL.md). The MCP server returns immediately and emits a channel notification when each actor finishes, giving you an async-notification workflow. The CLI has none of that: there's no push-completion, no structured arguments, and you lose the main reason the skill exists.
+
+Use this reference only when:
+- The MCP server genuinely can't be installed in the user's environment, and
+- The user has explicitly opted out of installing it after being offered.
+
+For Codex users: actor.sh is not currently compatible with Codex regardless of path, because Codex doesn't forward MCP notifications into the model's conversation. See [SKILL.md](SKILL.md) § Agent compatibility.
+
+---
+
+## Create and run an actor
+
+Pass a prompt to create and run in one step.
+
+```bash
+actor new fix-nav "Fix the nav bar — broken on mobile"
+actor new fix-nav --agent codex "..."                                       # Codex actor
+actor new fix-nav --base develop "..."                                      # branch off develop
+actor new fix-nav --dir /path/to/repo "..."                                 # worktree from another repo
+actor new fix-nav --no-worktree "..."                                       # no worktree
+actor new fix-nav --config model=opus "..."                                 # saved defaults
+actor new fix-nav --no-strip-api-keys "..."                                 # pass API keys through
+echo "fix it" | actor new fix-nav                                           # prompt from stdin
+```
+
+## Create without running
+
+```bash
+actor new fix-nav
+```
+
+## Run an existing actor
+
+```bash
+actor run fix-nav "continue fixing"
+actor run fix-nav --config model=opus "..."                                 # per-run override (not saved)
+echo "fix it" | actor run fix-nav                                           # prompt from stdin
+```
+
+## Change actor configuration
+
+```bash
+actor config fix-nav                                                        # view
+actor config fix-nav model=opus                                             # update
+actor config fix-nav model=sonnet effort=max                                # multiple at once
+```
+
+Config reference:
+- [Claude config](claude-config.md)
+- [Codex config](codex-config.md)
+
+## Monitor
+
+```bash
+actor list
+actor list --status running
+actor show fix-nav
+actor show fix-nav --runs 20
+actor logs fix-nav
+actor logs fix-nav --verbose
+actor logs fix-nav --watch                                                  # stream (CLI-only)
+```
+
+## Stop / discard
+
+```bash
+actor stop fix-nav
+actor discard fix-nav
+```
+
+## Background execution
+
+Because the CLI doesn't push completion events back to the model, running an actor in the CLI is inherently a foreground operation from the model's perspective. If your host supports background subprocesses (e.g., Claude Code's Bash tool `run_in_background: true`), use it — each `actor run` / `actor new <with prompt>` MUST be its own separate tool call. Do not use shell `&`, and never batch multiple runs in one call.
+
+Even with `run_in_background`, you'll only learn an actor finished when the host delivers the subprocess-exit notification. That's strictly inferior to the MCP channel notification, which carries the actor's actual output inline. This is why the MCP path is the recommended one.


### PR DESCRIPTION
## Summary

Supersedes the dual-path approach in PR #13 (now stale). This PR makes MCP the single primary path in the skill, splits the CLI reference into a separate \`cli.md\` file for fallback use only, and calls out Codex's incompatibility explicitly.

### Changes

- **SKILL.md** now documents only the \`mcp__actor__*\` tools. If the MCP server isn't installed, the skill prompts the user to install it via \`claude mcp add actor -- actor mcp\` rather than silently falling back to the CLI.
- **New \`cli.md\`** — standalone CLI reference. Framed as \"use only when MCP genuinely can't be installed.\" Links back to SKILL.md.
- **Agent compatibility section** in SKILL.md:
  - Claude Code via MCP: fully supported.
  - Codex via MCP: **not supported** — Codex doesn't forward MCP notifications to the model's conversation (issues [#17543](https://github.com/openai/codex/issues/17543), [#18056](https://github.com/openai/codex/issues/18056) are open but not merged). Actors would finish silently. Users should use Claude Code or wait.
  - Other MCP-capable agents: conditional on the host routing custom notifications to the model.
- \`allowed-tools\` retains \`Bash(actor *)\` so the CLI fallback remains invocable when needed.

## Test plan

- [ ] Claude Code session with MCP server: skill uses \`mcp__actor__*\` tools exclusively.
- [ ] Claude Code session without MCP server: skill prompts the user with the \`claude mcp add\` command.
- [ ] Reading SKILL.md, a coding agent in Codex understands that actor.sh isn't currently supported there.
- [x] All 173 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)