### PR TITLE
Auto patch-release to PyPI on every merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - '.github/**'
+      - '.claude-plugin/**'
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    # Skip if HEAD is already the automated release commit so we don't loop.
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write    # push version-bump commit + tag
+      id-token: write    # OIDC for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Run tests
+        run: uv run python -m unittest discover tests
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          uv version --bump patch
+          VERSION=$(uv version --short)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit + tag
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml uv.lock
+          git commit -m "chore(release): v${VERSION}"
+          git tag "v${VERSION}"
+          git push origin main --follow-tags
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            dist/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,21 @@ Tests use in-memory SQLite and fake implementations (FakeAgent, FakeGit, FakePro
 - **Worktrees:** `~/.actor/worktrees/<actor-name>/`
 - **Claude logs:** `~/.claude/projects/<encoded-dir>/<session-id>.jsonl`
 
+## Releasing
+
+Every merge to `main` automatically bumps the patch version, tags, and publishes to PyPI via `.github/workflows/release.yml`:
+
+1. Run the unit tests.
+2. `uv version --bump patch` → `0.1.3` → `0.1.4`.
+3. Commit as `chore(release): v0.1.4` and tag `v0.1.4`.
+4. `uv build` → wheel stamped with the new version.
+5. `pypa/gh-action-pypi-publish` uploads via PyPI trusted publishing (OIDC).
+6. GitHub Release created with auto-generated notes + wheel attached.
+
+The `chore(release):` prefix in the commit message prevents the workflow from retriggering on the version-bump push. Docs-only and CI-only changes (`**/*.md`, `.github/**`) are filtered out via `paths-ignore` so they don't cut a release.
+
+To skip a release manually, add `[skip release]` to the merge-commit body (requires a workflow guard update — not configured today).
+
 ## Architecture notes
 
 - Commands are pure functions that take a `Database` + interfaces and return strings. Side effects go through the `Agent`, `GitOps`, and `ProcessManager` ABCs — this is what makes everything testable with fakes.


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/release.yml\`. Every merge to \`main\` that touches non-doc, non-CI paths:

1. Runs unit tests.
2. \`uv version --bump patch\` — updates \`pyproject.toml\` + \`uv.lock\`.
3. Commits as \`chore(release): vX.Y.Z\` and tags \`vX.Y.Z\`.
4. \`uv build\`.
5. Publishes to PyPI via **trusted publishing** (OIDC, no API tokens).
6. Creates a GitHub release with auto-generated notes and the wheel attached.

Keeps us on \`uv_build\` — no migration to hatchling needed. The \`chore(release):\` commit prefix prevents the workflow from looping on its own bump commit. \`paths-ignore\` on \`**/*.md\`, \`.github/**\`, and \`.claude-plugin/**\` keeps docs/CI-only changes from cutting releases.

## Required one-time setup (for you to do after reviewing)

**1. PyPI trusted publisher.** Go to https://pypi.org/manage/project/actor-sh/settings/publishing/ (or create the \`actor-sh\` project first if it doesn't exist), then add a *pending publisher* with:

| Field | Value |
|-------|-------|
| Owner | \`mme\` |
| Repository name | \`actor.sh\` |
| Workflow name | \`release.yml\` |
| Environment name | *(leave blank)* |

Once the first release runs, the pending publisher gets promoted to a real one.

**2. GitHub workflow permissions.** Repo **Settings → Actions → General → Workflow permissions** → select **\"Read and write permissions\"**. This lets the workflow push the bump commit and tag back to \`main\`.

**3. Merge this PR.** After merging, the workflow *won't* fire for the merge itself (only \`.github/**\` changed). The next merge of any real change (src/, tests/) will trigger the first release.

## Notes

- If you ever want to cut a release manually, \`workflow_dispatch\` is wired in → Actions tab → Release → Run workflow.
- Concurrency group \`release\` with \`cancel-in-progress: false\` — multiple merges queue instead of cancelling each other.
- No API tokens in GitHub secrets. OIDC does the auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)