### PR TITLE
Dynamic versioning (hatchling + hatch-vcs) + skill body version stamp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,9 @@ jobs:
       - name: Create local tag
         env:
           NEW_TAG: ${{ steps.tag.outputs.new_tag }}
-        # Local tag only; hatch-vcs reads from local git state at build time.
-        # We don't push until after PyPI publish succeeds so a failed build
-        # doesn't orphan a tag on origin that no wheel backs.
+        # Local tag only; hatch-vcs reads from local git state at build
+        # time. We push to origin after the build succeeds (see the Push
+        # step below) — a failed build never orphans a tag on origin.
         run: git tag "${NEW_TAG}"
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - '.github/**'
+      - '.claude-plugin/**'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump level'
+        type: choice
+        required: true
+        default: patch
+        options: [patch, minor, major]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write    # push the git tag
+      id-token: write    # OIDC for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Run tests
+        run: uv run python -m unittest discover tests
+
+      - name: Compute next tag
+        id: tag
+        env:
+          BUMP: ${{ inputs.bump || 'patch' }}
+        run: |
+          LATEST=$(git tag --list 'v*' --sort=-v:refname | head -n1 | sed 's/^v//')
+          LATEST=${LATEST:-0.0.0}
+          IFS=. read -r MAJ MIN PAT <<<"$LATEST"
+          case "$BUMP" in
+            major) MAJ=$((MAJ+1)); MIN=0; PAT=0;;
+            minor) MIN=$((MIN+1)); PAT=0;;
+            patch) PAT=$((PAT+1));;
+          esac
+          NEW="v${MAJ}.${MIN}.${PAT}"
+          echo "new_tag=${NEW}" >> "$GITHUB_OUTPUT"
+          echo "Tag: ${NEW}"
+
+      - name: Tag release
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${NEW_TAG}"
+          git push origin "${NEW_TAG}"
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+        run: |
+          gh release create "${NEW_TAG}" \
+            --title "${NEW_TAG}" \
+            --generate-notes \
+            dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths-ignore:
       - '**/*.md'
-      - '.github/**'
       - '.claude-plugin/**'
   workflow_dispatch:
     inputs:
@@ -41,7 +40,11 @@ jobs:
         env:
           BUMP: ${{ inputs.bump || 'patch' }}
         run: |
-          LATEST=$(git tag --list 'v*' --sort=-v:refname | head -n1 | sed 's/^v//')
+          # Only consider plain semver tags; skip pre-release / arbitrary tags.
+          LATEST=$(git tag --list 'v*' --sort=-v:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | head -n1 \
+            | sed 's/^v//')
           LATEST=${LATEST:-0.0.0}
           IFS=. read -r MAJ MIN PAT <<<"$LATEST"
           case "$BUMP" in
@@ -53,20 +56,29 @@ jobs:
           echo "new_tag=${NEW}" >> "$GITHUB_OUTPUT"
           echo "Tag: ${NEW}"
 
-      - name: Tag release
-        env:
-          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+      - name: Configure git identity
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "${NEW_TAG}"
-          git push origin "${NEW_TAG}"
+
+      - name: Create local tag
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+        # Local tag only; hatch-vcs reads from local git state at build time.
+        # We don't push until after PyPI publish succeeds so a failed build
+        # doesn't orphan a tag on origin that no wheel backs.
+        run: git tag "${NEW_TAG}"
 
       - name: Build
         run: uv build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Push tag
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+        run: git push origin "${NEW_TAG}"
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,13 +72,18 @@ jobs:
       - name: Build
         run: uv build
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
       - name: Push tag
         env:
           NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+        # Push tag AFTER successful build (hatch-vcs stamped the wheel) but
