### PR TITLE
Make release workflow manual-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - '.claude-plugin/**'
-      - '.github/workflows/**'
   workflow_dispatch:
     inputs:
       bump:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,12 +89,12 @@ The package uses dynamic versioning via `hatchling` + `hatch-vcs` — the versio
 is derived from the latest git tag at build time. There is no hardcoded
 `version = "..."` in `pyproject.toml`.
 
-`.github/workflows/release.yml` runs on every push to `main` that touches
-non-doc/non-CI paths:
+`.github/workflows/release.yml` is triggered manually via
+`workflow_dispatch` (run it from the GitHub Actions UI or
+`gh workflow run release.yml -f bump=patch|minor|major`):
 
 1. Run unit tests.
-2. Read the latest `v*` tag, bump the patch (or whatever `workflow_dispatch`
-   input `bump` requests), compute the new tag `vX.Y.Z`.
+2. Read the latest `v*` tag, bump per the `bump` input, compute `vX.Y.Z`.
 3. Create and push the tag — no commit back to `main`.
 4. `uv build` — hatch-vcs stamps the wheel with `X.Y.Z`.
 5. Publish to PyPI via trusted publishing (OIDC, no tokens).


### PR DESCRIPTION
## Summary
- Drops the `push` trigger on `release.yml` — merging to `main` no longer auto-releases
- Release is now cut explicitly via `workflow_dispatch` (GitHub Actions UI or `gh workflow run release.yml -f bump=patch|minor|major`)
- `CLAUDE.md` updated to match

## Test plan
- [ ] After merge, confirm a push to `main` does NOT start a release run
- [ ] `gh workflow run release.yml -f bump=patch` still kicks off a release