### PR TITLE
Add CI workflow for PR gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: '3.13'
+
+      - name: Stub agent binaries
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          for name in claude codex; do
+            printf '#!/usr/bin/env bash\nexit 0\n' > "$HOME/.local/bin/$name"
+            chmod +x "$HOME/.local/bin/$name"
+          done
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run tests
+        run: uv run python -m unittest discover tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - '**/*.md'
       - '.claude-plugin/**'
+      - '.github/workflows/**'
   workflow_dispatch:
     inputs:
       bump:


### PR DESCRIPTION
## Summary
- Adds `ci.yml` that runs the test suite on every PR to main so checks can be made required
- Release still runs tests on push to main as defense-in-depth
- Workflow-only changes no longer trigger releases (use `workflow_dispatch` to force one)

## Test plan
- [ ] CI job on this PR goes green