+        # BEFORE publish. If publish fails, the tag is on origin and the
+        # next re-run rebuilds + republishes the same version — recoverable.
+        # If we pushed after publish and push failed, next run would bump
+        # from the older tag and PyPI would reject the duplicate.
         run: git push origin "${NEW_TAG}"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub release
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,28 @@ Tests use in-memory SQLite and fake implementations (FakeAgent, FakeGit, FakePro
 - **Worktrees:** `~/.actor/worktrees/<actor-name>/`
 - **Claude logs:** `~/.claude/projects/<encoded-dir>/<session-id>.jsonl`
 
+## Releasing
+
+The package uses dynamic versioning via `hatchling` + `hatch-vcs` — the version
+is derived from the latest git tag at build time. There is no hardcoded
+`version = "..."` in `pyproject.toml`.
+
+`.github/workflows/release.yml` runs on every push to `main` that touches
+non-doc/non-CI paths:
+
+1. Run unit tests.
+2. Read the latest `v*` tag, bump the patch (or whatever `workflow_dispatch`
+   input `bump` requests), compute the new tag `vX.Y.Z`.
+3. Create and push the tag — no commit back to `main`.
+4. `uv build` — hatch-vcs stamps the wheel with `X.Y.Z`.
+5. Publish to PyPI via trusted publishing (OIDC, no tokens).
+6. Create a GitHub release with auto-generated notes + wheel attached.
+
+Local dev installs (`uv sync`) get a PEP 440 dev version like
+`0.1.4.dev3+g1a2b3c4` derived from git state at install time, so
+`actor --version`, the MCP server's announced version, and the deployed
+SKILL.md all agree and the drift check still works.
+
 ## Architecture notes
 
 - Commands are pure functions that take a `Database` + interfaces and return strings. Side effects go through the `Agent`, `GitOps`, and `ProcessManager` ABCs — this is what makes everything testable with fakes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ Repository = "https://github.com/mme/actor.sh"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+# Explicit so a future hatch-vcs default change doesn't silently produce
+# surprising versions from our vX.Y.Z tags. setuptools-scm uses tag_regex.
+tag_regex = '^v(?P<version>\d+\.\d+\.\d+.*)$'
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/actor"]
 # Non-Python files inside the package tree (e.g. the bundled skill .md files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["uv_build>=0.7,<1"]
-build-backend = "uv_build"
+requires = ["hatchling>=1.25", "hatch-vcs>=0.4"]
+build-backend = "hatchling.build"
 
 [project]
 name = "actor-sh"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Manage coding agents in parallel"
 readme = "README.md"
 license = "MIT"
@@ -39,8 +39,10 @@ actor = "actor.cli:main"
 Homepage = "https://github.com/mme/actor.sh"
 Repository = "https://github.com/mme/actor.sh"
 
-[tool.uv]
-package = true
+[tool.hatch.version]
+source = "vcs"
 
-[tool.uv.build-backend]
-module-name = "actor"
+[tool.hatch.build.targets.wheel]
+packages = ["src/actor"]
+# Non-Python files inside the package tree (e.g. the bundled skill .md files
+# at src/actor/_skill/*.md) ship automatically with the package.

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -6,15 +6,10 @@ allowed-tools: mcp__actor__list_actors mcp__actor__show_actor mcp__actor__logs_a
 
 # Actor — Parallel Coding Agent Orchestrator
 
+<!-- BEGIN AUTO-UPDATED BY actor setup/update -->
+<!-- END AUTO-UPDATED BY actor setup/update -->
+
 You are an orchestrator that manages multiple coding agents running in parallel. Each agent runs in its own git worktree (by default) and has its own session that persists across runs.
-
-## Version check
-
-The MCP server announces its version in its server-level `instructions` ("actor-sh MCP version: X.Y.Z"). This skill file declares the version it was installed from in its YAML frontmatter (`version: X.Y.Z`). If those two versions differ, the `actor-sh` package was upgraded but the deployed skill wasn't refreshed — tell the user:
-
-> Your `actor` skill is from an older version of actor-sh (skill says `vA`, server says `vB`). Run `actor update` to refresh the deployed skill, then restart this session.
-
-Do this check once per session, not before every tool call.
 
 ## MCP is required for a good experience
 

--- a/src/actor/server.py
+++ b/src/actor/server.py
@@ -56,11 +56,13 @@ def _build_instructions(for_host: str | None = None) -> str:
     # `actor update` prompt every session.
     if __version__ == "unknown":
         return base
+    # The deployed skill's 'Version and updates' section (inside the
+    # <!-- BEGIN AUTO-UPDATED ... --> markers of SKILL.md) declares the
+    # version it was installed from. The skill itself tells the agent how
+    # to compare that against this server announcement.
     return (
         base
-        + f"\n\nactor-sh MCP version: {__version__}. If the actor skill document "
-        "declares a different version in its frontmatter, tell the user to run "
-        "`actor update` to refresh the deployed skill, then restart this session."
+        + f"\n\nactor-sh MCP version: {__version__}."
     )
 
 

--- a/src/actor/setup.py
+++ b/src/actor/setup.py
@@ -24,6 +24,18 @@ _CLAUDE_MCP_TIMEOUT_SEC = 30
 _SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
+def _rmtree_loud(path: Path) -> None:
+    """Best-effort rmtree; failures surface to stderr instead of disappearing.
+    Used for cleanup paths where a leftover dir is inconvenient but not fatal —
+    we'd rather the user see the warning than have cruft accumulate silently."""
+    try:
+        shutil.rmtree(path)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        print(f"[setup] warning: could not remove {path}: {e}", file=sys.stderr)
+
+
 def _validate_host(host: str) -> None:
     if host not in SUPPORTED_HOSTS:
         raise ActorError(
@@ -240,7 +252,7 @@ def cmd_setup(
         raise
     # Swap succeeded — clean up backup and stale MCP registration
     if old_backup is not None:
-        shutil.rmtree(old_backup, ignore_errors=True)
+        _rmtree_loud(old_backup)
 
     # From here on the skill is deployed. Wrap MCP steps so a failure tells
     # the user how to retry just the registration without wiping state.
@@ -304,7 +316,7 @@ def cmd_update(
             backup.rename(target)
         shutil.rmtree(staging, ignore_errors=True)
         raise
-    shutil.rmtree(backup, ignore_errors=True)
+    _rmtree_loud(backup)
 
     if prev_version is None:
         return (

--- a/src/actor/setup.py
+++ b/src/actor/setup.py
@@ -94,36 +94,53 @@ def _copy_bundled_skill(target: Path) -> list[str]:
     return copied
 
 
-def _stamp_version(skill_md: Path, version: str) -> None:
-    """Write `version: <value>` into the SKILL.md YAML frontmatter.
+_DEPLOY_BLOCK_BEGIN = "<!-- BEGIN AUTO-UPDATED BY actor setup/update -->"
+_DEPLOY_BLOCK_END = "<!-- END AUTO-UPDATED BY actor setup/update -->"
 
-    If a version line already exists, replace it. Otherwise insert it just
-    above the closing '---' of the frontmatter block.
+
+def _deploy_block(version: str) -> str:
+    """The version-check section written into SKILL.md's body at deploy time."""
+    return (
+        f"{_DEPLOY_BLOCK_BEGIN}\n"
+        f"## Version and updates\n"
+        f"\n"
+        f"This skill was deployed from **actor-sh {version}**. The MCP server announces its "
+        f"running version in its `instructions` field (`actor-sh MCP version: …`).\n"
+        f"\n"
+        f"**Version check, once per session:** if the server's announced version differs from "
+        f"`{version}`, the user has upgraded `actor-sh` but the deployed skill wasn't refreshed. "
+        f"Tell them:\n"
+        f"\n"
+        f"> Your actor skill is from an older version of actor-sh (skill: `{version}`, server: "
+        f"`<what the MCP instructions show>`). Run `actor update` to refresh it, then restart "
+        f"this session.\n"
+        f"\n"
+        f"Do the comparison once per session — not before every tool call.\n"
+        f"{_DEPLOY_BLOCK_END}"
+    )
+
+
+def _stamp_deploy_block(skill_md: Path, version: str) -> None:
+    """Replace the content between the deploy markers in SKILL.md with a freshly
+    generated block that includes the installed version and the drift-check
+    instructions.
+
+    The markers must already exist in the file (they're checked in to the source
+    SKILL.md as empty placeholders). If they're missing, error — that means the
+    bundled skill is malformed.
     """
     text = skill_md.read_text()
-    lines = text.splitlines(keepends=True)
-    if not lines or not lines[0].rstrip() == "---":
-        raise ActorError(f"{skill_md} has no YAML frontmatter")
-
-    # Find the closing '---'
-    close_idx = None
-    for i, line in enumerate(lines[1:], start=1):
-        if line.rstrip() == "---":
-            close_idx = i
-            break
-    if close_idx is None:
-        raise ActorError(f"{skill_md} has no closing '---' in frontmatter")
-
-    # Find an existing 'version:' line within the frontmatter
-    version_line = f"version: {version}\n"
-    for i in range(1, close_idx):
-        if lines[i].startswith("version:"):
-            lines[i] = version_line
-            skill_md.write_text("".join(lines))
-            return
-    # Not present — insert just before close
-    lines.insert(close_idx, version_line)
-    skill_md.write_text("".join(lines))
+    begin_idx = text.find(_DEPLOY_BLOCK_BEGIN)
+    end_idx = text.find(_DEPLOY_BLOCK_END)
+    if begin_idx < 0 or end_idx < 0 or end_idx < begin_idx:
+        raise ActorError(
+            f"{skill_md} is missing the deploy-block markers "
+            f"({_DEPLOY_BLOCK_BEGIN} / {_DEPLOY_BLOCK_END}); "
+            "the bundled skill appears malformed."
+        )
+    end_idx += len(_DEPLOY_BLOCK_END)
+    new_text = text[:begin_idx] + _deploy_block(version) + text[end_idx:]
+    skill_md.write_text(new_text)
 
 
 def _run_claude(*args: str, timeout: int = _CLAUDE_MCP_TIMEOUT_SEC) -> subprocess.CompletedProcess[str]:
@@ -198,7 +215,7 @@ def cmd_setup(
     old_backup: Path | None = None
     try:
         _copy_bundled_skill(staging)
-        _stamp_version(staging / "SKILL.md", __version__)
+        _stamp_deploy_block(staging / "SKILL.md", __version__)
 
         if target.exists():
             old_backup = parent / f".{name}-old-{os.getpid()}"
@@ -261,9 +278,9 @@ def cmd_update(
 
     before = (target / "SKILL.md").read_text()
     _copy_bundled_skill(target)
-    _stamp_version(target / "SKILL.md", new_version)
+    _stamp_deploy_block(target / "SKILL.md", new_version)
 
-    prev_version = _parse_frontmatter_version(before) or "unknown"
+    prev_version = _parse_deployed_version(before) or "unknown"
     if prev_version == new_version:
         return f"actor skill at {target} is already at version {new_version}."
     return (
@@ -272,13 +289,15 @@ def cmd_update(
     )
 
 
-def _parse_frontmatter_version(text: str) -> str | None:
-    lines = text.splitlines()
-    if not lines or lines[0].rstrip() != "---":
+_VERSION_IN_BLOCK_RE = re.compile(r"\*\*actor-sh ([^\*]+)\*\*")
+
+
+def _parse_deployed_version(text: str) -> str | None:
+    """Extract the installed version from the deploy block, if present."""
+    begin = text.find(_DEPLOY_BLOCK_BEGIN)
+    end = text.find(_DEPLOY_BLOCK_END)
+    if begin < 0 or end < 0 or end < begin:
         return None
-    for line in lines[1:]:
-        if line.rstrip() == "---":
-            return None
-        if line.startswith("version:"):
-            return line.split(":", 1)[1].strip().strip("\"'")
-    return None
+    block = text[begin:end]
+    m = _VERSION_IN_BLOCK_RE.search(block)
+    return m.group(1).strip() if m else None

--- a/src/actor/setup.py
+++ b/src/actor/setup.py
@@ -125,9 +125,13 @@ def _stamp_deploy_block(skill_md: Path, version: str) -> None:
     generated block that includes the installed version and the drift-check
     instructions.
 
-    The markers must already exist in the file (they're checked in to the source
-    SKILL.md as empty placeholders). If they're missing, error — that means the
-    bundled skill is malformed.
+    The markers must already exist in the file (the source SKILL.md checks in
+    empty placeholders). If they're missing, error — either the bundled skill
+    is malformed or the deployed file was manually edited; either way the caller
+    should surface a clear message.
+
+    Write is atomic via os.replace so a partial write (disk full, interrupt)
+    can't leave SKILL.md truncated.
     """
     text = skill_md.read_text()
     begin_idx = text.find(_DEPLOY_BLOCK_BEGIN)
@@ -135,12 +139,18 @@ def _stamp_deploy_block(skill_md: Path, version: str) -> None:
     if begin_idx < 0 or end_idx < 0 or end_idx < begin_idx:
         raise ActorError(
             f"{skill_md} is missing the deploy-block markers "
-            f"({_DEPLOY_BLOCK_BEGIN} / {_DEPLOY_BLOCK_END}); "
-            "the bundled skill appears malformed."
+            f"({_DEPLOY_BLOCK_BEGIN} / {_DEPLOY_BLOCK_END}). "
+            "Re-run `actor setup` to restore a correct SKILL.md."
         )
     end_idx += len(_DEPLOY_BLOCK_END)
     new_text = text[:begin_idx] + _deploy_block(version) + text[end_idx:]
-    skill_md.write_text(new_text)
+    # Defensive self-check: any future refactor of _deploy_block that drops a
+    # marker would silently render every subsequent update un-parseable.
+    if _DEPLOY_BLOCK_BEGIN not in new_text or _DEPLOY_BLOCK_END not in new_text:
+        raise ActorError("generated deploy block lost its markers (actor-sh bug)")
+    tmp = skill_md.with_suffix(skill_md.suffix + ".tmp")
+    tmp.write_text(new_text)
+    os.replace(tmp, skill_md)
 
 
 def _run_claude(*args: str, timeout: int = _CLAUDE_MCP_TIMEOUT_SEC) -> subprocess.CompletedProcess[str]:
@@ -276,11 +286,33 @@ def cmd_update(
             f"Run 'actor setup --for {for_host} --scope {scope}' first."
         )
 
-    before = (target / "SKILL.md").read_text()
-    _copy_bundled_skill(target)
-    _stamp_deploy_block(target / "SKILL.md", new_version)
+    before_text = (target / "SKILL.md").read_text()
+    prev_version = _parse_deployed_version(before_text)
 
-    prev_version = _parse_deployed_version(before) or "unknown"
+    # Atomic swap: stage the refreshed skill in a sibling temp dir, stamp, then
+    # rename-swap. Protects the deployed skill from partial writes if the
+    # stamp step fails mid-flight.
+    staging = Path(tempfile.mkdtemp(dir=target.parent, prefix=f".{name}-staging-"))
+    backup = target.parent / f".{name}-old-{os.getpid()}"
+    try:
+        _copy_bundled_skill(staging)
+        _stamp_deploy_block(staging / "SKILL.md", new_version)
+        target.rename(backup)
+        staging.rename(target)
+    except Exception:
+        if backup.exists() and not target.exists():
+            backup.rename(target)
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    shutil.rmtree(backup, ignore_errors=True)
+
+    if prev_version is None:
+        return (
+            f"actor skill at {target} refreshed to {new_version}. "
+            "(Couldn't read the prior version — the deployed skill may have been "
+            "edited by hand or predates version stamping.) "
+            "Restart your Claude Code session to pick up the changes."
+        )
     if prev_version == new_version:
         return f"actor skill at {target} is already at version {new_version}."
     return (
@@ -289,7 +321,9 @@ def cmd_update(
     )
 
 
-_VERSION_IN_BLOCK_RE = re.compile(r"\*\*actor-sh ([^\*]+)\*\*")
+# Anchored on the "deployed from" phrase so future edits to the block
+# prose can't accidentally match a different bold span.
+_VERSION_IN_BLOCK_RE = re.compile(r"deployed from \*\*actor-sh ([^\*]+)\*\*")
 
 
 def _parse_deployed_version(text: str) -> str | None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -11,9 +11,11 @@ from actor.errors import ActorError
 from actor.setup import (
     cmd_setup,
     cmd_update,
-    _parse_frontmatter_version,
+    _DEPLOY_BLOCK_BEGIN,
+    _DEPLOY_BLOCK_END,
+    _parse_deployed_version,
     _skill_target_dir,
-    _stamp_version,
+    _stamp_deploy_block,
 )
 
 
@@ -39,54 +41,63 @@ class TargetResolutionTests(unittest.TestCase):
             _skill_target_dir("cursor", "user", "actor")
 
 
-class StampVersionTests(unittest.TestCase):
-    def test_inserts_when_absent(self):
-        with tempfile.NamedTemporaryFile("w+", suffix=".md", delete=False) as f:
-            f.write("---\nname: actor\ndescription: x\n---\n\nbody\n")
-            path = Path(f.name)
-        try:
-            _stamp_version(path, "1.2.3")
-            out = path.read_text()
-            self.assertIn("version: 1.2.3", out)
-            self.assertEqual(out.count("version:"), 1)
-        finally:
-            path.unlink()
+def _fake_skill_md(tmp: Path) -> Path:
+    """A minimal SKILL.md with the deploy-block markers in place."""
+    path = tmp / "SKILL.md"
+    path.write_text(
+        "---\nname: actor\n---\n\n# Actor\n\n"
+        f"{_DEPLOY_BLOCK_BEGIN}\n"
+        f"{_DEPLOY_BLOCK_END}\n\n"
+        "body content\n"
+    )
+    return path
 
-    def test_replaces_existing(self):
-        with tempfile.NamedTemporaryFile("w+", suffix=".md", delete=False) as f:
-            f.write("---\nname: actor\nversion: 0.1.0\ndescription: x\n---\n\nbody\n")
-            path = Path(f.name)
-        try:
-            _stamp_version(path, "2.0.0")
-            out = path.read_text()
-            self.assertIn("version: 2.0.0", out)
-            self.assertNotIn("version: 0.1.0", out)
-            self.assertEqual(out.count("version:"), 1)
-        finally:
-            path.unlink()
 
-    def test_missing_frontmatter_raises(self):
-        with tempfile.NamedTemporaryFile("w+", suffix=".md", delete=False) as f:
-            f.write("# hello\nno frontmatter\n")
-            path = Path(f.name)
-        try:
+class StampDeployBlockTests(unittest.TestCase):
+    def test_fills_empty_block(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _fake_skill_md(Path(tmp))
+            _stamp_deploy_block(path, "1.2.3")
+            out = path.read_text()
+            self.assertIn("actor-sh 1.2.3", out)
+            # Markers still there, exactly once each
+            self.assertEqual(out.count(_DEPLOY_BLOCK_BEGIN), 1)
+            self.assertEqual(out.count(_DEPLOY_BLOCK_END), 1)
+
+    def test_replaces_existing_block(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _fake_skill_md(Path(tmp))
+            _stamp_deploy_block(path, "1.0.0")
+            _stamp_deploy_block(path, "2.0.0")
+            out = path.read_text()
+            self.assertIn("actor-sh 2.0.0", out)
+            self.assertNotIn("actor-sh 1.0.0", out)
+            # Body outside the block is preserved
+            self.assertIn("body content", out)
+
+    def test_missing_markers_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "SKILL.md"
+            path.write_text("# hello\nno markers\n")
             with self.assertRaises(ActorError):
-                _stamp_version(path, "1.0.0")
-        finally:
-            path.unlink()
+                _stamp_deploy_block(path, "1.0.0")
 
 
-class FrontmatterParseTests(unittest.TestCase):
-    def test_extracts_version(self):
-        text = "---\nname: actor\nversion: 0.3.1\n---\nbody\n"
-        self.assertEqual(_parse_frontmatter_version(text), "0.3.1")
+class DeployedVersionParseTests(unittest.TestCase):
+    def test_extracts_version_from_block(self):
+        block = (
+            f"# Actor\n{_DEPLOY_BLOCK_BEGIN}\n"
+            "This skill was deployed from **actor-sh 0.3.1**. …\n"
+            f"{_DEPLOY_BLOCK_END}\n"
+        )
+        self.assertEqual(_parse_deployed_version(block), "0.3.1")
 
-    def test_no_frontmatter_returns_none(self):
-        self.assertIsNone(_parse_frontmatter_version("# no frontmatter"))
+    def test_no_block_returns_none(self):
+        self.assertIsNone(_parse_deployed_version("# no markers"))
 
-    def test_no_version_key_returns_none(self):
-        text = "---\nname: actor\n---\nbody\n"
-        self.assertIsNone(_parse_frontmatter_version(text))
+    def test_empty_block_returns_none(self):
+        text = f"{_DEPLOY_BLOCK_BEGIN}\n{_DEPLOY_BLOCK_END}\n"
+        self.assertIsNone(_parse_deployed_version(text))
 
 
 class SetupEndToEndTests(unittest.TestCase):
@@ -103,7 +114,7 @@ class SetupEndToEndTests(unittest.TestCase):
                 target = Path(tmp) / ".claude" / "skills" / "actor"
                 self.assertTrue((target / "SKILL.md").exists())
                 self.assertTrue((target / "cli.md").exists())
-                self.assertIn("version: ", (target / "SKILL.md").read_text())
+                self.assertIn("actor-sh ", (target / "SKILL.md").read_text())
                 mcp_add.assert_called_once_with(name="actor", scope="user", for_host="claude-code")
                 mcp_remove.assert_not_called()  # nothing to clobber on first install
                 self.assertIn("installed", msg)
@@ -129,11 +140,11 @@ class UpdateEndToEndTests(unittest.TestCase):
                 cmd_setup(for_host="claude-code", scope="user", name="actor")
                 skill = Path(tmp) / ".claude" / "skills" / "actor" / "SKILL.md"
 
-                lines = skill.read_text().splitlines(keepends=True)
-                for i, line in enumerate(lines):
-                    if line.startswith("version:"):
-                        lines[i] = "version: 0.0.0-old\n"
-                skill.write_text("".join(lines))
+                # Simulate a stale deploy by rewriting the version string.
+                text = skill.read_text()
+                import re
+                text = re.sub(r"\*\*actor-sh [^\*]+\*\*", "**actor-sh 0.0.0-old**", text)
+                skill.write_text(text)
 
                 msg = cmd_update(for_host="claude-code", scope="user", name="actor")
                 self.assertIn("updated from 0.0.0-old", msg)
@@ -229,7 +240,7 @@ class SetupAtomicSwapTests(unittest.TestCase):
                 cmd_setup(for_host="claude-code", scope="user", name="actor")
                 target = Path(tmp) / ".claude" / "skills" / "actor"
                 first_text = (target / "SKILL.md").read_text()
-                self.assertIn("version: ", first_text)
+                self.assertIn("actor-sh ", first_text)
 
             # Second install, but _copy_bundled_skill raises mid-way. The
             # existing install must survive.
@@ -252,13 +263,12 @@ class SetupAtomicSwapTests(unittest.TestCase):
 class SetupVersionAssertionTests(unittest.TestCase):
     def test_stamped_version_matches_package_version(self):
         from actor import __version__
-        from actor.setup import _parse_frontmatter_version
         with tempfile.TemporaryDirectory() as tmp:
             with patch.dict(os.environ, {"HOME": tmp}), \
                  patch("actor.setup._claude_mcp_add"):
                 cmd_setup(for_host="claude-code", scope="user", name="actor")
                 skill = Path(tmp) / ".claude" / "skills" / "actor" / "SKILL.md"
-                self.assertEqual(_parse_frontmatter_version(skill.read_text()), __version__)
+                self.assertEqual(_parse_deployed_version(skill.read_text()), __version__)
 
 
 if __name__ == "__main__":

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -99,6 +99,46 @@ class DeployedVersionParseTests(unittest.TestCase):
         text = f"{_DEPLOY_BLOCK_BEGIN}\n{_DEPLOY_BLOCK_END}\n"
         self.assertIsNone(_parse_deployed_version(text))
 
+    def test_roundtrip_for_pep440_versions(self):
+        """Stamp → parse → same version for realistic PEP 440 strings."""
+        from actor.setup import _deploy_block
+        for version in (
+            "0.1.4",
+            "0.1.4.dev3+g1a2b3c4",
+            "0.1.dev190+gb95ac3fa7.d20260419",
+            "1.0.0",
+            "1.0.0rc1",
+            "1.0.0+local.with.dot",
+            "0.0.0-old",
+        ):
+            with self.subTest(version=version):
+                block = _deploy_block(version)
+                self.assertEqual(_parse_deployed_version(block), version)
+
+
+class StampIdempotencyTests(unittest.TestCase):
+    def test_double_stamp_same_version_is_identical(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _fake_skill_md(Path(tmp))
+            _stamp_deploy_block(path, "1.2.3")
+            first = path.read_text()
+            _stamp_deploy_block(path, "1.2.3")
+            self.assertEqual(path.read_text(), first)
+
+    def test_prefix_and_suffix_preserved(self):
+        """Content outside the block must survive byte-for-byte."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "SKILL.md"
+            path.write_text(
+                "PREFIX_BEFORE_BLOCK\n"
+                f"{_DEPLOY_BLOCK_BEGIN}\n{_DEPLOY_BLOCK_END}\n"
+                "SUFFIX_AFTER_BLOCK\n"
+            )
+            _stamp_deploy_block(path, "1.0.0")
+            out = path.read_text()
+            self.assertTrue(out.startswith("PREFIX_BEFORE_BLOCK\n"))
+            self.assertTrue(out.endswith("SUFFIX_AFTER_BLOCK\n"))
+
 
 class SetupEndToEndTests(unittest.TestCase):
     def _fake_home(self):

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,6 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "actor-sh"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Summary

Bundles three related changes:

### 1. Build backend → hatchling + hatch-vcs
- \`pyproject.toml\` no longer has a hardcoded \`version = \"...\"\`. Version is \`dynamic\` and derived from the latest git tag at build time.
- Dev installs get a PEP 440 dev version automatically: e.g. \`0.1.4.dev3+g1a2b3c4\`.
- \`uv\` remains the frontend for everything day-to-day (\`uv sync\`, \`uv build\`, \`uv publish\`).

### 2. Skill version is stamped into the body, not frontmatter
- Source \`SKILL.md\` has empty markers right after the H1: \`<!-- BEGIN AUTO-UPDATED BY actor setup/update -->\` / \`<!-- END ... -->\`.
- At \`actor setup\` / \`actor update\` time, \`_stamp_deploy_block\` fills them with a \"Version and updates\" section that names the installed version and tells the agent what to do on mismatch.
- Whether or not Claude Code exposes frontmatter to the model, the version is always visible now — it's in body text.
- Dropped the static \"Version check\" section from the source (superseded by the generated one).

### 3. Release workflow is tag-only (supersedes #17)
\`.github/workflows/release.yml\` on every push to main (non-doc/non-CI paths):
1. Run unit tests
2. Read latest \`v*\` tag, bump patch → compute new \`vX.Y.Z\`
3. Create and push the tag — **no commit back to main**
4. \`uv build\` — hatch-vcs stamps the new version
5. Publish to PyPI via trusted publishing (OIDC)
6. Create GitHub release with auto-generated notes + wheel

## Maintainer setup (one-time)

Same as PR #17:

1. PyPI trusted publisher for \`actor-sh\` (repo \`mme/actor.sh\`, workflow \`release.yml\`).
2. Repo Settings → Actions → General → Workflow permissions → **Read and write permissions** (so the job can push the tag).

## Test plan

- [x] \`uv sync\` produces an editable install with the dev version — confirmed \`0.1.dev190+gb95ac3fa7.d20260419\` end-to-end.
- [x] \`uv build --wheel\` produces a wheel with the correct dynamic version stamped into metadata.
- [x] \`actor setup\` writes the expected deploy block to the deployed SKILL.md; version string matches \`actor.__version__\`.
- [x] \`actor update\` reports version delta when the stamped version is outdated.
- [x] 202 unit tests pass.

Closes #17 (different approach — same goal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)