### PR TITLE
Interactive mode: embed live Claude/Codex sessions in watch + rework CLI -i

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,16 @@ src/actor/               # Python package
   agents/
     claude.py            # ClaudeAgent — spawns claude CLI sessions
     codex.py             # CodexAgent — spawns codex CLI sessions
+  watch/
+    app.py               # Textual dashboard
+    interactive/         # Embedded terminal for live Claude/Codex sessions
+      screen.py          # pyte wrapper + rich.Text rendering
+      input.py           # key + mouse → ANSI byte translator
+      batcher.py         # refresh coalescer (flicker prevention)
+      diagnostics.py     # ring buffer of I/O events for post-mortem
+      pty_session.py     # pty.fork + async read/write/resize/reap
+      widget.py          # Textual widget (glue)
+      manager.py         # per-actor session registry + DB integration
   _skill/                # Bundled Claude Code skill (agent-facing docs)
     SKILL.md             # Main skill definition
     cli.md               # CLI fallback reference
@@ -104,6 +114,25 @@ Local dev installs (`uv sync`) get a PEP 440 dev version like
 `0.1.4.dev3+g1a2b3c4` derived from git state at install time, so
 `actor --version`, the MCP server's announced version, and the deployed
 SKILL.md all agree and the drift check still works.
+
+## Interactive mode
+
+Both the CLI and the watch TUI can open a live Claude/Codex session for
+an existing actor.
+
+- CLI: `actor run <name> -i` inherits the caller's TTY via subprocess.Popen
+  (stdin/stdout/stderr passthrough). Tracked as a Run with prompt
+  `*interactive*` so it shows up in `actor show`.
+- Watch: select an actor in the tree and press Enter. The detail pane
+  swaps to a TerminalWidget backed by a forked PTY (see
+  `src/actor/watch/interactive/`). Ctrl+Z leaves the widget but keeps
+  the subprocess alive; quitting watch SIGTERMs everything.
+
+The watch integration is structured so the pure parts (screen, input,
+batcher, diagnostics) are unit-testable with synthetic inputs, and the
+impure parts (PtySession, widget) are integration-tested with real
+`/bin/cat` and `/bin/sh` subprocesses. Ctrl+Shift+D inside `actor watch`
+dumps the DiagnosticRecorder ring buffer to stderr for post-mortems.
 
 ## Architecture notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 ]
 dependencies = [
     "mcp>=1.0",
+    "pyte>=0.8.1",
     "textual>=1.0",
     "textual-serve>=1.0",
 ]

--- a/src/actor/__init__.py
+++ b/src/actor/__init__.py
@@ -120,12 +120,14 @@ __all__ = [
     # Commands
     "cmd_new",
     "cmd_run",
+    "cmd_interactive",
+    "INTERACTIVE_PROMPT",
     "cmd_list",
     "cmd_show",
     "cmd_stop",
     "cmd_config",
     "cmd_logs",
-    "cmd_done",
+    "cmd_discard",
     # Helpers
     "truncate",
     "format_duration",

--- a/src/actor/__init__.py
+++ b/src/actor/__init__.py
@@ -61,6 +61,8 @@ from .process import RealProcessManager
 from .commands import (
     cmd_new,
     cmd_run,
+    cmd_interactive,
+    INTERACTIVE_PROMPT,
     cmd_list,
     cmd_show,
     cmd_stop,

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -116,6 +116,18 @@ stop_actor(name="fix-nav")
 discard_actor(name="fix-nav")                                               # worktree stays on disk
 ```
 
+### Interactive sessions
+
+Live Claude / Codex terminal sessions can be embedded in `actor watch`:
+
+- In the watch tree, select an actor and press **Enter** — the detail pane swaps to an embedded terminal running `claude --resume <session_id>` (or `codex resume <session_id>`) in the actor's worktree.
+- The actor must not be RUNNING and must already have a session (i.e. it's been run at least once).
+- **Ctrl+Z** leaves interactive mode but keeps the subprocess alive. Selecting a different actor in the tree shows that actor's logs (or its own live terminal if it also has one); coming back restores the session.
+- Quitting watch kills all live subprocesses and marks their runs STOPPED.
+- Each interactive session creates a Run with prompt `*interactive*` so it shows up in `show_actor` and `logs_actor` alongside normal runs.
+
+From the CLI: `actor run <name> -i` does the same thing but uses your existing TTY (no embedded widget).
+
 ## Workflow Examples
 
 ### User: "spin up an actor to refactor the auth module"

--- a/src/actor/_skill/cli.md
+++ b/src/actor/_skill/cli.md
@@ -51,7 +51,12 @@ actor new fix-nav
 actor run fix-nav "continue fixing"
 actor run fix-nav --config model=opus "..."                                 # per-run override (not saved)
 echo "fix it" | actor run fix-nav                                           # prompt from stdin
+actor run fix-nav -i                                                        # resume interactively in the current TTY
 ```
+
+`-i` (interactive) drops you into a live Claude/Codex session that resumes
+the actor's prior conversation. Tracked as a Run with prompt `*interactive*`
+so it shows up in `actor show` / the watch dashboard alongside normal runs.
 
 ## Change actor configuration
 

--- a/src/actor/agents/claude.py
+++ b/src/actor/agents/claude.py
@@ -209,6 +209,15 @@ class ClaudeAgent(Agent):
 
         return entries
 
+    def interactive_argv(self, session_id: str, config: Config) -> List[str]:
+        return [
+            "claude",
+            *self._CHANNEL_ARGS,
+            *self._permission_args(config),
+            "--resume", session_id,
+            *self._config_args(config),
+        ]
+
     def stop(self, pid: int) -> None:
         with self._lock:
             proc = self._children.pop(pid, None)

--- a/src/actor/agents/codex.py
+++ b/src/actor/agents/codex.py
@@ -273,6 +273,9 @@ class CodexAgent(Agent):
 
         return entries
 
+    def interactive_argv(self, session_id: str, config: Config) -> List[str]:
+        return ["codex", "resume", session_id]
+
     def stop(self, pid: int) -> None:
         with self._lock:
             entry = self._children.pop(pid, None)

--- a/src/actor/agents/codex.py
+++ b/src/actor/agents/codex.py
@@ -274,7 +274,13 @@ class CodexAgent(Agent):
         return entries
 
     def interactive_argv(self, session_id: str, config: Config) -> List[str]:
-        return ["codex", "resume", session_id]
+        # Propagate permission + config flags so interactive sessions honor
+        # the same defaults as non-interactive runs (parity with Claude).
+        return [
+            "codex", "resume", session_id,
+            *self._permission_args(config),
+            *self._config_args(config),
+        ]
 
     def stop(self, pid: int) -> None:
         with self._lock:

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -371,7 +371,11 @@ def main(argv: Optional[List[str]] = None) -> None:
                     db, agent, proc_mgr, name=args.name,
                 )
                 print(msg, file=sys.stderr)
-                sys.exit(exit_code if exit_code >= 0 else 1)
+                # POSIX convention for signal termination: 128 + signum.
+                # cmd_interactive returns -signum in that case.
+                if exit_code < 0:
+                    sys.exit(128 - exit_code)
+                sys.exit(exit_code)
 
             # Resolve prompt: argument, stdin, or error
             prompt = args.prompt

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -16,6 +16,7 @@ from .agents.codex import CodexAgent
 from .commands import (
     cmd_config,
     cmd_discard,
+    cmd_interactive,
     cmd_list,
     cmd_logs,
     cmd_new,
@@ -365,21 +366,12 @@ def main(argv: Optional[List[str]] = None) -> None:
         elif args.command == "run":
             # Interactive mode
             if args.interactive:
-                actor = db.get_actor(args.name)
-                status = db.resolve_actor_status(args.name, proc_mgr)
-                if status == Status.RUNNING:
-                    raise ActorError(f"'{args.name}' is currently running — stop it first")
-                session_id = actor.agent_session
-                if session_id is None:
-                    raise ActorError(f"'{args.name}' has no session yet — run it non-interactively first")
-                os.chdir(actor.dir)
-                if actor.agent == AgentKind.CLAUDE:
-                    cmd = ["claude", "--resume", session_id]
-                elif actor.agent == AgentKind.CODEX:
-                    cmd = ["codex", "resume", session_id]
-                else:
-                    raise ActorError(f"interactive mode not supported for agent: {actor.agent}")
-                os.execvp(cmd[0], cmd)
+                agent = agent_for(args.name)
+                exit_code, msg = cmd_interactive(
+                    db, agent, proc_mgr, name=args.name,
+                )
+                print(msg, file=sys.stderr)
+                sys.exit(exit_code if exit_code >= 0 else 1)
 
             # Resolve prompt: argument, stdin, or error
             prompt = args.prompt

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -354,11 +354,7 @@ def cmd_interactive(
 
 
 def _default_interactive_runner(argv: List[str], cwd: Path, env: dict) -> int:
-    """Spawn argv in cwd with the caller's TTY and block until exit.
-
-    Uses subprocess.Popen with stdin/stdout/stderr inherited so the child
-    gets a real terminal. Returns the exit code (or -1 on signal).
-    """
+    """Spawn argv in cwd with the caller's TTY and block until exit."""
     proc = subprocess.Popen(argv, cwd=str(cwd), env=env)
     try:
         return proc.wait()
@@ -368,7 +364,16 @@ def _default_interactive_runner(argv: List[str], cwd: Path, env: dict) -> int:
             return proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
-            return proc.wait()
+            try:
+                return proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                # Give up rather than block the shell forever. Surface a
+                # warning so the user can chase a zombie/stuck process.
+                print(
+                    f"warning: child pid {proc.pid} did not exit after SIGKILL",
+                    file=sys.stderr,
+                )
+                return -1
 
 
 # -- cmd_list --

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 from .errors import (
     ActorError,
@@ -274,6 +275,100 @@ def cmd_run(
     status = Status.DONE if exit_code == 0 else Status.ERROR
     db.update_run_status(run_id, status, exit_code)
     return output
+
+
+# -- cmd_interactive --
+
+INTERACTIVE_PROMPT = "*interactive*"
+
+
+def cmd_interactive(
+    db: Database,
+    agent: Agent,
+    proc_mgr: ProcessManager,
+    name: str,
+    runner: Optional[Callable[[List[str], Path, dict], int]] = None,
+) -> Tuple[int, str]:
+    """Enter an interactive session for an existing actor.
+
+    Creates a Run with prompt INTERACTIVE_PROMPT before spawning, runs the
+    agent in a real TTY (stdin/stdout/stderr inherited), and updates the Run
+    when the process exits. Returns (exit_code, status_message).
+
+    `runner` is injectable for testing: takes (argv, cwd, env) and returns
+    the child's exit code. Default uses subprocess.Popen with TTY inheritance.
+    """
+    actor = db.get_actor(name)
+
+    status = db.resolve_actor_status(name, proc_mgr)
+    if status == Status.RUNNING:
+        raise IsRunningError(name)
+
+    session_id = actor.agent_session
+    if session_id is None:
+        raise ActorError(
+            f"'{name}' has no session yet \u2014 run it non-interactively first"
+        )
+
+    if not binary_exists(actor.agent.binary_name):
+        raise AgentNotFoundError(actor.agent.binary_name)
+
+    dir_path = Path(actor.dir)
+    if not dir_path.is_dir():
+        raise ActorError(
+            f"actor directory '{actor.dir}' does not exist \u2014 use 'actor discard {name}' to clean up"
+        )
+
+    argv = agent.interactive_argv(session_id, actor.config)
+
+    run = Run(
+        id=0,
+        actor_name=name,
+        prompt=INTERACTIVE_PROMPT,
+        status=Status.RUNNING,
+        exit_code=None,
+        pid=None,
+        config=actor.config,
+        started_at=_now_iso(),
+        finished_at=None,
+    )
+    run_id = db.insert_run(run)
+    db.touch_actor(name)
+
+    env = dict(os.environ)
+    env["ACTOR_NAME"] = name
+
+    try:
+        exit_code = (runner or _default_interactive_runner)(argv, dir_path, env)
+    except BaseException:
+        db.update_run_status(run_id, Status.ERROR, -1)
+        raise
+
+    current = db.latest_run(name)
+    if current is not None and current.id == run_id and current.status == Status.STOPPED:
+        return exit_code, f"Interactive session for '{name}' stopped."
+
+    final = Status.DONE if exit_code == 0 else Status.ERROR
+    db.update_run_status(run_id, final, exit_code)
+    return exit_code, f"Interactive session for '{name}' ended (exit {exit_code})."
+
+
+def _default_interactive_runner(argv: List[str], cwd: Path, env: dict) -> int:
+    """Spawn argv in cwd with the caller's TTY and block until exit.
+
+    Uses subprocess.Popen with stdin/stdout/stderr inherited so the child
+    gets a real terminal. Returns the exit code (or -1 on signal).
+    """
+    proc = subprocess.Popen(argv, cwd=str(cwd), env=env)
+    try:
+        return proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+        try:
+            return proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            return proc.wait()
 
 
 # -- cmd_list --

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -289,15 +289,8 @@ def cmd_interactive(
     name: str,
     runner: Optional[Callable[[List[str], Path, dict], int]] = None,
 ) -> Tuple[int, str]:
-    """Enter an interactive session for an existing actor.
-
-    Creates a Run with prompt INTERACTIVE_PROMPT before spawning, runs the
-    agent in a real TTY (stdin/stdout/stderr inherited), and updates the Run
-    when the process exits. Returns (exit_code, status_message).
-
-    `runner` is injectable for testing: takes (argv, cwd, env) and returns
-    the child's exit code. Default uses subprocess.Popen with TTY inheritance.
-    """
+    """`runner` is injectable so tests can drive without spawning a real
+    subprocess. Returns (exit_code, status_message)."""
     actor = db.get_actor(name)
 
     status = db.resolve_actor_status(name, proc_mgr)
@@ -354,7 +347,6 @@ def cmd_interactive(
 
 
 def _default_interactive_runner(argv: List[str], cwd: Path, env: dict) -> int:
-    """Spawn argv in cwd with the caller's TTY and block until exit."""
     proc = subprocess.Popen(argv, cwd=str(cwd), env=env)
     try:
         return proc.wait()

--- a/src/actor/db.py
+++ b/src/actor/db.py
@@ -219,6 +219,18 @@ class Database:
         if cur.rowcount == 0:
             raise ActorError("run not found")
 
+    def get_run(self, run_id: int) -> Optional[Run]:
+        cur = self._conn.execute(
+            """SELECT id, actor_name, prompt, status, exit_code, pid, config,
+                      started_at, finished_at
+               FROM runs WHERE id = ?""",
+            (run_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return self._row_to_run(row)
+
     def latest_run(self, actor_name: str) -> Optional[Run]:
         cur = self._conn.execute(
             """SELECT id, actor_name, prompt, status, exit_code, pid, config,

--- a/src/actor/interfaces.py
+++ b/src/actor/interfaces.py
@@ -49,6 +49,10 @@ class Agent(abc.ABC):
     def stop(self, pid: int) -> None:
         """Kill a running agent process."""
 
+    @abc.abstractmethod
+    def interactive_argv(self, session_id: str, config: Config) -> List[str]:
+        """Argv to launch an interactive session (TTY / PTY). No prompt."""
+
 
 class GitOps(abc.ABC):
     @abc.abstractmethod

--- a/src/actor/types.py
+++ b/src/actor/types.py
@@ -36,6 +36,10 @@ class Status(Enum):
     DONE = "done"
     ERROR = "error"
     STOPPED = "stopped"
+    # Display-only: an interactive terminal session is open for the
+    # actor. Not persisted to the Run row — overlaid by the watch app
+    # when InteractiveSessionManager.has(name) is True.
+    INTERACTIVE = "interactive"
 
     def as_str(self) -> str:
         return self.value

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -110,7 +110,7 @@ class ActorWatchApp(App):
         Binding("down,ctrl+n", "navigate_down", show=False),
         Binding("a", "focus_actors", "Actors"),
         Binding("p", "command_palette", "Palette"),
-        Binding("i", "enter_interactive", "Interactive", key_display="⏎ / i"),
+        Binding("i", "enter_interactive", "Interactive", key_display="⏎/i"),
         Binding("l", "show_tab('logs')", "Logs"),
         Binding("d", "show_tab('diff')", "Diff"),
         Binding("question_mark", "show_tab('info')", "Info"),

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -110,7 +110,7 @@ class ActorWatchApp(App):
         Binding("down,ctrl+n", "navigate_down", show=False),
         Binding("a", "focus_actors", "Actors"),
         Binding("p", "command_palette", "Palette"),
-        Binding("i", "enter_interactive", "Interactive"),
+        Binding("i", "enter_interactive", "Interactive", key_display="⏎ / i"),
         Binding("l", "show_tab('logs')", "Logs"),
         Binding("d", "show_tab('diff')", "Diff"),
         Binding("question_mark", "show_tab('info')", "Info"),

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -12,7 +12,6 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import (
-    ContentSwitcher,
     DataTable,
     Footer,
     RichLog,
@@ -147,19 +146,25 @@ class ActorWatchApp(App):
                 yield Static(" ★ ACTOR.SH", id="actor-title")
                 yield ActorTree()
             with Vertical(id="detail-panel"):
-                with ContentSwitcher(id="detail-switcher", initial="tabs-view"):
-                    with Vertical(id="tabs-view"):
-                        with TabbedContent(id="tabs"):
-                            with TabPane("Logs", id="logs"):
-                                yield RichLog(id="logs-content", wrap=True, markup=False, auto_scroll=False)
-                            with TabPane("Diff", id="diff"):
-                                yield VerticalScroll(id="diff-scroll")
-                            with TabPane("Info", id="info"):
-                                yield VerticalScroll(
-                                    Static("Select an actor", id="info-content"),
-                                    DataTable(id="runs-table"),
-                                )
-                    yield Vertical(id="interactive-view")
+                with TabbedContent(id="tabs"):
+                    with TabPane("Logs", id="logs"):
+                        # The Logs tab holds either the RichLog (when
+                        # the selected actor has no live interactive
+                        # session) or the actor's TerminalWidget (when
+                        # it does). _sync_detail_view flips the content
+                        # inside this container; Diff and Info stay
+                        # accessible via their tabs either way.
+                        yield Vertical(
+                            RichLog(id="logs-content", wrap=True, markup=False, auto_scroll=False),
+                            id="logs-pane",
+                        )
+                    with TabPane("Diff", id="diff"):
+                        yield VerticalScroll(id="diff-scroll")
+                    with TabPane("Info", id="info"):
+                        yield VerticalScroll(
+                            Static("Select an actor", id="info-content"),
+                            DataTable(id="runs-table"),
+                        )
         yield Splash(id="splash", animate=self._animate)
         yield Static("Loading...", id="status-bar")
         yield Footer(show_command_palette=False)
@@ -297,14 +302,20 @@ class ActorWatchApp(App):
         self._refresh_logs(actor)
 
     def _clear_detail(self) -> None:
+        from textual.css.query import NoMatches
+
         info = self.query_one("#info-content", Static)
         info.update("Select an actor")
 
         table = self.query_one("#runs-table", DataTable)
         table.clear(columns=True)
 
-        log = self.query_one("#logs-content", RichLog)
-        log.clear()
+        try:
+            log = self.query_one("#logs-content", RichLog)
+            log.clear()
+        except NoMatches:
+            # Logs tab currently holds an interactive TerminalWidget.
+            pass
         self._last_log_actor = None
         self._last_log_count = 0
         self._last_log_entries = []
@@ -327,13 +338,21 @@ class ActorWatchApp(App):
     _last_log_entries: list = []
 
     def on_resize(self) -> None:
-        log = self.query_one("#logs-content", RichLog)
+        from textual.css.query import NoMatches
+        try:
+            log = self.query_one("#logs-content", RichLog)
+        except NoMatches:
+            return  # Logs tab holds a TerminalWidget; it handles its own resize.
         if log.size.width != self._last_log_width and self._last_log_entries:
             self._last_log_count = 0
             self._set_logs(self._last_log_actor, self._last_log_entries)
 
     def _set_logs(self, actor_name: str, entries: list) -> None:
-        log = self.query_one("#logs-content", RichLog)
+        from textual.css.query import NoMatches
+        try:
+            log = self.query_one("#logs-content", RichLog)
+        except NoMatches:
+            return  # Logs tab is currently hosting a TerminalWidget.
 
         actor_changed = actor_name != self._last_log_actor
         if not actor_changed and len(entries) == self._last_log_count and log.size.width == self._last_log_width:
@@ -461,8 +480,9 @@ class ActorWatchApp(App):
     # -- Interactive mode ----------------------------------------------------
 
     def _sync_detail_view(self) -> None:
-        """Switch the detail panel between tabs and an interactive terminal
-        based on whether the currently-selected actor has a live session.
+        """Populate the Logs tab with either the RichLog or the actor's
+        interactive TerminalWidget, based on whether the selected actor
+        has a live session. Diff / Info tabs are unaffected.
 
         NoMatches is silently tolerated because this runs from on_ready,
         on_tree_node_highlighted, and keybindings — the detail layout
@@ -471,8 +491,7 @@ class ActorWatchApp(App):
         from textual.css.query import NoMatches
 
         try:
-            switcher = self.query_one("#detail-switcher", ContentSwitcher)
-            view = self.query_one("#interactive-view", Vertical)
+            logs_pane = self.query_one("#logs-pane", Vertical)
         except NoMatches:
             return
         actor = self.query_one(ActorTree).selected_actor
@@ -481,27 +500,37 @@ class ActorWatchApp(App):
         )
 
         if info is None:
-            # No live session for the selected actor — swap to the tabs
-            # pane and unmount any lingering terminal widget so a future
-            # re-mount doesn't compete with a stale one. Widget.remove()
-            # is fire-and-forget (returns an AwaitRemove we don't await);
-            # the switcher already hides the view so a one-frame overlap
-            # during teardown is invisible.
-            if switcher.current != "tabs-view":
-                switcher.current = "tabs-view"
-            for child in list(view.children):
-                child.remove()
+            # No live session — show the standard RichLog. If the pane
+            # currently holds a terminal (from a previously-selected
+            # actor), unmount it and remount the RichLog.
+            current_children = list(logs_pane.children)
+            has_richlog = any(
+                isinstance(c, RichLog) and c.id == "logs-content"
+                for c in current_children
+            )
+            if not has_richlog:
+                for child in current_children:
+                    child.remove()
+                logs_pane.mount(
+                    RichLog(id="logs-content", wrap=True, markup=False, auto_scroll=False)
+                )
             self._interactive_active = None
             return
 
-        # Actor has a live session — mount its terminal (unmounting any
-        # previously-shown one first).
-        for child in list(view.children):
-            if child is not info.widget:
+        # Live session — put the actor's TerminalWidget in the Logs tab.
+        current_children = list(logs_pane.children)
+        if info.widget not in current_children:
+            for child in current_children:
                 child.remove()
-        if info.widget not in view.children:
-            view.mount(info.widget)
-        switcher.current = "interactive-view"
+            logs_pane.mount(info.widget)
+        # Activate the Logs tab if we're elsewhere, so the user actually
+        # sees the terminal they just opened.
+        try:
+            tabs = self.query_one("#tabs", TabbedContent)
+            if tabs.active != "logs":
+                tabs.active = "logs"
+        except Exception:
+            pass
         self._interactive_active = actor.name
         # Defer the focus call so it lands after Textual finishes
         # processing the event that triggered the sync (e.g. the
@@ -556,12 +585,9 @@ class ActorWatchApp(App):
         self._sync_detail_view()
 
     def on_terminal_widget_exit_requested(self, message: TerminalWidget.ExitRequested) -> None:
-        """Ctrl+Z from the embedded terminal: only shift focus to the
-        actor tree. The terminal view stays visible — while an
-        interactive session is live for the selected actor, that actor's
-        terminal is always shown in the detail pane."""
-        # Drop the terminal's focus so the tree's .focus() takes effect
-        # cleanly, then defer to let the key event settle.
+        """Ctrl+Z from the embedded terminal: move focus to the actor tree.
+        The Logs tab keeps the live terminal mounted; Diff / Info tabs
+        are still reachable via the tab bar."""
         self.set_focus(None)
         self.call_after_refresh(lambda: self.query_one(ActorTree).focus())
 
@@ -575,17 +601,12 @@ class ActorWatchApp(App):
         if target is None:
             return
         self._interactive.close(target)
-        # Status-change notification ("✓ actor done" / "✗ actor error") is
-        # produced by the next _update_ui poll; no need to double up with a
-        # per-session toast here.
-        # _sync_detail_view handles the ContentSwitcher swap AND unmounts
-        # the dead terminal widget from #interactive-view — the session
-        # is no longer in the registry so the "no session" branch fires.
+        # _sync_detail_view swaps the Logs-tab content back to RichLog
+        # now that the session is gone from the registry.
         self._refresh_detail()
         self._sync_detail_view()
-        # The terminal widget just unmounted — focus would otherwise
-        # land on nothing. Drop it back onto the tree so the user can
-        # immediately navigate to another actor.
+        # The terminal widget just unmounted — drop focus onto the tree
+        # so the user can immediately navigate to another actor.
         self.set_focus(None)
         self.call_after_refresh(lambda: self.query_one(ActorTree).focus())
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -323,7 +323,7 @@ class ActorWatchApp(App):
         log = self.query_one("#logs-content", RichLog)
         if log.size.width != self._last_log_width and self._last_log_entries:
             self._last_log_count = 0
-            self._set_logs(self._last_log_entries)
+            self._set_logs(self._last_log_actor, self._last_log_entries)
 
     def _set_logs(self, actor_name: str, entries: list) -> None:
         log = self.query_one("#logs-content", RichLog)
@@ -541,8 +541,14 @@ class ActorWatchApp(App):
             self.query_one("#detail-switcher", ContentSwitcher).current = "tabs-view"
         except NoMatches:
             pass
-        self.query_one(ActorTree).focus()
         self._interactive_active = None
+        # Dropping focus before re-focusing the tree is necessary because
+        # the terminal widget still holds focus at the moment of the key
+        # event; calling .focus() on the tree alone competes with the
+        # widget's re-focus pass. Defer via call_after_refresh so the
+        # switcher's layout change settles first.
+        self.set_focus(None)
+        self.call_after_refresh(lambda: self.query_one(ActorTree).focus())
 
     def on_terminal_widget_session_exited(self, message: TerminalWidget.SessionExited) -> None:
         from textual.css.query import NoMatches
@@ -578,9 +584,10 @@ class ActorWatchApp(App):
 
     def on_unmount(self) -> None:
         """Textual app teardown: kill all live interactive subprocesses so
-        no PTY child outlives the watch process. close_all() already
-        catches per-session failures and routes them to diagnostics."""
-        self._interactive.close_all()
+        no PTY child outlives the watch process. Uses the non-blocking
+        shutdown path — a blocking waitpid here stalls Textual's own
+        shutdown coroutine and leads to a hang that only Ctrl+C escapes."""
+        self._interactive.shutdown()
 
     def _focus_detail_content(self, tab_id: str | None = None) -> None:
         if tab_id is None:

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -114,10 +114,10 @@ class ActorWatchApp(App):
         Binding("l", "show_tab('logs')", "Logs"),
         Binding("d", "show_tab('diff')", "Diff"),
         Binding("i", "show_tab('info')", "Info"),
-        # priority=True so we run before Tree's built-in Enter binding (which
-        # would otherwise consume the event for select_cursor and swallow it).
-        # Also ensures the footer shows it.
-        Binding("enter", "enter_interactive", "Interactive", show=True, priority=True),
+        # Note: Enter is NOT bound here — we can't intercept it at the app
+        # level without stealing it from the embedded terminal widget.
+        # Interactive-mode entry is driven off Tree.NodeSelected (see the
+        # on_tree_node_selected handler); ActorTree owns the footer label.
         Binding("ctrl+shift+d", "dump_diagnostics", show=False),
     ]
 
@@ -447,6 +447,11 @@ class ActorWatchApp(App):
         self._refresh_detail()
         self._maybe_refresh_diff()
         self._sync_detail_view()
+
+    def on_tree_node_selected(self, event) -> None:
+        """Enter pressed on a tree node: start/show interactive session."""
+        event.stop()
+        self.action_enter_interactive()
 
     # -- Interactive mode ----------------------------------------------------
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from rich.text import Text
 from rich.theme import Theme as RichTheme
 
@@ -10,6 +12,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import (
+    ContentSwitcher,
     DataTable,
     Footer,
     RichLog,
@@ -19,9 +22,13 @@ from textual.widgets import (
 )
 
 from ..db import Database
+from ..interfaces import binary_exists
 from ..process import RealProcessManager
-from ..types import Actor, Status
-from ..cli import _db_path
+from ..types import Actor, AgentKind, Status
+from ..cli import _db_path, _create_agent
+from .interactive.diagnostics import DiagnosticRecorder
+from .interactive.manager import InteractiveSessionManager
+from .interactive.widget import TerminalWidget
 from .patches import apply_patches
 from .splash import Splash
 from .themes import CLAUDE_DARK, CLAUDE_LIGHT
@@ -107,6 +114,8 @@ class ActorWatchApp(App):
         Binding("l", "show_tab('logs')", "Logs"),
         Binding("d", "show_tab('diff')", "Diff"),
         Binding("i", "show_tab('info')", "Info"),
+        Binding("enter", "enter_interactive", "Interactive", show=True),
+        Binding("ctrl+shift+d", "dump_diagnostics", show=False),
     ]
 
     _prev_statuses: dict[str, Status] = {}
@@ -117,6 +126,13 @@ class ActorWatchApp(App):
     def __init__(self, animate: bool = True) -> None:
         super().__init__()
         self._animate = animate
+        self._diagnostics = DiagnosticRecorder(capacity=2048)
+        self._interactive = InteractiveSessionManager(
+            db_opener=lambda: Database.open(_db_path()),
+            recorder=self._diagnostics,
+        )
+        # Actor whose terminal widget is currently mounted, if any.
+        self._interactive_active: str | None = None
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         if self._splash_active and action != "quit":
@@ -129,16 +145,19 @@ class ActorWatchApp(App):
                 yield Static(" ★ ACTOR.SH", id="actor-title")
                 yield ActorTree()
             with Vertical(id="detail-panel"):
-                with TabbedContent(id="tabs"):
-                    with TabPane("Logs", id="logs"):
-                        yield RichLog(id="logs-content", wrap=True, markup=False, auto_scroll=False)
-                    with TabPane("Diff", id="diff"):
-                        yield VerticalScroll(id="diff-scroll")
-                    with TabPane("Info", id="info"):
-                        yield VerticalScroll(
-                            Static("Select an actor", id="info-content"),
-                            DataTable(id="runs-table"),
-                        )
+                with ContentSwitcher(id="detail-switcher", initial="tabs-view"):
+                    with Vertical(id="tabs-view"):
+                        with TabbedContent(id="tabs"):
+                            with TabPane("Logs", id="logs"):
+                                yield RichLog(id="logs-content", wrap=True, markup=False, auto_scroll=False)
+                            with TabPane("Diff", id="diff"):
+                                yield VerticalScroll(id="diff-scroll")
+                            with TabPane("Info", id="info"):
+                                yield VerticalScroll(
+                                    Static("Select an actor", id="info-content"),
+                                    DataTable(id="runs-table"),
+                                )
+                    yield Vertical(id="interactive-view")
         yield Splash(id="splash", animate=self._animate)
         yield Static("Loading...", id="status-bar")
         yield Footer(show_command_palette=False)
@@ -424,6 +443,141 @@ class ActorWatchApp(App):
     def on_tree_node_highlighted(self, event) -> None:
         self._refresh_detail()
         self._maybe_refresh_diff()
+        self._sync_detail_view()
+
+    # -- Interactive mode ----------------------------------------------------
+
+    def _sync_detail_view(self) -> None:
+        """Switch the detail panel between tabs and an interactive terminal
+        based on whether the currently-selected actor has a live session."""
+        try:
+            switcher = self.query_one("#detail-switcher", ContentSwitcher)
+        except Exception:
+            return
+        actor = self.query_one(ActorTree).selected_actor
+        if actor is None or not self._interactive.has(actor.name):
+            if switcher.current != "tabs-view":
+                switcher.current = "tabs-view"
+                self._interactive_active = None
+            return
+
+        info = self._interactive.get(actor.name)
+        if info is None:
+            switcher.current = "tabs-view"
+            self._interactive_active = None
+            return
+
+        # Unmount any previously-shown terminal, mount this one.
+        view = self.query_one("#interactive-view", Vertical)
+        for child in list(view.children):
+            child.remove()
+        view.mount(info.widget)
+        switcher.current = "interactive-view"
+        self._interactive_active = actor.name
+        info.widget.focus()
+
+    def action_enter_interactive(self) -> None:
+        """Enter key on the tree: start an interactive session for the
+        selected actor (or show its existing one)."""
+        # Only trigger if the tree has focus — otherwise leave Enter alone
+        # for the other widgets that may consume it.
+        if not self._tree_has_focus():
+            return
+
+        actor = self.query_one(ActorTree).selected_actor
+        if actor is None:
+            return
+
+        if self._interactive.has(actor.name):
+            self._sync_detail_view()
+            return
+
+        status = self._prev_statuses.get(actor.name, Status.IDLE)
+        if status == Status.RUNNING:
+            self.notify(f"{actor.name} is currently running — stop it first",
+                        severity="error")
+            return
+        if actor.agent_session is None:
+            self.notify(f"{actor.name} has no session yet — run it first",
+                        severity="error")
+            return
+        if not binary_exists(actor.agent.binary_name):
+            self.notify(f"agent binary '{actor.agent.binary_name}' not on PATH",
+                        severity="error")
+            return
+
+        try:
+            self._interactive.create(
+                actor_name=actor.name,
+                agent=_create_agent(actor.agent),
+                session_id=actor.agent_session,
+                cwd=Path(actor.dir),
+                config=dict(actor.config),
+            )
+        except Exception as e:
+            self.notify(f"failed to start interactive session: {e}", severity="error")
+            return
+
+        self._sync_detail_view()
+
+    def on_terminal_widget_exit_requested(self, message: TerminalWidget.ExitRequested) -> None:
+        """Ctrl+Z: leave interactive mode but keep the session alive in the bg."""
+        # Find the actor this widget belongs to.
+        name = self._interactive_active
+        if name is None:
+            return
+        try:
+            switcher = self.query_one("#detail-switcher", ContentSwitcher)
+            switcher.current = "tabs-view"
+        except Exception:
+            pass
+        # Return focus to the tree.
+        self.query_one(ActorTree).focus()
+        self._interactive_active = None
+
+    def on_terminal_widget_session_exited(self, message: TerminalWidget.SessionExited) -> None:
+        """Child process exited on its own. Close the session and restore logs."""
+        # Find the matching actor in the manager.
+        target: str | None = None
+        for name in self._interactive.live_names():
+            info = self._interactive.get(name)
+            if info is not None and info.widget is message.widget:
+                target = name
+                break
+        if target is None:
+            return
+        self._interactive.close(target)
+        if self._interactive_active == target:
+            try:
+                switcher = self.query_one("#detail-switcher", ContentSwitcher)
+                switcher.current = "tabs-view"
+            except Exception:
+                pass
+            self._interactive_active = None
+        code = message.exit_code
+        severity = "information" if code == 0 else "warning"
+        self.notify(f"{target} interactive session ended (exit {code})", severity=severity)
+        # Refresh the logs so the new *interactive* run row is visible.
+        self._refresh_detail()
+
+    def action_dump_diagnostics(self) -> None:
+        """Dump the terminal-I/O diagnostics ring buffer to the notification
+        system and stderr. Hidden binding for flicker post-mortems."""
+        import sys
+        dump = self._diagnostics.format(limit=200)
+        print(f"--- terminal diagnostics ({len(self._diagnostics)} events) ---",
+              file=sys.stderr)
+        print(dump, file=sys.stderr)
+        print("--- end ---", file=sys.stderr)
+        self.notify(f"dumped {len(self._diagnostics)} diagnostic events to stderr")
+
+    def on_unmount(self) -> None:
+        """Textual app teardown: kill all live interactive subprocesses so
+        no PTY child outlives the watch process."""
+        try:
+            self._interactive.close_all()
+        except Exception:
+            pass
 
     def _focus_detail_content(self, tab_id: str | None = None) -> None:
         if tab_id is None:

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -583,6 +583,11 @@ class ActorWatchApp(App):
         # is no longer in the registry so the "no session" branch fires.
         self._refresh_detail()
         self._sync_detail_view()
+        # The terminal widget just unmounted — focus would otherwise
+        # land on nothing. Drop it back onto the tree so the user can
+        # immediately navigate to another actor.
+        self.set_focus(None)
+        self.call_after_refresh(lambda: self.query_one(ActorTree).focus())
 
     def action_dump_diagnostics(self) -> None:
         import sys

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -114,7 +114,10 @@ class ActorWatchApp(App):
         Binding("l", "show_tab('logs')", "Logs"),
         Binding("d", "show_tab('diff')", "Diff"),
         Binding("i", "show_tab('info')", "Info"),
-        Binding("enter", "enter_interactive", "Interactive", show=True),
+        # priority=True so we run before Tree's built-in Enter binding (which
+        # would otherwise consume the event for select_cursor and swallow it).
+        # Also ensures the footer shows it.
+        Binding("enter", "enter_interactive", "Interactive", show=True, priority=True),
         Binding("ctrl+shift+d", "dump_diagnostics", show=False),
     ]
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -419,6 +419,18 @@ class ActorWatchApp(App):
         except Exception as e:
             self.call_from_thread(self._set_diff_text, f"Diff error: {e}")
 
+    def _set_logs_tab_label(self, label: str) -> None:
+        """Swap the Logs tab label between 'Logs' and 'Interactive'
+        without changing the tab id (the `l` shortcut still targets it)."""
+        from textual.css.query import NoMatches
+        try:
+            tabs = self.query_one("#tabs", TabbedContent)
+            tab = tabs.get_tab("logs")
+        except NoMatches:
+            return
+        if str(tab.label) != label:
+            tab.label = label
+
     def _update_diff_tab_label(self, added: int = 0, removed: int = 0) -> None:
         tabs = self.query_one("#tabs", TabbedContent)
         tab = tabs.get_tab("diff")
@@ -514,6 +526,7 @@ class ActorWatchApp(App):
                 logs_pane.mount(
                     RichLog(id="logs-content", wrap=True, markup=False, auto_scroll=False)
                 )
+            self._set_logs_tab_label("Logs")
             self._interactive_active = None
             return
 
@@ -523,6 +536,7 @@ class ActorWatchApp(App):
             for child in current_children:
                 child.remove()
             logs_pane.mount(info.widget)
+        self._set_logs_tab_label("Interactive")
         # Activate the Logs tab if we're elsewhere, so the user actually
         # sees the terminal they just opened.
         try:

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -110,7 +110,7 @@ class ActorWatchApp(App):
         Binding("down,ctrl+n", "navigate_down", show=False),
         Binding("a", "focus_actors", "Actors"),
         Binding("p", "command_palette", "Palette"),
-        Binding("i", "enter_interactive", "Interactive", key_display="⏎/i"),
+        Binding("i", "enter_interactive", "Interactive"),
         Binding("l", "show_tab('logs')", "Logs"),
         Binding("d", "show_tab('diff')", "Diff"),
         Binding("question_mark", "show_tab('info')", "Info"),
@@ -453,10 +453,6 @@ class ActorWatchApp(App):
         self._refresh_detail()
         self._maybe_refresh_diff()
         self._sync_detail_view()
-
-    def on_tree_node_selected(self, event) -> None:
-        event.stop()
-        self.action_enter_interactive()
 
     # -- Interactive mode ----------------------------------------------------
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -476,7 +476,10 @@ class ActorWatchApp(App):
         if info is None:
             # No live session for the selected actor — swap to the tabs
             # pane and unmount any lingering terminal widget so a future
-            # re-mount doesn't compete with a stale one.
+            # re-mount doesn't compete with a stale one. Widget.remove()
+            # is fire-and-forget (returns an AwaitRemove we don't await);
+            # the switcher already hides the view so a one-frame overlap
+            # during teardown is invisible.
             if switcher.current != "tabs-view":
                 switcher.current = "tabs-view"
             for child in list(view.children):

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -110,9 +110,10 @@ class ActorWatchApp(App):
         Binding("down,ctrl+n", "navigate_down", show=False),
         Binding("a", "focus_actors", "Actors"),
         Binding("p", "command_palette", "Palette"),
+        Binding("i", "enter_interactive", "Interactive"),
         Binding("l", "show_tab('logs')", "Logs"),
         Binding("d", "show_tab('diff')", "Diff"),
-        Binding("i", "show_tab('info')", "Info"),
+        Binding("question_mark", "show_tab('info')", "Info"),
         # Enter is handled by the Tree's NodeSelected message, not an app
         # binding — a priority binding here would steal Enter from the
         # embedded terminal widget.
@@ -147,17 +148,11 @@ class ActorWatchApp(App):
                 yield ActorTree()
             with Vertical(id="detail-panel"):
                 with TabbedContent(id="tabs"):
+                    # Interactive tab is added dynamically via
+                    # _sync_detail_view when the selected actor has a
+                    # live session; removed again when the session ends.
                     with TabPane("Logs", id="logs"):
-                        # The Logs tab holds either the RichLog (when
-                        # the selected actor has no live interactive
-                        # session) or the actor's TerminalWidget (when
-                        # it does). _sync_detail_view flips the content
-                        # inside this container; Diff and Info stay
-                        # accessible via their tabs either way.
-                        yield Vertical(
-                            RichLog(id="logs-content", wrap=True, markup=False, auto_scroll=False),
-                            id="logs-pane",
-                        )
+                        yield RichLog(id="logs-content", wrap=True, markup=False, auto_scroll=False)
                     with TabPane("Diff", id="diff"):
                         yield VerticalScroll(id="diff-scroll")
                     with TabPane("Info", id="info"):
@@ -302,20 +297,14 @@ class ActorWatchApp(App):
         self._refresh_logs(actor)
 
     def _clear_detail(self) -> None:
-        from textual.css.query import NoMatches
-
         info = self.query_one("#info-content", Static)
         info.update("Select an actor")
 
         table = self.query_one("#runs-table", DataTable)
         table.clear(columns=True)
 
-        try:
-            log = self.query_one("#logs-content", RichLog)
-            log.clear()
-        except NoMatches:
-            # Logs tab currently holds an interactive TerminalWidget.
-            pass
+        log = self.query_one("#logs-content", RichLog)
+        log.clear()
         self._last_log_actor = None
         self._last_log_count = 0
         self._last_log_entries = []
@@ -338,21 +327,13 @@ class ActorWatchApp(App):
     _last_log_entries: list = []
 
     def on_resize(self) -> None:
-        from textual.css.query import NoMatches
-        try:
-            log = self.query_one("#logs-content", RichLog)
-        except NoMatches:
-            return  # Logs tab holds a TerminalWidget; it handles its own resize.
+        log = self.query_one("#logs-content", RichLog)
         if log.size.width != self._last_log_width and self._last_log_entries:
             self._last_log_count = 0
             self._set_logs(self._last_log_actor, self._last_log_entries)
 
     def _set_logs(self, actor_name: str, entries: list) -> None:
-        from textual.css.query import NoMatches
-        try:
-            log = self.query_one("#logs-content", RichLog)
-        except NoMatches:
-            return  # Logs tab is currently hosting a TerminalWidget.
+        log = self.query_one("#logs-content", RichLog)
 
         actor_changed = actor_name != self._last_log_actor
         if not actor_changed and len(entries) == self._last_log_count and log.size.width == self._last_log_width:
@@ -419,18 +400,6 @@ class ActorWatchApp(App):
         except Exception as e:
             self.call_from_thread(self._set_diff_text, f"Diff error: {e}")
 
-    def _set_logs_tab_label(self, label: str) -> None:
-        """Swap the Logs tab label between 'Logs' and 'Interactive'
-        without changing the tab id (the `l` shortcut still targets it)."""
-        from textual.css.query import NoMatches
-        try:
-            tabs = self.query_one("#tabs", TabbedContent)
-            tab = tabs.get_tab("logs")
-        except NoMatches:
-            return
-        if str(tab.label) != label:
-            tab.label = label
-
     def _update_diff_tab_label(self, added: int = 0, removed: int = 0) -> None:
         tabs = self.query_one("#tabs", TabbedContent)
         tab = tabs.get_tab("diff")
@@ -492,18 +461,13 @@ class ActorWatchApp(App):
     # -- Interactive mode ----------------------------------------------------
 
     def _sync_detail_view(self) -> None:
-        """Populate the Logs tab with either the RichLog or the actor's
-        interactive TerminalWidget, based on whether the selected actor
-        has a live session. Diff / Info tabs are unaffected.
-
-        NoMatches is silently tolerated because this runs from on_ready,
-        on_tree_node_highlighted, and keybindings — the detail layout
-        may not yet be mounted on the first tick.
-        """
+        """Add/remove the Interactive tab based on whether the selected
+        actor has a live session. Does NOT activate the tab; use
+        action_enter_interactive for that."""
         from textual.css.query import NoMatches
 
         try:
-            logs_pane = self.query_one("#logs-pane", Vertical)
+            tabs = self.query_one("#tabs", TabbedContent)
         except NoMatches:
             return
         actor = self.query_one(ActorTree).selected_actor
@@ -511,92 +475,93 @@ class ActorWatchApp(App):
             self._interactive.get(actor.name) if actor is not None else None
         )
 
+        existing: TabPane | None = None
+        try:
+            existing = tabs.get_pane("interactive")
+        except Exception:
+            existing = None
+
         if info is None:
-            # No live session — show the standard RichLog. If the pane
-            # currently holds a terminal (from a previously-selected
-            # actor), unmount it and remount the RichLog.
-            current_children = list(logs_pane.children)
-            has_richlog = any(
-                isinstance(c, RichLog) and c.id == "logs-content"
-                for c in current_children
-            )
-            if not has_richlog:
-                for child in current_children:
-                    child.remove()
-                logs_pane.mount(
-                    RichLog(id="logs-content", wrap=True, markup=False, auto_scroll=False)
-                )
-            self._set_logs_tab_label("Logs")
+            if existing is not None:
+                tabs.remove_pane("interactive")
             self._interactive_active = None
             return
 
-        # Live session — put the actor's TerminalWidget in the Logs tab.
-        current_children = list(logs_pane.children)
-        if info.widget not in current_children:
-            for child in current_children:
-                child.remove()
-            logs_pane.mount(info.widget)
-        self._set_logs_tab_label("Interactive")
-        # Activate the Logs tab if we're elsewhere, so the user actually
-        # sees the terminal they just opened.
-        try:
-            tabs = self.query_one("#tabs", TabbedContent)
-            if tabs.active != "logs":
-                tabs.active = "logs"
-        except Exception:
-            pass
+        # Actor has a live session. Rebuild the Interactive pane so its
+        # child widget matches the currently-selected actor's terminal
+        # (each actor owns a distinct TerminalWidget).
+        if existing is not None:
+            # If the existing pane already holds this actor's widget, leave it.
+            if info.widget in list(existing.children):
+                self._interactive_active = actor.name
+                return
+            tabs.remove_pane("interactive")
+
+        # add_pane is async — it schedules the mount but we can proceed.
+        new_pane = TabPane("Interactive", info.widget, id="interactive")
+        tabs.add_pane(new_pane, before="logs")
         self._interactive_active = actor.name
-        # Defer the focus call so it lands after Textual finishes
-        # processing the event that triggered the sync (e.g. the
-        # Enter key on the tree). Without this, competing focus
-        # changes during the same event loop iteration can leave the
-        # tree focused and keys stop reaching the terminal.
-        target_widget = info.widget
-        self.call_after_refresh(lambda: target_widget.focus())
 
     def action_enter_interactive(self) -> None:
-        """Enter key on the tree: start an interactive session for the
-        selected actor (or show its existing one)."""
-        # Only trigger if the tree has focus — otherwise leave Enter alone
-        # for the other widgets that may consume it.
-        if not self._tree_has_focus():
-            return
-
+        """Bound to `i` (app-wide) and Tree.NodeSelected (Enter on tree):
+        take the user to the Interactive tab for the selected actor,
+        creating the session if needed. Always scrolls to the bottom
+        and focuses the terminal so the user is ready to type."""
         actor = self.query_one(ActorTree).selected_actor
         if actor is None:
+            self.notify("no actor selected", severity="warning")
             return
 
-        if self._interactive.has(actor.name):
-            self._sync_detail_view()
-            return
-
-        status = self._prev_statuses.get(actor.name, Status.IDLE)
-        if status == Status.RUNNING:
-            self.notify(f"{actor.name} is currently running — stop it first",
-                        severity="error")
-            return
-        if actor.agent_session is None:
-            self.notify(f"{actor.name} has no session yet — run it first",
-                        severity="error")
-            return
-        if not binary_exists(actor.agent.binary_name):
-            self.notify(f"agent binary '{actor.agent.binary_name}' not on PATH",
-                        severity="error")
-            return
-
-        try:
-            self._interactive.create(
-                actor_name=actor.name,
-                agent=_create_agent(actor.agent),
-                session_id=actor.agent_session,
-                cwd=Path(actor.dir),
-                config=dict(actor.config),
-            )
-        except Exception as e:
-            self.notify(f"failed to start interactive session: {e}", severity="error")
-            return
+        if not self._interactive.has(actor.name):
+            status = self._prev_statuses.get(actor.name, Status.IDLE)
+            if status == Status.RUNNING:
+                self.notify(f"{actor.name} is currently running — stop it first",
+                            severity="error")
+                return
+            if actor.agent_session is None:
+                self.notify(f"{actor.name} has no session yet — run it first",
+                            severity="error")
+                return
+            if not binary_exists(actor.agent.binary_name):
+                self.notify(f"agent binary '{actor.agent.binary_name}' not on PATH",
+                            severity="error")
+                return
+            try:
+                self._interactive.create(
+                    actor_name=actor.name,
+                    agent=_create_agent(actor.agent),
+                    session_id=actor.agent_session,
+                    cwd=Path(actor.dir),
+                    config=dict(actor.config),
+                )
+            except Exception as e:
+                self.notify(f"failed to start interactive session: {e}", severity="error")
+                return
 
         self._sync_detail_view()
+
+        # Activate the Interactive tab, focus the terminal, and scroll
+        # to the bottom — intentionally different from tab-nav, which
+        # preserves scroll position.
+        info = self._interactive.get(actor.name)
+        if info is None:
+            return
+        try:
+            tabs = self.query_one("#tabs", TabbedContent)
+        except Exception:
+            return
+        tabs.active = "interactive"
+
+        target_widget = info.widget
+
+        def _activate() -> None:
+            target_widget.focus()
+            try:
+                target_widget.scroll_end(animate=False, force=True)
+            except Exception:
+                pass
+
+        self.call_after_refresh(_activate)
 
     def on_terminal_widget_exit_requested(self, message: TerminalWidget.ExitRequested) -> None:
         """Ctrl+Z from the embedded terminal: move focus to the actor tree.

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -223,6 +223,13 @@ class ActorWatchApp(App):
         self.call_from_thread(self._update_ui, actors, statuses)
 
     def _update_ui(self, actors: list[Actor], statuses: dict[str, Status]) -> None:
+        # Overlay INTERACTIVE status for actors with a live terminal
+        # session. This is display-only — the DB Run row is still
+        # RUNNING/STOPPED/etc.
+        for name in self._interactive.live_names():
+            if name in statuses:
+                statuses[name] = Status.INTERACTIVE
+
         for a in actors:
             new_status = statuses.get(a.name)
             old_status = self._prev_statuses.get(a.name)

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -114,10 +114,9 @@ class ActorWatchApp(App):
         Binding("l", "show_tab('logs')", "Logs"),
         Binding("d", "show_tab('diff')", "Diff"),
         Binding("i", "show_tab('info')", "Info"),
-        # Note: Enter is NOT bound here — we can't intercept it at the app
-        # level without stealing it from the embedded terminal widget.
-        # Interactive-mode entry is driven off Tree.NodeSelected (see the
-        # on_tree_node_selected handler); ActorTree owns the footer label.
+        # Enter is handled by the Tree's NodeSelected message, not an app
+        # binding — a priority binding here would steal Enter from the
+        # embedded terminal widget.
         Binding("ctrl+shift+d", "dump_diagnostics", show=False),
     ]
 
@@ -449,7 +448,6 @@ class ActorWatchApp(App):
         self._sync_detail_view()
 
     def on_tree_node_selected(self, event) -> None:
-        """Enter pressed on a tree node: start/show interactive session."""
         event.stop()
         self.action_enter_interactive()
 
@@ -535,7 +533,6 @@ class ActorWatchApp(App):
         self._sync_detail_view()
 
     def on_terminal_widget_exit_requested(self, message: TerminalWidget.ExitRequested) -> None:
-        """Ctrl+Z — leave the widget but keep the subprocess alive."""
         from textual.css.query import NoMatches
 
         if self._interactive_active is None:
@@ -548,7 +545,6 @@ class ActorWatchApp(App):
         self._interactive_active = None
 
     def on_terminal_widget_session_exited(self, message: TerminalWidget.SessionExited) -> None:
-        """Child process exited on its own — close the session, restore logs."""
         from textual.css.query import NoMatches
 
         target: str | None = None
@@ -572,8 +568,6 @@ class ActorWatchApp(App):
         self._refresh_detail()
 
     def action_dump_diagnostics(self) -> None:
-        """Dump the terminal-I/O diagnostics ring buffer to the notification
-        system and stderr. Hidden binding for flicker post-mortems."""
         import sys
         dump = self._diagnostics.format(limit=200)
         print(f"--- terminal diagnostics ({len(self._diagnostics)} events) ---",

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -465,25 +465,32 @@ class ActorWatchApp(App):
 
         try:
             switcher = self.query_one("#detail-switcher", ContentSwitcher)
+            view = self.query_one("#interactive-view", Vertical)
         except NoMatches:
             return
         actor = self.query_one(ActorTree).selected_actor
-        if actor is None or not self._interactive.has(actor.name):
+        info = (
+            self._interactive.get(actor.name) if actor is not None else None
+        )
+
+        if info is None:
+            # No live session for the selected actor — swap to the tabs
+            # pane and unmount any lingering terminal widget so a future
+            # re-mount doesn't compete with a stale one.
             if switcher.current != "tabs-view":
                 switcher.current = "tabs-view"
-                self._interactive_active = None
-            return
-
-        info = self._interactive.get(actor.name)
-        if info is None:
-            switcher.current = "tabs-view"
+            for child in list(view.children):
+                child.remove()
             self._interactive_active = None
             return
 
-        view = self.query_one("#interactive-view", Vertical)
+        # Actor has a live session — mount its terminal (unmounting any
+        # previously-shown one first).
         for child in list(view.children):
-            child.remove()
-        view.mount(info.widget)
+            if child is not info.widget:
+                child.remove()
+        if info.widget not in view.children:
+            view.mount(info.widget)
         switcher.current = "interactive-view"
         self._interactive_active = actor.name
         info.widget.focus()
@@ -533,26 +540,16 @@ class ActorWatchApp(App):
         self._sync_detail_view()
 
     def on_terminal_widget_exit_requested(self, message: TerminalWidget.ExitRequested) -> None:
-        from textual.css.query import NoMatches
-
-        if self._interactive_active is None:
-            return
-        try:
-            self.query_one("#detail-switcher", ContentSwitcher).current = "tabs-view"
-        except NoMatches:
-            pass
-        self._interactive_active = None
-        # Dropping focus before re-focusing the tree is necessary because
-        # the terminal widget still holds focus at the moment of the key
-        # event; calling .focus() on the tree alone competes with the
-        # widget's re-focus pass. Defer via call_after_refresh so the
-        # switcher's layout change settles first.
+        """Ctrl+Z from the embedded terminal: only shift focus to the
+        actor tree. The terminal view stays visible — while an
+        interactive session is live for the selected actor, that actor's
+        terminal is always shown in the detail pane."""
+        # Drop the terminal's focus so the tree's .focus() takes effect
+        # cleanly, then defer to let the key event settle.
         self.set_focus(None)
         self.call_after_refresh(lambda: self.query_one(ActorTree).focus())
 
     def on_terminal_widget_session_exited(self, message: TerminalWidget.SessionExited) -> None:
-        from textual.css.query import NoMatches
-
         target: str | None = None
         for name in self._interactive.live_names():
             info = self._interactive.get(name)
@@ -562,16 +559,14 @@ class ActorWatchApp(App):
         if target is None:
             return
         self._interactive.close(target)
-        if self._interactive_active == target:
-            try:
-                self.query_one("#detail-switcher", ContentSwitcher).current = "tabs-view"
-            except NoMatches:
-                pass
-            self._interactive_active = None
         code = message.exit_code
         severity = "information" if code == 0 else "warning"
         self.notify(f"{target} interactive session ended (exit {code})", severity=severity)
+        # _sync_detail_view handles the ContentSwitcher swap AND unmounts
+        # the dead terminal widget from #interactive-view — the session
+        # is no longer in the registry so the "no session" branch fires.
         self._refresh_detail()
+        self._sync_detail_view()
 
     def action_dump_diagnostics(self) -> None:
         import sys

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -496,7 +496,13 @@ class ActorWatchApp(App):
             view.mount(info.widget)
         switcher.current = "interactive-view"
         self._interactive_active = actor.name
-        info.widget.focus()
+        # Defer the focus call so it lands after Textual finishes
+        # processing the event that triggered the sync (e.g. the
+        # Enter key on the tree). Without this, competing focus
+        # changes during the same event loop iteration can leave the
+        # tree focused and keys stop reaching the terminal.
+        target_widget = info.widget
+        self.call_after_refresh(lambda: target_widget.focus())
 
     def action_enter_interactive(self) -> None:
         """Enter key on the tree: start an interactive session for the
@@ -562,9 +568,9 @@ class ActorWatchApp(App):
         if target is None:
             return
         self._interactive.close(target)
-        code = message.exit_code
-        severity = "information" if code == 0 else "warning"
-        self.notify(f"{target} interactive session ended (exit {code})", severity=severity)
+        # Status-change notification ("✓ actor done" / "✗ actor error") is
+        # produced by the next _update_ui poll; no need to double up with a
+        # per-session toast here.
         # _sync_detail_view handles the ContentSwitcher swap AND unmounts
         # the dead terminal widget from #interactive-view — the session
         # is no longer in the registry so the "no session" branch fires.

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -457,10 +457,17 @@ class ActorWatchApp(App):
 
     def _sync_detail_view(self) -> None:
         """Switch the detail panel between tabs and an interactive terminal
-        based on whether the currently-selected actor has a live session."""
+        based on whether the currently-selected actor has a live session.
+
+        NoMatches is silently tolerated because this runs from on_ready,
+        on_tree_node_highlighted, and keybindings — the detail layout
+        may not yet be mounted on the first tick.
+        """
+        from textual.css.query import NoMatches
+
         try:
             switcher = self.query_one("#detail-switcher", ContentSwitcher)
-        except Exception:
+        except NoMatches:
             return
         actor = self.query_one(ActorTree).selected_actor
         if actor is None or not self._interactive.has(actor.name):
@@ -475,7 +482,6 @@ class ActorWatchApp(App):
             self._interactive_active = None
             return
 
-        # Unmount any previously-shown terminal, mount this one.
         view = self.query_one("#interactive-view", Vertical)
         for child in list(view.children):
             child.remove()
@@ -529,23 +535,22 @@ class ActorWatchApp(App):
         self._sync_detail_view()
 
     def on_terminal_widget_exit_requested(self, message: TerminalWidget.ExitRequested) -> None:
-        """Ctrl+Z: leave interactive mode but keep the session alive in the bg."""
-        # Find the actor this widget belongs to.
-        name = self._interactive_active
-        if name is None:
+        """Ctrl+Z — leave the widget but keep the subprocess alive."""
+        from textual.css.query import NoMatches
+
+        if self._interactive_active is None:
             return
         try:
-            switcher = self.query_one("#detail-switcher", ContentSwitcher)
-            switcher.current = "tabs-view"
-        except Exception:
+            self.query_one("#detail-switcher", ContentSwitcher).current = "tabs-view"
+        except NoMatches:
             pass
-        # Return focus to the tree.
         self.query_one(ActorTree).focus()
         self._interactive_active = None
 
     def on_terminal_widget_session_exited(self, message: TerminalWidget.SessionExited) -> None:
-        """Child process exited on its own. Close the session and restore logs."""
-        # Find the matching actor in the manager.
+        """Child process exited on its own — close the session, restore logs."""
+        from textual.css.query import NoMatches
+
         target: str | None = None
         for name in self._interactive.live_names():
             info = self._interactive.get(name)
@@ -557,15 +562,13 @@ class ActorWatchApp(App):
         self._interactive.close(target)
         if self._interactive_active == target:
             try:
-                switcher = self.query_one("#detail-switcher", ContentSwitcher)
-                switcher.current = "tabs-view"
-            except Exception:
+                self.query_one("#detail-switcher", ContentSwitcher).current = "tabs-view"
+            except NoMatches:
                 pass
             self._interactive_active = None
         code = message.exit_code
         severity = "information" if code == 0 else "warning"
         self.notify(f"{target} interactive session ended (exit {code})", severity=severity)
-        # Refresh the logs so the new *interactive* run row is visible.
         self._refresh_detail()
 
     def action_dump_diagnostics(self) -> None:
@@ -581,11 +584,9 @@ class ActorWatchApp(App):
 
     def on_unmount(self) -> None:
         """Textual app teardown: kill all live interactive subprocesses so
-        no PTY child outlives the watch process."""
-        try:
-            self._interactive.close_all()
-        except Exception:
-            pass
+        no PTY child outlives the watch process. close_all() already
+        catches per-session failures and routes them to diagnostics."""
+        self._interactive.close_all()
 
     def _focus_detail_content(self, tab_id: str | None = None) -> None:
         if tab_id is None:

--- a/src/actor/watch/helpers.py
+++ b/src/actor/watch/helpers.py
@@ -15,6 +15,7 @@ STATUS_ICON = {
     Status.ERROR: "󰗖",
     Status.IDLE: "",
     Status.STOPPED: "",
+    Status.INTERACTIVE: "⌨",  # U+2328 KEYBOARD — plain, non-emoji variant
 }
 
 

--- a/src/actor/watch/interactive/__init__.py
+++ b/src/actor/watch/interactive/__init__.py
@@ -1,13 +1,1 @@
-"""Interactive embedded-terminal support for `actor watch`.
-
-Pure modules (unit-testable, no I/O):
-  screen.py       — pyte wrapper + rich.Text rendering
-  input.py        — key + mouse event → bytes translator
-  batcher.py      — refresh coalescer (flicker prevention)
-  diagnostics.py  — ring buffer recording I/O events for post-mortem
-
-Impure modules (integration-tested):
-  pty_session.py  — pty.fork + read/write/resize/close lifecycle
-  widget.py       — Textual widget gluing the pure parts to a live session
-  manager.py      — dict[actor_name, PtySession], lifecycle on the app
-"""
+"""Interactive embedded-terminal support for `actor watch`."""

--- a/src/actor/watch/interactive/__init__.py
+++ b/src/actor/watch/interactive/__init__.py
@@ -1,0 +1,13 @@
+"""Interactive embedded-terminal support for `actor watch`.
+
+Pure modules (unit-testable, no I/O):
+  screen.py       — pyte wrapper + rich.Text rendering
+  input.py        — key + mouse event → bytes translator
+  batcher.py      — refresh coalescer (flicker prevention)
+  diagnostics.py  — ring buffer recording I/O events for post-mortem
+
+Impure modules (integration-tested):
+  pty_session.py  — pty.fork + read/write/resize/close lifecycle
+  widget.py       — Textual widget gluing the pure parts to a live session
+  manager.py      — dict[actor_name, PtySession], lifecycle on the app
+"""

--- a/src/actor/watch/interactive/batcher.py
+++ b/src/actor/watch/interactive/batcher.py
@@ -1,16 +1,7 @@
 """Output batcher: coalesce rapid refreshes into at most one per interval.
 
-When a subprocess dumps a lot of output (initial TUI redraw, piping a
-large file, etc.) we can get dozens of chunks in a single scheduler tick.
-Each chunk parses into the screen buffer fine, but rendering after every
-chunk causes visible flicker and wastes CPU.
-
-The batcher is a pure function-with-state: `on_bytes(n)` records that n
-bytes arrived. `should_refresh_now(now)` tells the caller whether it's
-time to render, considering a minimum inter-refresh interval and a
-maximum defer-time so the UI still feels live during sustained output.
-
-No I/O, no threads, no timers — the caller owns the clock.
+The caller owns the clock (no I/O, no threads). Under bursty PTY output
+we'd otherwise render once per chunk, producing visible flicker.
 """
 from __future__ import annotations
 
@@ -20,21 +11,15 @@ from typing import Optional
 
 @dataclass
 class RefreshBatcher:
-    """Decide when to re-render based on bytes-in + wall time."""
-
-    # Minimum wall time between refreshes (seconds). Tiny outputs still
-    # batch, but anything beyond this gap always refreshes.
-    min_interval: float = 0.016   # ~60fps ceiling
-    # Maximum time to defer a refresh when bytes keep arriving. Guarantees
-    # the UI updates even during a never-ending output firehose.
+    # min_interval floors the refresh rate (~60fps); max_defer caps how
+    # long we hold back a refresh when bytes keep streaming in.
+    min_interval: float = 0.016
     max_defer: float = 0.050
-    # State
     _pending_bytes: int = 0
     _pending_since: Optional[float] = None
     _last_refresh: float = field(default=float("-inf"))
 
     def on_bytes(self, n: int, now: float) -> None:
-        """Note that n bytes arrived at time `now`."""
         if n <= 0:
             return
         self._pending_bytes += n
@@ -42,18 +27,14 @@ class RefreshBatcher:
             self._pending_since = now
 
     def should_refresh_now(self, now: float) -> bool:
-        """True if the caller should re-render at `now`."""
         if self._pending_bytes == 0:
             return False
-        # If it's been long enough since the last refresh, fire.
         if now - self._last_refresh >= self.min_interval:
             return True
-        # Otherwise wait — but don't wait longer than max_defer.
         since = now - (self._pending_since or now)
         return since >= self.max_defer
 
     def mark_refreshed(self, now: float) -> int:
-        """Caller invokes this after re-rendering. Returns bytes flushed."""
         flushed = self._pending_bytes
         self._pending_bytes = 0
         self._pending_since = None

--- a/src/actor/watch/interactive/batcher.py
+++ b/src/actor/watch/interactive/batcher.py
@@ -1,0 +1,64 @@
+"""Output batcher: coalesce rapid refreshes into at most one per interval.
+
+When a subprocess dumps a lot of output (initial TUI redraw, piping a
+large file, etc.) we can get dozens of chunks in a single scheduler tick.
+Each chunk parses into the screen buffer fine, but rendering after every
+chunk causes visible flicker and wastes CPU.
+
+The batcher is a pure function-with-state: `on_bytes(n)` records that n
+bytes arrived. `should_refresh_now(now)` tells the caller whether it's
+time to render, considering a minimum inter-refresh interval and a
+maximum defer-time so the UI still feels live during sustained output.
+
+No I/O, no threads, no timers — the caller owns the clock.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class RefreshBatcher:
+    """Decide when to re-render based on bytes-in + wall time."""
+
+    # Minimum wall time between refreshes (seconds). Tiny outputs still
+    # batch, but anything beyond this gap always refreshes.
+    min_interval: float = 0.016   # ~60fps ceiling
+    # Maximum time to defer a refresh when bytes keep arriving. Guarantees
+    # the UI updates even during a never-ending output firehose.
+    max_defer: float = 0.050
+    # State
+    _pending_bytes: int = 0
+    _pending_since: Optional[float] = None
+    _last_refresh: float = field(default=float("-inf"))
+
+    def on_bytes(self, n: int, now: float) -> None:
+        """Note that n bytes arrived at time `now`."""
+        if n <= 0:
+            return
+        self._pending_bytes += n
+        if self._pending_since is None:
+            self._pending_since = now
+
+    def should_refresh_now(self, now: float) -> bool:
+        """True if the caller should re-render at `now`."""
+        if self._pending_bytes == 0:
+            return False
+        # If it's been long enough since the last refresh, fire.
+        if now - self._last_refresh >= self.min_interval:
+            return True
+        # Otherwise wait — but don't wait longer than max_defer.
+        since = now - (self._pending_since or now)
+        return since >= self.max_defer
+
+    def mark_refreshed(self, now: float) -> int:
+        """Caller invokes this after re-rendering. Returns bytes flushed."""
+        flushed = self._pending_bytes
+        self._pending_bytes = 0
+        self._pending_since = None
+        self._last_refresh = now
+        return flushed
+
+    def pending_bytes(self) -> int:
+        return self._pending_bytes

--- a/src/actor/watch/interactive/diagnostics.py
+++ b/src/actor/watch/interactive/diagnostics.py
@@ -17,21 +17,21 @@ from typing import Callable, Deque, List, Optional
 
 
 class EventKind(str, Enum):
-    READ = "read"            # bytes read from PTY master
-    WRITE = "write"          # bytes written to PTY master
-    REFRESH = "refresh"      # widget re-render fired
-    REFRESH_SKIP = "skip"    # batcher coalesced
-    RESIZE = "resize"        # PTY + screen resize
-    EXIT = "exit"            # child process exited
-    ERROR = "error"          # unexpected condition
+    READ = "read"
+    WRITE = "write"
+    REFRESH = "refresh"
+    REFRESH_SKIP = "skip"
+    RESIZE = "resize"
+    EXIT = "exit"
+    ERROR = "error"
 
 
 @dataclass(frozen=True)
 class TerminalEvent:
     t: float
     kind: EventKind
-    size: int
-    preview: bytes
+    full_size: int
+    preview_bytes: bytes
     note: str
 
 
@@ -58,15 +58,14 @@ class DiagnosticRecorder:
         self._events.append(TerminalEvent(
             t=self._now(),
             kind=kind,
-            size=size,
-            preview=preview,
+            full_size=size,
+            preview_bytes=preview,
             note=note,
         ))
 
     def recent(self, limit: Optional[int] = None) -> List[TerminalEvent]:
         if limit is None or limit >= len(self._events):
             return list(self._events)
-        # newest `limit` events, oldest-first
         items = list(self._events)
         return items[-limit:]
 
@@ -77,11 +76,10 @@ class DiagnosticRecorder:
         return len(self._events)
 
     def format(self, limit: Optional[int] = None) -> str:
-        """Human-readable dump for stderr / logs."""
         lines: List[str] = []
         for ev in self.recent(limit):
-            preview = ev.preview.decode("ascii", errors="replace").replace("\x1b", "\\x1b")
+            preview = ev.preview_bytes.decode("ascii", errors="replace").replace("\x1b", "\\x1b")
             lines.append(
-                f"  t={ev.t:.4f} {ev.kind.value:8s} size={ev.size:5d}  {preview!r}  {ev.note}"
+                f"  t={ev.t:.4f} {ev.kind.value:8s} size={ev.full_size:5d}  {preview!r}  {ev.note}"
             )
         return "\n".join(lines)

--- a/src/actor/watch/interactive/diagnostics.py
+++ b/src/actor/watch/interactive/diagnostics.py
@@ -1,0 +1,87 @@
+"""Ring buffer of terminal I/O events for post-mortem of flicker / hangs.
+
+Every layer of the interactive stack can push a TerminalEvent; the ring
+buffer keeps the most recent N events. A hidden binding in the watch app
+dumps them to stderr so we can see exactly what happened when something
+misbehaves in a live session.
+
+Pure: no I/O, no clocks except for a user-injectable `now` callable.
+"""
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Deque, List, Optional
+
+
+class EventKind(str, Enum):
+    READ = "read"            # bytes read from PTY master
+    WRITE = "write"          # bytes written to PTY master
+    REFRESH = "refresh"      # widget re-render fired
+    REFRESH_SKIP = "skip"    # batcher coalesced
+    RESIZE = "resize"        # PTY + screen resize
+    EXIT = "exit"            # child process exited
+    ERROR = "error"          # unexpected condition
+
+
+@dataclass(frozen=True)
+class TerminalEvent:
+    t: float
+    kind: EventKind
+    size: int
+    preview: bytes
+    note: str
+
+
+_PREVIEW_BYTES = 32
+
+
+class DiagnosticRecorder:
+    """Thread-safe-ish ring buffer (CPython list append/deque are atomic)."""
+
+    def __init__(self, capacity: int = 1024, now: Callable[[], float] = time.monotonic) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self._events: Deque[TerminalEvent] = deque(maxlen=capacity)
+        self._now = now
+
+    def record(
+        self,
+        kind: EventKind,
+        data: Optional[bytes] = None,
+        note: str = "",
+    ) -> None:
+        size = len(data) if data is not None else 0
+        preview = b"" if data is None else bytes(data[:_PREVIEW_BYTES])
+        self._events.append(TerminalEvent(
+            t=self._now(),
+            kind=kind,
+            size=size,
+            preview=preview,
+            note=note,
+        ))
+
+    def recent(self, limit: Optional[int] = None) -> List[TerminalEvent]:
+        if limit is None or limit >= len(self._events):
+            return list(self._events)
+        # newest `limit` events, oldest-first
+        items = list(self._events)
+        return items[-limit:]
+
+    def clear(self) -> None:
+        self._events.clear()
+
+    def __len__(self) -> int:
+        return len(self._events)
+
+    def format(self, limit: Optional[int] = None) -> str:
+        """Human-readable dump for stderr / logs."""
+        lines: List[str] = []
+        for ev in self.recent(limit):
+            preview = ev.preview.decode("ascii", errors="replace").replace("\x1b", "\\x1b")
+            lines.append(
+                f"  t={ev.t:.4f} {ev.kind.value:8s} size={ev.size:5d}  {preview!r}  {ev.note}"
+            )
+        return "\n".join(lines)

--- a/src/actor/watch/interactive/input.py
+++ b/src/actor/watch/interactive/input.py
@@ -1,0 +1,194 @@
+"""Key + mouse event -> byte sequence translator.
+
+Pure. Takes abstracted events (Textual-friendly but not Textual-bound) and
+produces the ANSI bytes to write into the PTY master fd.
+
+References:
+- xterm control sequences: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+- DECCKM (application cursor keys) flips arrow sequences between CSI A/B/C/D
+  (\x1b[A …) and SS3 A/B/C/D (\x1bOA …).
+- Mouse reporting modes (DECSET 1000 / 1002 / 1003) and SGR (1006) for
+  extended coordinates. We only support click-tracking (1000) + SGR (1006)
+  in v1, which covers claude-code's cursor mode usage.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional
+
+
+# --- Keymap --------------------------------------------------------------
+
+# CSI- vs SS3-prefixed cursor/nav keys. When app_cursor is True, the PTY
+# is in DECCKM app-cursor mode and wants SS3 (\x1bO…) for arrows/home/end.
+_CSI: Dict[str, str] = {
+    "up":        "\x1b[A",
+    "down":      "\x1b[B",
+    "right":     "\x1b[C",
+    "left":      "\x1b[D",
+    "home":      "\x1b[H",
+    "end":       "\x1b[F",
+}
+
+_SS3: Dict[str, str] = {
+    "up":        "\x1bOA",
+    "down":      "\x1bOB",
+    "right":     "\x1bOC",
+    "left":      "\x1bOD",
+    "home":      "\x1bOH",
+    "end":       "\x1bOF",
+}
+
+# Common fixed keys (no app-cursor variant).
+_FIXED: Dict[str, str] = {
+    "enter":      "\r",
+    "tab":        "\t",
+    "shift+tab":  "\x1b[Z",
+    "escape":     "\x1b",
+    "backspace":  "\x7f",
+    "delete":     "\x1b[3~",
+    "insert":     "\x1b[2~",
+    "pageup":     "\x1b[5~",
+    "pagedown":   "\x1b[6~",
+    "f1":         "\x1bOP",
+    "f2":         "\x1bOQ",
+    "f3":         "\x1bOR",
+    "f4":         "\x1bOS",
+    "f5":         "\x1b[15~",
+    "f6":         "\x1b[17~",
+    "f7":         "\x1b[18~",
+    "f8":         "\x1b[19~",
+    "f9":         "\x1b[20~",
+    "f10":        "\x1b[21~",
+    "f11":        "\x1b[23~",
+    "f12":        "\x1b[24~",
+}
+
+
+def key_to_bytes(
+    key: str,
+    character: Optional[str] = None,
+    *,
+    app_cursor: bool = False,
+) -> Optional[bytes]:
+    """Translate a key press to PTY bytes.
+
+    `key` is a normalized name like "up", "ctrl+c", "tab". Modifier prefixes
+    supported: "ctrl+", "alt+". `character` is the printable glyph if any
+    (caller owns unicode normalization). `app_cursor` enables DECCKM SS3
+    for arrow/home/end.
+
+    Returns None for keys we don't want to forward (caller can ignore them).
+    """
+    # Fixed mappings first.
+    if key in _FIXED:
+        return _FIXED[key].encode()
+
+    # Arrows / home / end — app_cursor switches prefix.
+    table = _SS3 if app_cursor else _CSI
+    if key in table:
+        return table[key].encode()
+
+    # Ctrl+<letter> and a few common ctrl combos.
+    if key.startswith("ctrl+") and len(key) == 6:
+        letter = key[5].lower()
+        if "a" <= letter <= "z":
+            return bytes([ord(letter) - ord("a") + 1])
+        if letter == " " or letter == "@":
+            return b"\x00"
+        if letter == "[":
+            return b"\x1b"
+        if letter == "\\":
+            return b"\x1c"
+        if letter == "]":
+            return b"\x1d"
+        if letter == "^":
+            return b"\x1e"
+        if letter == "_":
+            return b"\x1f"
+
+    # Alt+<letter> = ESC <letter>.
+    if key.startswith("alt+") and len(key) == 5:
+        return b"\x1b" + key[4].encode()
+
+    # Printable character — always forward.
+    if character is not None:
+        try:
+            return character.encode("utf-8")
+        except UnicodeEncodeError:
+            return None
+
+    return None
+
+
+# --- Mouse ---------------------------------------------------------------
+
+class MouseButton(Enum):
+    LEFT = 0
+    MIDDLE = 1
+    RIGHT = 2
+    RELEASE = 3    # plain x11 "release" (button=3 in legacy protocol)
+    WHEEL_UP = 64
+    WHEEL_DOWN = 65
+
+
+@dataclass
+class MouseMode:
+    """Flags mirroring DECSET modes the child has enabled."""
+    # DECSET 1000 — report clicks
+    tracking: bool = False
+    # DECSET 1002 — also report drags (button-event tracking)
+    drag: bool = False
+    # DECSET 1003 — report all motion
+    any_motion: bool = False
+    # DECSET 1006 — SGR extended coords (recommended; unlocks large terminals)
+    sgr: bool = False
+
+    def should_report_click(self) -> bool:
+        return self.tracking or self.drag or self.any_motion
+
+
+def mouse_press_to_bytes(
+    button: MouseButton,
+    x: int, y: int,
+    mode: MouseMode,
+) -> Optional[bytes]:
+    """Encode a mouse press/wheel event.
+
+    `x` and `y` are 0-based cell coordinates within the terminal. We emit
+    1-based coordinates per xterm protocol.
+    Returns None if the child hasn't enabled any mouse tracking.
+    """
+    if not mode.should_report_click():
+        # Wheel events are useful even without click tracking (many TUIs
+        # interpret them as scroll); xterm still requires tracking to be on.
+        return None
+
+    cb = button.value
+    cx = x + 1
+    cy = y + 1
+    if mode.sgr:
+        return f"\x1b[<{cb};{cx};{cy}M".encode()
+    # Legacy X10: CSI M Cb Cx Cy with all values offset by 32.
+    # Clamp to the legacy protocol's 223-cell limit.
+    cb_b = 32 + cb
+    cx_b = 32 + min(cx, 223)
+    cy_b = 32 + min(cy, 223)
+    return bytes([0x1b, ord("["), ord("M"), cb_b, cx_b, cy_b])
+
+
+def mouse_release_to_bytes(
+    x: int, y: int,
+    mode: MouseMode,
+) -> Optional[bytes]:
+    """Encode a mouse release. SGR terminates with lowercase m; legacy
+    protocol always sends button=3 (RELEASE)."""
+    if not mode.should_report_click():
+        return None
+    cx = x + 1
+    cy = y + 1
+    if mode.sgr:
+        # Caller may want to specify the released button; v1 uses 0 (left).
+        return f"\x1b[<0;{cx};{cy}m".encode()
+    return bytes([0x1b, ord("["), ord("M"), 32 + 3, 32 + min(cx, 223), 32 + min(cy, 223)])

--- a/src/actor/watch/interactive/input.py
+++ b/src/actor/watch/interactive/input.py
@@ -125,17 +125,24 @@ def key_to_bytes(
 # --- Mouse ---------------------------------------------------------------
 
 class MouseButton(Enum):
+    """Button identity. Release is an event phase, not a button — see
+    MouseEventKind. WHEEL_UP / WHEEL_DOWN use xterm's pseudo-button 64/65."""
     LEFT = 0
     MIDDLE = 1
     RIGHT = 2
-    RELEASE = 3    # plain x11 "release" (button=3 in legacy protocol)
     WHEEL_UP = 64
     WHEEL_DOWN = 65
 
 
-@dataclass
+class MouseEventKind(Enum):
+    PRESS = "press"
+    RELEASE = "release"
+
+
+@dataclass(frozen=True)
 class MouseMode:
-    """Flags mirroring DECSET modes the child has enabled."""
+    """Flags mirroring DECSET modes the child has enabled. Immutable so
+    screen.py can safely share an instance with renderers."""
     # DECSET 1000 — report clicks
     tracking: bool = False
     # DECSET 1002 — also report drags (button-event tracking)
@@ -154,7 +161,7 @@ def mouse_press_to_bytes(
     x: int, y: int,
     mode: MouseMode,
 ) -> Optional[bytes]:
-    """Encode a mouse press/wheel event.
+    """Encode a mouse press or wheel event.
 
     `x` and `y` are 0-based cell coordinates within the terminal. We emit
     1-based coordinates per xterm protocol.
@@ -181,14 +188,15 @@ def mouse_press_to_bytes(
 def mouse_release_to_bytes(
     x: int, y: int,
     mode: MouseMode,
+    button: MouseButton = MouseButton.LEFT,
 ) -> Optional[bytes]:
     """Encode a mouse release. SGR terminates with lowercase m; legacy
-    protocol always sends button=3 (RELEASE)."""
+    protocol uses the single "release" button code (3) regardless of which
+    button was released."""
     if not mode.should_report_click():
         return None
     cx = x + 1
     cy = y + 1
     if mode.sgr:
-        # Caller may want to specify the released button; v1 uses 0 (left).
-        return f"\x1b[<0;{cx};{cy}m".encode()
+        return f"\x1b[<{button.value};{cx};{cy}m".encode()
     return bytes([0x1b, ord("["), ord("M"), 32 + 3, 32 + min(cx, 223), 32 + min(cy, 223)])

--- a/src/actor/watch/interactive/input.py
+++ b/src/actor/watch/interactive/input.py
@@ -1,15 +1,7 @@
 """Key + mouse event -> byte sequence translator.
 
-Pure. Takes abstracted events (Textual-friendly but not Textual-bound) and
-produces the ANSI bytes to write into the PTY master fd.
-
-References:
-- xterm control sequences: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
-- DECCKM (application cursor keys) flips arrow sequences between CSI A/B/C/D
-  (\x1b[A …) and SS3 A/B/C/D (\x1bOA …).
-- Mouse reporting modes (DECSET 1000 / 1002 / 1003) and SGR (1006) for
-  extended coordinates. We only support click-tracking (1000) + SGR (1006)
-  in v1, which covers claude-code's cursor mode usage.
+Reference: xterm control sequences at
+https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 """
 from __future__ import annotations
 
@@ -18,10 +10,8 @@ from enum import Enum
 from typing import Dict, Optional
 
 
-# --- Keymap --------------------------------------------------------------
-
-# CSI- vs SS3-prefixed cursor/nav keys. When app_cursor is True, the PTY
-# is in DECCKM app-cursor mode and wants SS3 (\x1bO…) for arrows/home/end.
+# DECCKM (param 1) flips arrow/nav keys between CSI (\x1b[A …) and
+# SS3 (\x1bOA …). The child advertises its preference via DECSET.
 _CSI: Dict[str, str] = {
     "up":        "\x1b[A",
     "down":      "\x1b[B",
@@ -141,15 +131,11 @@ class MouseEventKind(Enum):
 
 @dataclass(frozen=True)
 class MouseMode:
-    """Flags mirroring DECSET modes the child has enabled. Immutable so
-    screen.py can safely share an instance with renderers."""
-    # DECSET 1000 — report clicks
+    """DECSET mouse-reporting modes the child has enabled.
+    tracking=1000, drag=1002, any_motion=1003, sgr=1006."""
     tracking: bool = False
-    # DECSET 1002 — also report drags (button-event tracking)
     drag: bool = False
-    # DECSET 1003 — report all motion
     any_motion: bool = False
-    # DECSET 1006 — SGR extended coords (recommended; unlocks large terminals)
     sgr: bool = False
 
     def should_report_click(self) -> bool:
@@ -161,15 +147,10 @@ def mouse_press_to_bytes(
     x: int, y: int,
     mode: MouseMode,
 ) -> Optional[bytes]:
-    """Encode a mouse press or wheel event.
-
-    `x` and `y` are 0-based cell coordinates within the terminal. We emit
-    1-based coordinates per xterm protocol.
-    Returns None if the child hasn't enabled any mouse tracking.
-    """
+    """Encode a mouse press or wheel event. 0-based cell coords in;
+    1-based xterm-protocol coords out. None if tracking is off."""
     if not mode.should_report_click():
-        # Wheel events are useful even without click tracking (many TUIs
-        # interpret them as scroll); xterm still requires tracking to be on.
+        # Wheel/scroll events require tracking to be on per xterm protocol.
         return None
 
     cb = button.value
@@ -190,9 +171,8 @@ def mouse_release_to_bytes(
     mode: MouseMode,
     button: MouseButton = MouseButton.LEFT,
 ) -> Optional[bytes]:
-    """Encode a mouse release. SGR terminates with lowercase m; legacy
-    protocol uses the single "release" button code (3) regardless of which
-    button was released."""
+    """SGR mode distinguishes the released button (lowercase m terminator).
+    Legacy X10 emits a single "release" code (3) regardless of button."""
     if not mode.should_report_click():
         return None
     cx = x + 1

--- a/src/actor/watch/interactive/manager.py
+++ b/src/actor/watch/interactive/manager.py
@@ -9,7 +9,7 @@ Run row; on session exit, updates it to DONE/ERROR/STOPPED.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
@@ -17,13 +17,13 @@ from ...commands import INTERACTIVE_PROMPT
 from ...db import Database
 from ...interfaces import Agent
 from ...types import Run, Status, _now_iso
-from .diagnostics import DiagnosticRecorder
+from .diagnostics import DiagnosticRecorder, EventKind
 from .pty_session import PtySession
 from .screen import TerminalScreen
 from .widget import TerminalWidget
 
 
-@dataclass
+@dataclass(frozen=True)
 class InteractiveSession:
     actor_name: str
     session: PtySession
@@ -47,6 +47,9 @@ class InteractiveSessionManager:
         self._db_opener = db_opener
         self._sessions: Dict[str, InteractiveSession] = {}
         self._recorder = recorder
+        # Sessions closed explicitly via close()/close_all() should be
+        # marked STOPPED rather than DONE/ERROR on finalize.
+        self._stopping: set[str] = set()
 
     # -- queries ----------------------------------------------------------
 
@@ -83,6 +86,7 @@ class InteractiveSessionManager:
             cwd=cwd,
             rows=self.DEFAULT_ROWS,
             cols=self.DEFAULT_COLS,
+            recorder=self._recorder,
         )
         screen = TerminalScreen(rows=self.DEFAULT_ROWS, cols=self.DEFAULT_COLS)
         widget = TerminalWidget(pty_session, screen, recorder=self._recorder)
@@ -98,28 +102,42 @@ class InteractiveSessionManager:
         )
         self._sessions[actor_name] = info
 
-        # Side-channel: when the child exits naturally, close + update DB.
-        def _on_exit(code: int) -> None:
-            self._finalize_run(actor_name, info.run_id, code)
-        widget._session._on_exit = _on_exit  # type: ignore[attr-defined]
+        # Chain on_exit: preserve the widget's handler (which posts the
+        # SessionExited message for UI recovery) AND add DB finalization.
+        widget_on_exit = pty_session._on_exit  # set by widget constructor
+
+        def _chained_on_exit(code: int) -> None:
+            try:
+                self._finalize_run(actor_name, info.run_id, code)
+            finally:
+                if widget_on_exit is not None:
+                    widget_on_exit(code)
+        pty_session.set_callbacks(on_exit=_chained_on_exit)
 
         pty_session.spawn()
         return info
 
     def close(self, actor_name: str) -> None:
-        """Kill the session (if running) and remove it from the registry."""
+        """Kill the session (if running) and remove it from the registry.
+        The run is finalized as STOPPED (app-initiated teardown)."""
         info = self._sessions.pop(actor_name, None)
         if info is None:
             return
-        info.session.close()
-        # _on_exit will have fired via close() -> _handle_exit().
-        # If for some reason it didn't (race), make sure the DB row doesn't
-        # stay RUNNING forever.
+        self._stopping.add(actor_name)
+        try:
+            info.session.close()
+        finally:
+            self._stopping.discard(actor_name)
+        # Belt-and-suspenders: if the on_exit chain didn't run for any
+        # reason, _finalize_run is idempotent on already-done rows.
         self._finalize_run(actor_name, info.run_id, info.session.exit_code or -1)
 
     def close_all(self) -> None:
         for name in list(self._sessions.keys()):
-            self.close(name)
+            try:
+                self.close(name)
+            except Exception as e:
+                self._record_error(f"close_all({name!r}): {e!r}")
 
     # -- DB integration ----------------------------------------------------
 
@@ -141,15 +159,24 @@ class InteractiveSessionManager:
             return run_id
 
     def _finalize_run(self, actor_name: str, run_id: int, exit_code: int) -> None:
-        with self._db_opener() as db:
-            current = db.get_run(run_id)
-            if current is None:
-                return
-            # Don't overwrite a STOPPED status set externally.
-            if current.status == Status.STOPPED:
-                return
-            # Don't double-finalize if already done.
-            if current.status in (Status.DONE, Status.ERROR):
-                return
-            final = Status.DONE if exit_code == 0 else Status.ERROR
-            db.update_run_status(run_id, final, exit_code)
+        try:
+            with self._db_opener() as db:
+                current = db.get_run(run_id)
+                if current is None:
+                    return
+                # Already finalized — don't overwrite.
+                if current.status in (Status.DONE, Status.ERROR, Status.STOPPED):
+                    return
+                if actor_name in self._stopping:
+                    final = Status.STOPPED
+                else:
+                    final = Status.DONE if exit_code == 0 else Status.ERROR
+                db.update_run_status(run_id, final, exit_code)
+        except Exception as e:
+            # DB errors at shutdown shouldn't crash the TUI; surface via
+            # the diagnostics recorder so the user can still extract info.
+            self._record_error(f"finalize_run({actor_name!r}, {run_id}): {e!r}")
+
+    def _record_error(self, note: str) -> None:
+        if self._recorder is not None:
+            self._recorder.record(EventKind.ERROR, note=note)

--- a/src/actor/watch/interactive/manager.py
+++ b/src/actor/watch/interactive/manager.py
@@ -117,9 +117,16 @@ class InteractiveSessionManager:
         pty_session.spawn()
         # Record the pid so resolve_actor_status can see the child is alive;
         # without this the Run is classified ERROR by the liveness probe.
+        # The session is already live at this point — a DB hiccup here
+        # shouldn't kill the spawn, so we record and move on.
         if pty_session.pid is not None:
-            with self._db_opener() as db:
-                db.update_run_pid(run_id, pty_session.pid)
+            try:
+                with self._db_opener() as db:
+                    db.update_run_pid(run_id, pty_session.pid)
+            except Exception as e:
+                self._record_error(
+                    f"create({actor_name!r}) update_run_pid failed: {e!r}",
+                )
         return info
 
     def close(self, actor_name: str) -> None:

--- a/src/actor/watch/interactive/manager.py
+++ b/src/actor/watch/interactive/manager.py
@@ -127,9 +127,15 @@ class InteractiveSessionManager:
         try:
             info.session.close()
         finally:
-            self._stopping.discard(actor_name)
-        # In case the on_exit chain didn't fire — _finalize_run is idempotent.
-        self._finalize_run(actor_name, info.run_id, info.session.exit_code or -1)
+            # Always finalize the run, even if session.close() raises
+            # (incl. KeyboardInterrupt during the close poll). Otherwise
+            # the DB row would stay RUNNING forever.
+            try:
+                self._finalize_run(
+                    actor_name, info.run_id, info.session.exit_code or -1,
+                )
+            finally:
+                self._stopping.discard(actor_name)
 
     def close_all(self) -> None:
         for name in list(self._sessions.keys()):

--- a/src/actor/watch/interactive/manager.py
+++ b/src/actor/watch/interactive/manager.py
@@ -1,0 +1,155 @@
+"""Per-actor PtySession + TerminalWidget registry.
+
+The watch app owns one InteractiveSessionManager. It tracks live sessions
+keyed by actor name, hands out widgets for the selected actor, and kills
+everything on app shutdown.
+
+Also integrates with the Database: on create, inserts an *interactive*
+Run row; on session exit, updates it to DONE/ERROR/STOPPED.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+from ...commands import INTERACTIVE_PROMPT
+from ...db import Database
+from ...interfaces import Agent
+from ...types import Run, Status, _now_iso
+from .diagnostics import DiagnosticRecorder
+from .pty_session import PtySession
+from .screen import TerminalScreen
+from .widget import TerminalWidget
+
+
+@dataclass
+class InteractiveSession:
+    actor_name: str
+    session: PtySession
+    screen: TerminalScreen
+    widget: TerminalWidget
+    run_id: int
+
+
+class InteractiveSessionManager:
+    """Owns live interactive sessions for the watch app."""
+
+    DEFAULT_ROWS = 24
+    DEFAULT_COLS = 80
+
+    def __init__(
+        self,
+        db_opener: Callable[[], Database],
+        *,
+        recorder: Optional[DiagnosticRecorder] = None,
+    ) -> None:
+        self._db_opener = db_opener
+        self._sessions: Dict[str, InteractiveSession] = {}
+        self._recorder = recorder
+
+    # -- queries ----------------------------------------------------------
+
+    def get(self, actor_name: str) -> Optional[InteractiveSession]:
+        return self._sessions.get(actor_name)
+
+    def has(self, actor_name: str) -> bool:
+        return actor_name in self._sessions
+
+    def live_names(self) -> List[str]:
+        return list(self._sessions.keys())
+
+    # -- lifecycle --------------------------------------------------------
+
+    def create(
+        self,
+        actor_name: str,
+        agent: Agent,
+        session_id: str,
+        cwd: Path,
+        config: dict,
+    ) -> InteractiveSession:
+        """Spawn a new interactive session for the given actor.
+
+        Raises if one is already live for this actor (caller should close
+        first, or call `get()` to reuse).
+        """
+        if actor_name in self._sessions:
+            raise RuntimeError(f"interactive session already exists for {actor_name!r}")
+
+        argv = agent.interactive_argv(session_id, config)
+        pty_session = PtySession(
+            argv=argv,
+            cwd=cwd,
+            rows=self.DEFAULT_ROWS,
+            cols=self.DEFAULT_COLS,
+        )
+        screen = TerminalScreen(rows=self.DEFAULT_ROWS, cols=self.DEFAULT_COLS)
+        widget = TerminalWidget(pty_session, screen, recorder=self._recorder)
+
+        run_id = self._insert_run(actor_name, config)
+
+        info = InteractiveSession(
+            actor_name=actor_name,
+            session=pty_session,
+            screen=screen,
+            widget=widget,
+            run_id=run_id,
+        )
+        self._sessions[actor_name] = info
+
+        # Side-channel: when the child exits naturally, close + update DB.
+        def _on_exit(code: int) -> None:
+            self._finalize_run(actor_name, info.run_id, code)
+        widget._session._on_exit = _on_exit  # type: ignore[attr-defined]
+
+        pty_session.spawn()
+        return info
+
+    def close(self, actor_name: str) -> None:
+        """Kill the session (if running) and remove it from the registry."""
+        info = self._sessions.pop(actor_name, None)
+        if info is None:
+            return
+        info.session.close()
+        # _on_exit will have fired via close() -> _handle_exit().
+        # If for some reason it didn't (race), make sure the DB row doesn't
+        # stay RUNNING forever.
+        self._finalize_run(actor_name, info.run_id, info.session.exit_code or -1)
+
+    def close_all(self) -> None:
+        for name in list(self._sessions.keys()):
+            self.close(name)
+
+    # -- DB integration ----------------------------------------------------
+
+    def _insert_run(self, actor_name: str, config: dict) -> int:
+        with self._db_opener() as db:
+            run = Run(
+                id=0,
+                actor_name=actor_name,
+                prompt=INTERACTIVE_PROMPT,
+                status=Status.RUNNING,
+                exit_code=None,
+                pid=None,
+                config=dict(config),
+                started_at=_now_iso(),
+                finished_at=None,
+            )
+            run_id = db.insert_run(run)
+            db.touch_actor(actor_name)
+            return run_id
+
+    def _finalize_run(self, actor_name: str, run_id: int, exit_code: int) -> None:
+        with self._db_opener() as db:
+            current = db.get_run(run_id)
+            if current is None:
+                return
+            # Don't overwrite a STOPPED status set externally.
+            if current.status == Status.STOPPED:
+                return
+            # Don't double-finalize if already done.
+            if current.status in (Status.DONE, Status.ERROR):
+                return
+            final = Status.DONE if exit_code == 0 else Status.ERROR
+            db.update_run_status(run_id, final, exit_code)

--- a/src/actor/watch/interactive/manager.py
+++ b/src/actor/watch/interactive/manager.py
@@ -164,6 +164,8 @@ class InteractiveSessionManager:
             return run_id
 
     def _finalize_run(self, actor_name: str, run_id: int, exit_code: int) -> None:
+        """Idempotent, never raises. Errors are routed to the diagnostic
+        recorder so the nested-finally in `close()` can rely on it."""
         try:
             with self._db_opener() as db:
                 current = db.get_run(run_id)

--- a/src/actor/watch/interactive/manager.py
+++ b/src/actor/watch/interactive/manager.py
@@ -118,8 +118,8 @@ class InteractiveSessionManager:
         return info
 
     def close(self, actor_name: str) -> None:
-        """Kill the session (if running) and remove it from the registry.
-        The run is finalized as STOPPED (app-initiated teardown)."""
+        """App-initiated teardown. Run is marked STOPPED (not ERROR) so
+        the status distinguishes `quit watch` from the child exiting."""
         info = self._sessions.pop(actor_name, None)
         if info is None:
             return
@@ -128,8 +128,7 @@ class InteractiveSessionManager:
             info.session.close()
         finally:
             self._stopping.discard(actor_name)
-        # Belt-and-suspenders: if the on_exit chain didn't run for any
-        # reason, _finalize_run is idempotent on already-done rows.
+        # In case the on_exit chain didn't fire — _finalize_run is idempotent.
         self._finalize_run(actor_name, info.run_id, info.session.exit_code or -1)
 
     def close_all(self) -> None:
@@ -164,7 +163,6 @@ class InteractiveSessionManager:
                 current = db.get_run(run_id)
                 if current is None:
                     return
-                # Already finalized — don't overwrite.
                 if current.status in (Status.DONE, Status.ERROR, Status.STOPPED):
                     return
                 if actor_name in self._stopping:
@@ -173,8 +171,7 @@ class InteractiveSessionManager:
                     final = Status.DONE if exit_code == 0 else Status.ERROR
                 db.update_run_status(run_id, final, exit_code)
         except Exception as e:
-            # DB errors at shutdown shouldn't crash the TUI; surface via
-            # the diagnostics recorder so the user can still extract info.
+            # DB errors at shutdown shouldn't crash the TUI.
             self._record_error(f"finalize_run({actor_name!r}, {run_id}): {e!r}")
 
     def _record_error(self, note: str) -> None:

--- a/src/actor/watch/interactive/manager.py
+++ b/src/actor/watch/interactive/manager.py
@@ -115,6 +115,11 @@ class InteractiveSessionManager:
         pty_session.set_callbacks(on_exit=_chained_on_exit)
 
         pty_session.spawn()
+        # Record the pid so resolve_actor_status can see the child is alive;
+        # without this the Run is classified ERROR by the liveness probe.
+        if pty_session.pid is not None:
+            with self._db_opener() as db:
+                db.update_run_pid(run_id, pty_session.pid)
         return info
 
     def close(self, actor_name: str) -> None:
@@ -143,6 +148,30 @@ class InteractiveSessionManager:
                 self.close(name)
             except Exception as e:
                 self._record_error(f"close_all({name!r}): {e!r}")
+
+    def shutdown(self) -> None:
+        """Non-blocking variant for Textual app teardown. SIGKILLs every
+        live session, finalizes each Run as STOPPED, returns fast. Any
+        child that doesn't reap inside the WNOHANG window is left as a
+        transient zombie and the OS cleans up when actor-sh exits."""
+        for name in list(self._sessions.keys()):
+            info = self._sessions.pop(name, None)
+            if info is None:
+                continue
+            self._stopping.add(name)
+            try:
+                try:
+                    info.session.shutdown_kill()
+                except Exception as e:
+                    self._record_error(f"shutdown({name!r}): {e!r}")
+                try:
+                    self._finalize_run(
+                        name, info.run_id, info.session.exit_code or -1,
+                    )
+                except Exception as e:
+                    self._record_error(f"shutdown finalize({name!r}): {e!r}")
+            finally:
+                self._stopping.discard(name)
 
     # -- DB integration ----------------------------------------------------
 

--- a/src/actor/watch/interactive/pty_session.py
+++ b/src/actor/watch/interactive/pty_session.py
@@ -175,7 +175,7 @@ class PtySession:
             deadline = time.monotonic() + _TERM_DEADLINE_S
             while time.monotonic() < deadline:
                 try:
-                    os.kill(self._pid, 0)  # probe only
+                    os.kill(self._pid, 0)
                 except ProcessLookupError:
                     break
                 time.sleep(_TERM_POLL_S)
@@ -188,6 +188,56 @@ class PtySession:
 
     def kill(self) -> None:
         self.close(signal.SIGKILL)
+
+    def shutdown_kill(self) -> None:
+        """Non-blocking shutdown variant for use inside Textual's on_unmount.
+
+        Sends SIGKILL immediately, does a single WNOHANG waitpid, and
+        returns — never spin-waits and never calls blocking waitpid. Leaves
+        any straggler as a zombie (the OS will reap it when actor-sh exits).
+
+        `close()` blocks the asyncio loop long enough to guarantee a clean
+        reap; that's wrong during app teardown because the event loop is
+        itself being torn down and Ctrl+C lands inside our wait.
+        """
+        if self._exit_fired:
+            return
+        if self._pid is not None:
+            try:
+                os.kill(self._pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        self._exit_fired = True
+        if self._fd is not None and self._loop is not None:
+            try:
+                self._loop.remove_reader(self._fd)
+            except (ValueError, KeyError) as e:
+                self._record_error(f"shutdown remove_reader: {e!r}")
+            self._unregister_writer()
+        if self._pid is not None:
+            try:
+                pid, status = os.waitpid(self._pid, os.WNOHANG)
+            except ChildProcessError:
+                pid, status = -1, 0
+            if pid == 0:
+                # Still alive; don't block. Accept a transient zombie.
+                self._exit_code = -int(signal.SIGKILL)
+                self._record_error(
+                    f"shutdown_kill: pid {self._pid} not reaped — left as zombie",
+                )
+            elif os.WIFEXITED(status):
+                self._exit_code = os.WEXITSTATUS(status)
+            elif os.WIFSIGNALED(status):
+                self._exit_code = -os.WTERMSIG(status)
+            else:
+                self._exit_code = -1
+            self._pid = None
+        self._close_fd()
+        if self._on_exit is not None and self._exit_code is not None:
+            try:
+                self._on_exit(self._exit_code)
+            except Exception as e:
+                self._record_error(f"shutdown on_exit raised: {e!r}")
 
     # -- properties --------------------------------------------------------
 

--- a/src/actor/watch/interactive/pty_session.py
+++ b/src/actor/watch/interactive/pty_session.py
@@ -19,13 +19,18 @@ import pty
 import signal
 import struct
 import termios
+import time
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
+from .diagnostics import DiagnosticRecorder, EventKind
 
-# Observed "best" chunk size that keeps latency low without overwhelming
-# the parser. 64 KiB matches cmdlane; keeps us aligned with how OS delivers.
+
+# 64 KiB chunk keeps latency low without overwhelming the parser.
 _READ_CHUNK = 65536
+# Poll interval when waitpid needs to escalate from SIGTERM to SIGKILL.
+_TERM_POLL_S = 0.05
+_TERM_DEADLINE_S = 0.5
 
 
 class PtySession:
@@ -40,6 +45,7 @@ class PtySession:
         cols: int = 80,
         on_output: Optional[Callable[[bytes], None]] = None,
         on_exit: Optional[Callable[[int], None]] = None,
+        recorder: Optional[DiagnosticRecorder] = None,
     ) -> None:
         if not argv:
             raise ValueError("argv must be non-empty")
@@ -50,35 +56,52 @@ class PtySession:
         self._cols = cols
         self._on_output = on_output
         self._on_exit = on_exit
+        self._recorder = recorder
         self._pid: Optional[int] = None
         self._fd: Optional[int] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._exit_code: Optional[int] = None
         self._exit_fired = False
+        # Pending writes held back by EAGAIN, drained via add_writer.
+        self._write_queue: bytearray = bytearray()
+        self._writer_registered = False
+
+    def set_callbacks(
+        self,
+        *,
+        on_output: Optional[Callable[[bytes], None]] = None,
+        on_exit: Optional[Callable[[int], None]] = None,
+    ) -> None:
+        """Swap callbacks. Used by widget + manager to chain handlers.
+        Pass only the fields you want to replace — omitted args stay."""
+        if on_output is not None:
+            self._on_output = on_output
+        if on_exit is not None:
+            self._on_exit = on_exit
 
     # -- lifecycle ---------------------------------------------------------
 
     def spawn(self) -> None:
-        """Fork + exec the child. Must be called from an async context so
-        the running loop can be used as the read-loop driver."""
         if self._pid is not None:
             raise RuntimeError("already spawned")
 
         pid, fd = pty.fork()
         if pid == 0:
-            # Child: replace process image.
+            # In the child, fds 0/1/2 are already the pty slave after pty.fork.
             try:
-                _set_winsize(0, self._rows, self._cols)  # 0 = our stdin, now the slave
-                if self._env is None:
-                    env = dict(os.environ)
-                else:
-                    env = dict(self._env)
-                # Ensure the child sees a sane TERM — claude uses it for color.
+                _set_winsize(0, self._rows, self._cols)
+                env = dict(os.environ) if self._env is None else dict(self._env)
                 env.setdefault("TERM", "xterm-256color")
                 os.chdir(str(self._cwd))
                 os.execvpe(self._argv[0], self._argv, env)
-            except BaseException:
-                # If exec fails, don't come back into asyncio-land.
+            except BaseException as e:
+                # Can't raise back out of the forked child — its parent
+                # already forked away. Surface an exec-failure hint on
+                # stderr so the user sees "exit 127" with a reason.
+                try:
+                    os.write(2, f"actor: exec failed: {e}\n".encode())
+                except Exception:
+                    pass
                 os._exit(127)
 
         self._pid = pid
@@ -92,31 +115,56 @@ class PtySession:
     # -- I/O ---------------------------------------------------------------
 
     def write(self, data: bytes) -> None:
-        """Write input bytes to the child. Silently no-ops if the session
-        has already exited (caller can check `.exited` if they care)."""
-        if self._fd is None:
+        """Write input bytes to the child. No-ops after the PTY master is
+        closed. Queues + backs off on EAGAIN (full PTY buffer)."""
+        if self._fd is None or not data:
+            return
+        # If we already have pending bytes, append — the writer-drainer
+        # will flush everything in order.
+        if self._write_queue:
+            self._write_queue.extend(data)
+            self._ensure_writer()
             return
         try:
-            os.write(self._fd, data)
+            written = os.write(self._fd, data)
         except OSError as e:
             if e.errno in (errno.EBADF, errno.EIO):
                 self._handle_exit()
                 return
+            if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                self._write_queue.extend(data)
+                self._ensure_writer()
+                return
+            self._record_error(f"write errno {e.errno}: {e}")
             raise
+        if written < len(data):
+            self._write_queue.extend(data[written:])
+            self._ensure_writer()
 
     def resize(self, rows: int, cols: int) -> None:
         if rows <= 0 or cols <= 0:
             return
         self._rows = rows
         self._cols = cols
-        if self._fd is not None:
-            try:
-                _set_winsize(self._fd, rows, cols)
-            except OSError:
-                pass
+        if self._fd is None:
+            return
+        try:
+            _set_winsize(self._fd, rows, cols)
+        except OSError as e:
+            # ENOTTY / EBADF mean the fd is no longer a pty (child exited
+            # mid-resize). Record and proceed with exit handling.
+            self._record_error(f"resize ioctl errno {e.errno}: {e}")
+            if e.errno in (errno.EBADF, errno.ENOTTY):
+                self._handle_exit()
 
     def close(self, signal_no: int = signal.SIGTERM) -> None:
-        """Kill + reap the child. Idempotent. Fires on_exit exactly once."""
+        """Signal + reap the child. Escalates to SIGKILL if the child ignores
+        signal_no. Idempotent. Fires on_exit exactly once.
+
+        Uses os.kill(pid, 0) to probe liveness rather than WNOHANG waitpid
+        so we don't reap here — reaping happens in a single place (_reap)
+        so exit-status translation lives in one place.
+        """
         if self._pid is None and self._exit_fired:
             return
         if self._pid is not None:
@@ -124,10 +172,21 @@ class PtySession:
                 os.kill(self._pid, signal_no)
             except ProcessLookupError:
                 pass
+            deadline = time.monotonic() + _TERM_DEADLINE_S
+            while time.monotonic() < deadline:
+                try:
+                    os.kill(self._pid, 0)  # probe only
+                except ProcessLookupError:
+                    break
+                time.sleep(_TERM_POLL_S)
+            else:
+                try:
+                    os.kill(self._pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
         self._handle_exit()
 
     def kill(self) -> None:
-        """Unconditionally SIGKILL the child."""
         self.close(signal.SIGKILL)
 
     # -- properties --------------------------------------------------------
@@ -162,12 +221,51 @@ class PtySession:
                 return
             if e.errno == errno.EAGAIN:
                 return
+            self._record_error(f"read errno {e.errno}: {e}")
             raise
         if not data:
             self._handle_exit()
             return
         if self._on_output is not None:
-            self._on_output(data)
+            try:
+                self._on_output(data)
+            except Exception as e:  # pragma: no cover — defensive
+                self._record_error(f"on_output raised: {e!r}")
+
+    def _ensure_writer(self) -> None:
+        if self._writer_registered or self._fd is None or self._loop is None:
+            return
+        self._loop.add_writer(self._fd, self._drain_writer)
+        self._writer_registered = True
+
+    def _drain_writer(self) -> None:
+        if self._fd is None or not self._write_queue:
+            self._unregister_writer()
+            return
+        try:
+            written = os.write(self._fd, bytes(self._write_queue))
+        except OSError as e:
+            if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                return
+            if e.errno in (errno.EBADF, errno.EIO):
+                self._unregister_writer()
+                self._handle_exit()
+                return
+            self._record_error(f"drain errno {e.errno}: {e}")
+            self._unregister_writer()
+            return
+        del self._write_queue[:written]
+        if not self._write_queue:
+            self._unregister_writer()
+
+    def _unregister_writer(self) -> None:
+        if not self._writer_registered or self._fd is None or self._loop is None:
+            return
+        try:
+            self._loop.remove_writer(self._fd)
+        except (ValueError, KeyError) as e:
+            self._record_error(f"remove_writer: {e!r}")
+        self._writer_registered = False
 
     def _handle_exit(self) -> None:
         if self._exit_fired:
@@ -176,26 +274,31 @@ class PtySession:
         if self._fd is not None and self._loop is not None:
             try:
                 self._loop.remove_reader(self._fd)
-            except (ValueError, KeyError):
-                pass
+            except (ValueError, KeyError) as e:
+                self._record_error(f"remove_reader: {e!r}")
+            self._unregister_writer()
         self._reap()
         if self._on_exit is not None and self._exit_code is not None:
             self._on_exit(self._exit_code)
 
     def _reap(self) -> None:
         if self._pid is None:
+            if self._exit_code is None:
+                self._exit_code = -1
+            self._close_fd()
             return
         try:
             pid, status = os.waitpid(self._pid, os.WNOHANG)
             if pid == 0:
-                # Still alive; try a blocking wait briefly.
+                # Still alive; close() has already signalled. Block briefly
+                # — SIGKILL guarantees reap in bounded time.
                 pid, status = os.waitpid(self._pid, 0)
         except ChildProcessError:
-            # Already reaped.
-            self._exit_code = self._exit_code if self._exit_code is not None else -1
+            if self._exit_code is None:
+                self._exit_code = -1
             self._pid = None
+            self._close_fd()
             return
-        # Translate status to exit code.
         if os.WIFEXITED(status):
             self._exit_code = os.WEXITSTATUS(status)
         elif os.WIFSIGNALED(status):
@@ -203,12 +306,20 @@ class PtySession:
         else:
             self._exit_code = -1
         self._pid = None
-        if self._fd is not None:
-            try:
-                os.close(self._fd)
-            except OSError:
-                pass
-            self._fd = None
+        self._close_fd()
+
+    def _close_fd(self) -> None:
+        if self._fd is None:
+            return
+        try:
+            os.close(self._fd)
+        except OSError:
+            pass
+        self._fd = None
+
+    def _record_error(self, note: str) -> None:
+        if self._recorder is not None:
+            self._recorder.record(EventKind.ERROR, note=note)
 
 
 # --- low-level helpers ----------------------------------------------------
@@ -219,6 +330,5 @@ def _set_nonblocking(fd: int) -> None:
 
 
 def _set_winsize(fd: int, rows: int, cols: int) -> None:
-    """TIOCSWINSZ: rows, cols, x-pixels, y-pixels."""
     winsize = struct.pack("HHHH", rows, cols, 0, 0)
     fcntl.ioctl(fd, termios.TIOCSWINSZ, winsize)

--- a/src/actor/watch/interactive/pty_session.py
+++ b/src/actor/watch/interactive/pty_session.py
@@ -23,9 +23,14 @@ from .diagnostics import DiagnosticRecorder, EventKind
 
 # 64 KiB chunk keeps latency low without overwhelming the parser.
 _READ_CHUNK = 65536
-# Poll interval when waitpid needs to escalate from SIGTERM to SIGKILL.
+# Liveness-probe poll for close()'s kill(pid, 0) loop before SIGKILL escalation.
 _TERM_POLL_S = 0.05
 _TERM_DEADLINE_S = 0.5
+# Short poll used by _reap() when the child hasn't quite exited yet but we
+# also don't want to block the asyncio loop indefinitely on a natural-EOF
+# path (EIO/EBADF from os.read can arrive before the child is reaped).
+_REAP_POLL_S = 0.02
+_REAP_DEADLINE_S = 0.5
 
 
 class PtySession:
@@ -282,19 +287,43 @@ class PtySession:
                 self._exit_code = -1
             self._close_fd()
             return
-        try:
-            pid, status = os.waitpid(self._pid, os.WNOHANG)
-            if pid == 0:
-                # Still alive; close() has already signalled. Block briefly
-                # — SIGKILL guarantees reap in bounded time.
-                pid, status = os.waitpid(self._pid, 0)
-        except ChildProcessError:
-            if self._exit_code is None:
-                self._exit_code = -1
-            self._pid = None
-            self._close_fd()
-            return
-        if os.WIFEXITED(status):
+        status: Optional[int] = None
+        # Try WNOHANG first; then poll up to _REAP_DEADLINE_S so we don't
+        # block the asyncio loop indefinitely on paths where close() didn't
+        # SIGKILL (e.g. EOF on the master fd while the child is still
+        # running briefly). Escalate to SIGKILL if the deadline expires.
+        deadline = time.monotonic() + _REAP_DEADLINE_S
+        while True:
+            try:
+                pid, status = os.waitpid(self._pid, os.WNOHANG)
+            except ChildProcessError:
+                if self._exit_code is None:
+                    self._exit_code = -1
+                self._pid = None
+                self._close_fd()
+                return
+            if pid != 0:
+                break
+            if time.monotonic() >= deadline:
+                try:
+                    os.kill(self._pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                # One last blocking wait now that SIGKILL is in flight —
+                # guaranteed to return in ~ms.
+                try:
+                    pid, status = os.waitpid(self._pid, 0)
+                except ChildProcessError:
+                    if self._exit_code is None:
+                        self._exit_code = -1
+                    self._pid = None
+                    self._close_fd()
+                    return
+                break
+            time.sleep(_REAP_POLL_S)
+        if status is None:
+            self._exit_code = -1
+        elif os.WIFEXITED(status):
             self._exit_code = os.WEXITSTATUS(status)
         elif os.WIFSIGNALED(status):
             self._exit_code = -os.WTERMSIG(status)

--- a/src/actor/watch/interactive/pty_session.py
+++ b/src/actor/watch/interactive/pty_session.py
@@ -1,13 +1,8 @@
-"""Interactive PTY session: fork + execvpe, non-blocking read, resize, kill.
+"""Interactive PTY session lifetime (fork + execvpe, async read, resize, kill).
 
-One PtySession owns:
-  - a forked child process
-  - the master PTY file descriptor
-  - the on_output callback that receives bytes as they arrive
-  - the on_exit callback that fires when the child exits
-
-No Textual / rendering concerns live here — that's widget.py's job.
-asyncio-based: add_reader schedules the read callback on the event loop.
+Callback-based: on_output gets each chunk as it arrives; on_exit fires
+once when the child is reaped. Textual / rendering concerns live in
+widget.py.
 """
 from __future__ import annotations
 

--- a/src/actor/watch/interactive/pty_session.py
+++ b/src/actor/watch/interactive/pty_session.py
@@ -1,0 +1,224 @@
+"""Interactive PTY session: fork + execvpe, non-blocking read, resize, kill.
+
+One PtySession owns:
+  - a forked child process
+  - the master PTY file descriptor
+  - the on_output callback that receives bytes as they arrive
+  - the on_exit callback that fires when the child exits
+
+No Textual / rendering concerns live here — that's widget.py's job.
+asyncio-based: add_reader schedules the read callback on the event loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import errno
+import fcntl
+import os
+import pty
+import signal
+import struct
+import termios
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+
+# Observed "best" chunk size that keeps latency low without overwhelming
+# the parser. 64 KiB matches cmdlane; keeps us aligned with how OS delivers.
+_READ_CHUNK = 65536
+
+
+class PtySession:
+    """Manages one forked-pty child process."""
+
+    def __init__(
+        self,
+        argv: List[str],
+        cwd: Path,
+        env: Optional[Dict[str, str]] = None,
+        rows: int = 24,
+        cols: int = 80,
+        on_output: Optional[Callable[[bytes], None]] = None,
+        on_exit: Optional[Callable[[int], None]] = None,
+    ) -> None:
+        if not argv:
+            raise ValueError("argv must be non-empty")
+        self._argv = list(argv)
+        self._cwd = cwd
+        self._env = dict(env) if env is not None else None
+        self._rows = rows
+        self._cols = cols
+        self._on_output = on_output
+        self._on_exit = on_exit
+        self._pid: Optional[int] = None
+        self._fd: Optional[int] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._exit_code: Optional[int] = None
+        self._exit_fired = False
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def spawn(self) -> None:
+        """Fork + exec the child. Must be called from an async context so
+        the running loop can be used as the read-loop driver."""
+        if self._pid is not None:
+            raise RuntimeError("already spawned")
+
+        pid, fd = pty.fork()
+        if pid == 0:
+            # Child: replace process image.
+            try:
+                _set_winsize(0, self._rows, self._cols)  # 0 = our stdin, now the slave
+                if self._env is None:
+                    env = dict(os.environ)
+                else:
+                    env = dict(self._env)
+                # Ensure the child sees a sane TERM — claude uses it for color.
+                env.setdefault("TERM", "xterm-256color")
+                os.chdir(str(self._cwd))
+                os.execvpe(self._argv[0], self._argv, env)
+            except BaseException:
+                # If exec fails, don't come back into asyncio-land.
+                os._exit(127)
+
+        self._pid = pid
+        self._fd = fd
+        _set_nonblocking(fd)
+        _set_winsize(fd, self._rows, self._cols)
+
+        self._loop = asyncio.get_running_loop()
+        self._loop.add_reader(fd, self._on_fd_ready)
+
+    # -- I/O ---------------------------------------------------------------
+
+    def write(self, data: bytes) -> None:
+        """Write input bytes to the child. Silently no-ops if the session
+        has already exited (caller can check `.exited` if they care)."""
+        if self._fd is None:
+            return
+        try:
+            os.write(self._fd, data)
+        except OSError as e:
+            if e.errno in (errno.EBADF, errno.EIO):
+                self._handle_exit()
+                return
+            raise
+
+    def resize(self, rows: int, cols: int) -> None:
+        if rows <= 0 or cols <= 0:
+            return
+        self._rows = rows
+        self._cols = cols
+        if self._fd is not None:
+            try:
+                _set_winsize(self._fd, rows, cols)
+            except OSError:
+                pass
+
+    def close(self, signal_no: int = signal.SIGTERM) -> None:
+        """Kill + reap the child. Idempotent. Fires on_exit exactly once."""
+        if self._pid is None and self._exit_fired:
+            return
+        if self._pid is not None:
+            try:
+                os.kill(self._pid, signal_no)
+            except ProcessLookupError:
+                pass
+        self._handle_exit()
+
+    def kill(self) -> None:
+        """Unconditionally SIGKILL the child."""
+        self.close(signal.SIGKILL)
+
+    # -- properties --------------------------------------------------------
+
+    @property
+    def pid(self) -> Optional[int]:
+        return self._pid
+
+    @property
+    def fd(self) -> Optional[int]:
+        return self._fd
+
+    @property
+    def exit_code(self) -> Optional[int]:
+        return self._exit_code
+
+    @property
+    def exited(self) -> bool:
+        return self._exit_code is not None
+
+    # -- internals ---------------------------------------------------------
+
+    def _on_fd_ready(self) -> None:
+        if self._fd is None:
+            return
+        try:
+            data = os.read(self._fd, _READ_CHUNK)
+        except OSError as e:
+            if e.errno in (errno.EIO, errno.EBADF):
+                # PTY closed (child exited / slave released).
+                self._handle_exit()
+                return
+            if e.errno == errno.EAGAIN:
+                return
+            raise
+        if not data:
+            self._handle_exit()
+            return
+        if self._on_output is not None:
+            self._on_output(data)
+
+    def _handle_exit(self) -> None:
+        if self._exit_fired:
+            return
+        self._exit_fired = True
+        if self._fd is not None and self._loop is not None:
+            try:
+                self._loop.remove_reader(self._fd)
+            except (ValueError, KeyError):
+                pass
+        self._reap()
+        if self._on_exit is not None and self._exit_code is not None:
+            self._on_exit(self._exit_code)
+
+    def _reap(self) -> None:
+        if self._pid is None:
+            return
+        try:
+            pid, status = os.waitpid(self._pid, os.WNOHANG)
+            if pid == 0:
+                # Still alive; try a blocking wait briefly.
+                pid, status = os.waitpid(self._pid, 0)
+        except ChildProcessError:
+            # Already reaped.
+            self._exit_code = self._exit_code if self._exit_code is not None else -1
+            self._pid = None
+            return
+        # Translate status to exit code.
+        if os.WIFEXITED(status):
+            self._exit_code = os.WEXITSTATUS(status)
+        elif os.WIFSIGNALED(status):
+            self._exit_code = -os.WTERMSIG(status)
+        else:
+            self._exit_code = -1
+        self._pid = None
+        if self._fd is not None:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            self._fd = None
+
+
+# --- low-level helpers ----------------------------------------------------
+
+def _set_nonblocking(fd: int) -> None:
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+
+def _set_winsize(fd: int, rows: int, cols: int) -> None:
+    """TIOCSWINSZ: rows, cols, x-pixels, y-pixels."""
+    winsize = struct.pack("HHHH", rows, cols, 0, 0)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, winsize)

--- a/src/actor/watch/interactive/pty_session.py
+++ b/src/actor/watch/interactive/pty_session.py
@@ -215,11 +215,23 @@ class PtySession:
                 self._record_error(f"shutdown remove_reader: {e!r}")
             self._unregister_writer()
         if self._pid is not None:
+            already_reaped = False
             try:
                 pid, status = os.waitpid(self._pid, os.WNOHANG)
             except ChildProcessError:
-                pid, status = -1, 0
-            if pid == 0:
+                # ECHILD: child already reaped elsewhere (asyncio child
+                # watcher, parent's SIGCHLD handler, etc). Record it so
+                # a future bug involving double-reap or pid reuse is
+                # visible in diagnostics.
+                self._record_error(
+                    f"shutdown_kill: pid {self._pid} already reaped (ECHILD)",
+                )
+                self._exit_code = -int(signal.SIGKILL)
+                already_reaped = True
+
+            if already_reaped:
+                pass
+            elif pid == 0:
                 # Still alive; don't block. Accept a transient zombie.
                 self._exit_code = -int(signal.SIGKILL)
                 self._record_error(

--- a/src/actor/watch/interactive/screen.py
+++ b/src/actor/watch/interactive/screen.py
@@ -160,8 +160,10 @@ def _char_style(char: Char) -> Style:
             underline=char.underscore,
             strike=char.strikethrough, blink=char.blink,
         )
-    except Exception:
-        # Unknown color encoding: drop color rather than crash render.
+    except (ValueError, TypeError):
+        # Unknown color encoding from rich: drop color rather than crash.
+        # Other exceptions (AttributeError from malformed Char, etc.) are
+        # bugs; let them surface.
         return Style(
             bold=char.bold, italic=char.italics,
             underline=char.underscore,

--- a/src/actor/watch/interactive/screen.py
+++ b/src/actor/watch/interactive/screen.py
@@ -1,0 +1,179 @@
+"""Pyte-backed terminal screen with rich.Text rendering + mouse-mode sniffing.
+
+Pure. Accepts bytes via `feed`, exposes the current frame via `render`.
+Also sniffs DECSET sequences (mouse tracking, app cursor) as they stream
+past so the input layer can adjust its encoding.
+"""
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+import pyte
+from pyte.screens import Char
+
+from rich.style import Style
+from rich.text import Text
+
+from .input import MouseMode
+
+
+# Capture `CSI ? <params> h|l` — DECSET/DECRST. We only need the param list
+# and whether it's set (h) or reset (l).
+_DECSET_RE = re.compile(rb"\x1b\[\?([\d;]+)([hl])")
+
+
+class TerminalScreen:
+    """Wraps pyte.HistoryScreen + rich rendering.
+
+    Rows/cols are cell counts. `scrollback` is the number of lines pyte
+    keeps in its off-screen history (each direction).
+    """
+
+    def __init__(self, rows: int = 24, cols: int = 80, scrollback: int = 10_000) -> None:
+        self._rows = rows
+        self._cols = cols
+        # HistoryScreen splits scrollback into top/bottom halves internally.
+        # Giving each half `scrollback` lines keeps the math simple.
+        self._screen = pyte.HistoryScreen(
+            cols, rows,
+            history=scrollback, ratio=0.5,
+        )
+        self._stream = pyte.ByteStream(self._screen)
+        self.mouse_mode = MouseMode()
+        self.app_cursor = False
+
+    # -- Stream in ---------------------------------------------------------
+
+    def feed(self, data: bytes) -> None:
+        """Feed raw PTY output bytes into the emulator."""
+        # Sniff mouse / cursor-mode toggles. We only look at DECSET/DECRST
+        # sequences; everything else flows through pyte untouched.
+        for m in _DECSET_RE.finditer(data):
+            params = [int(p) for p in m.group(1).split(b";") if p]
+            on = m.group(2) == b"h"
+            for p in params:
+                self._apply_decset(p, on)
+        self._stream.feed(data)
+
+    def _apply_decset(self, param: int, on: bool) -> None:
+        if param == 1:          # DECCKM — application cursor keys
+            self.app_cursor = on
+        elif param == 1000:     # X10 / VT200 button-event tracking
+            self.mouse_mode.tracking = on
+        elif param == 1002:     # button-event tracking with drag
+            self.mouse_mode.drag = on
+        elif param == 1003:     # any-event tracking
+            self.mouse_mode.any_motion = on
+        elif param == 1006:     # SGR extended mouse coordinates
+            self.mouse_mode.sgr = on
+
+    # -- Geometry ----------------------------------------------------------
+
+    def resize(self, rows: int, cols: int) -> None:
+        if rows == self._rows and cols == self._cols:
+            return
+        self._rows = rows
+        self._cols = cols
+        self._screen.resize(rows, cols)
+
+    @property
+    def rows(self) -> int:
+        return self._rows
+
+    @property
+    def cols(self) -> int:
+        return self._cols
+
+    @property
+    def cursor(self) -> Tuple[int, int]:
+        return (self._screen.cursor.x, self._screen.cursor.y)
+
+    # -- Rendering ---------------------------------------------------------
+
+    def render_lines(self) -> List[Text]:
+        """Render the current screen buffer as a list of rich.Text lines.
+
+        Scrollback is not included — that's the visible frame only. (The
+        scrollback API on pyte.HistoryScreen uses prev_page/next_page; we
+        can expose a scrolled offset later if needed.)
+        """
+        lines: List[Text] = []
+        screen = self._screen
+        cursor_x, cursor_y = self._screen.cursor.x, self._screen.cursor.y
+        cursor_hidden = screen.cursor.hidden
+
+        for y in range(self._rows):
+            line = Text()
+            buffer_line = screen.buffer[y]
+            # pyte stores a sparse dict by x; iterate columns densely.
+            x = 0
+            while x < self._cols:
+                char: Char = buffer_line[x]
+                # Coalesce runs of identical-style chars into one segment.
+                run_start = x
+                run_style = _char_style(char)
+                while x < self._cols:
+                    nxt = buffer_line[x]
+                    if _char_style(nxt) != run_style:
+                        break
+                    x += 1
+                text = "".join(buffer_line[i].data for i in range(run_start, x))
+                line.append(text, style=run_style)
+            # Cursor overlay: invert one cell unless the child hid the cursor.
+            if not cursor_hidden and y == cursor_y and 0 <= cursor_x < self._cols:
+                line.stylize("reverse", cursor_x, cursor_x + 1)
+            lines.append(line)
+        return lines
+
+
+_PYTE_COLOR_ALIASES = {
+    "default": None,
+    "black": "color(0)",
+    "red": "color(1)",
+    "green": "color(2)",
+    "brown": "color(3)",
+    "blue": "color(4)",
+    "magenta": "color(5)",
+    "cyan": "color(6)",
+    "white": "color(7)",
+    "brightblack": "color(8)",
+    "brightred": "color(9)",
+    "brightgreen": "color(10)",
+    "brightbrown": "color(11)",
+    "brightblue": "color(12)",
+    "brightmagenta": "color(13)",
+    "brightcyan": "color(14)",
+    "brightwhite": "color(15)",
+}
+
+
+def _resolve_color(color: str) -> str | None:
+    """pyte uses names or '#rrggbb' hex; rich handles hex directly."""
+    if color is None:
+        return None
+    if color.startswith("#") and len(color) == 7:
+        return color
+    if color in _PYTE_COLOR_ALIASES:
+        return _PYTE_COLOR_ALIASES[color]
+    # Numeric 256-color strings from pyte come through as e.g. "42"
+    if color.isdigit():
+        return f"color({color})"
+    # Fall back: treat unknown as no color.
+    return None
+
+
+def _char_style(char: Char) -> Style:
+    fg = _resolve_color(char.fg)
+    bg = _resolve_color(char.bg)
+    if char.reverse:
+        fg, bg = bg, fg
+    return Style(
+        color=fg,
+        bgcolor=bg,
+        bold=char.bold,
+        italic=char.italics,
+        underline=char.underscore,
+        strike=char.strikethrough,
+        blink=char.blink,
+    )

--- a/src/actor/watch/interactive/screen.py
+++ b/src/actor/watch/interactive/screen.py
@@ -22,6 +22,13 @@ from .input import MouseMode
 # and whether it's set (h) or reset (l).
 _DECSET_RE = re.compile(rb"\x1b\[\?([\d;]+)([hl])")
 
+# xterm / DEC private CSI variants (leading <, =, or > after '[').
+# Pyte doesn't understand these and, worse, its SGR parser drops the '>'
+# and treats e.g. `\x1b[>4;2m` (modifyOtherKeys) as SGR `4;2` — which sets
+# underline on every subsequent cell. Strip them before feeding pyte.
+# Examples from claude-code's init: `[>4;2m`, `[>1u`, `[>c`.
+_PRIVATE_CSI_RE = re.compile(rb"\x1b\[[<=>][\d;]*[a-zA-Z~]")
+
 
 class TerminalScreen:
     """Wraps pyte.HistoryScreen + rich rendering.
@@ -54,6 +61,8 @@ class TerminalScreen:
             on = m.group(2) == b"h"
             for p in params:
                 self._apply_decset(p, on)
+        # Strip private CSI variants pyte mishandles (see _PRIVATE_CSI_RE).
+        data = _PRIVATE_CSI_RE.sub(b"", data)
         self._stream.feed(data)
 
     def _apply_decset(self, param: int, on: bool) -> None:

--- a/src/actor/watch/interactive/screen.py
+++ b/src/actor/watch/interactive/screen.py
@@ -148,18 +148,29 @@ _PYTE_COLOR_ALIASES = {
 }
 
 
+_HEX_RE = re.compile(r"^#?[0-9a-fA-F]{6}$")
+
+
 def _resolve_color(color: str) -> str | None:
-    """pyte uses names or '#rrggbb' hex; rich handles hex directly."""
-    if color is None:
+    """Map a pyte color string to a rich-compatible color spec.
+
+    Pyte emits:
+      - 'default'           — terminal default (return None → rich skips)
+      - named colors        — 'red', 'brightblue', etc.
+      - 6-char hex          — 'RRGGBB' or '#RRGGBB' (truecolor SGR)
+      - 1-3 digit numeric   — '42' (256-palette SGR)
+    """
+    if color is None or color == "default":
         return None
-    if color.startswith("#") and len(color) == 7:
-        return color
     if color in _PYTE_COLOR_ALIASES:
         return _PYTE_COLOR_ALIASES[color]
-    # Numeric 256-color strings from pyte come through as e.g. "42"
-    if color.isdigit():
+    # Truecolor: hex string with or without the leading '#'.
+    if _HEX_RE.match(color):
+        return color if color.startswith("#") else f"#{color}"
+    # 256-palette index. isdigit() also matches hex digit strings like
+    # '999999' — the hex check above must run first.
+    if color.isdigit() and 0 <= int(color) <= 255:
         return f"color({color})"
-    # Fall back: treat unknown as no color.
     return None
 
 
@@ -168,12 +179,23 @@ def _char_style(char: Char) -> Style:
     bg = _resolve_color(char.bg)
     if char.reverse:
         fg, bg = bg, fg
-    return Style(
-        color=fg,
-        bgcolor=bg,
-        bold=char.bold,
-        italic=char.italics,
-        underline=char.underscore,
-        strike=char.strikethrough,
-        blink=char.blink,
-    )
+    try:
+        return Style(
+            color=fg,
+            bgcolor=bg,
+            bold=char.bold,
+            italic=char.italics,
+            underline=char.underscore,
+            strike=char.strikethrough,
+            blink=char.blink,
+        )
+    except Exception:
+        # Any unexpected color string (new pyte encoding, malformed sequence)
+        # should degrade to plain text rather than crash the render loop.
+        return Style(
+            bold=char.bold,
+            italic=char.italics,
+            underline=char.underscore,
+            strike=char.strikethrough,
+            blink=char.blink,
+        )

--- a/src/actor/watch/interactive/screen.py
+++ b/src/actor/watch/interactive/screen.py
@@ -1,9 +1,4 @@
-"""Pyte-backed terminal screen with rich.Text rendering + mouse-mode sniffing.
-
-Pure. Accepts bytes via `feed`, exposes the current frame via `render`.
-Also sniffs DECSET sequences (mouse tracking, app cursor) as they stream
-past so the input layer can adjust its encoding.
-"""
+"""Pyte-backed terminal screen with rich.Text rendering."""
 from __future__ import annotations
 
 import re
@@ -19,30 +14,21 @@ from rich.text import Text
 from .input import MouseMode
 
 
-# Capture `CSI ? <params> h|l` — DECSET/DECRST. We only need the param list
-# and whether it's set (h) or reset (l).
 _DECSET_RE = re.compile(rb"\x1b\[\?([\d;]+)([hl])")
 
-# xterm / DEC private CSI variants (leading <, =, or > after '[').
-# Pyte doesn't understand these and, worse, its SGR parser drops the '>'
-# and treats e.g. `\x1b[>4;2m` (modifyOtherKeys) as SGR `4;2` — which sets
-# underline on every subsequent cell. Strip them before feeding pyte.
-# Examples from claude-code's init: `[>4;2m`, `[>1u`, `[>c`.
+# xterm/DEC private CSI variants (leading <, =, or > after '['). Pyte's
+# SGR parser drops the leading symbol and treats e.g. `\x1b[>4;2m`
+# (modifyOtherKeys) as SGR 4;2 — underlining every subsequent cell. Strip
+# these before feeding pyte. Seen in claude-code init: [>4;2m, [>1u, [>c.
 _PRIVATE_CSI_RE = re.compile(rb"\x1b\[[<=>][\d;]*[a-zA-Z~]")
 
 
 class TerminalScreen:
-    """Wraps pyte.HistoryScreen + rich rendering.
-
-    Rows/cols are cell counts. `scrollback` is the number of lines pyte
-    keeps in its off-screen history (each direction).
-    """
-
     def __init__(self, rows: int = 24, cols: int = 80, scrollback: int = 10_000) -> None:
         self._rows = rows
         self._cols = cols
-        # HistoryScreen splits scrollback into top/bottom halves internally.
-        # Giving each half `scrollback` lines keeps the math simple.
+        # HistoryScreen splits history top/bottom via ratio; 0.5 keeps the
+        # math symmetric.
         self._screen = pyte.HistoryScreen(
             cols, rows,
             history=scrollback, ratio=0.5,
@@ -51,18 +37,12 @@ class TerminalScreen:
         self.mouse_mode = MouseMode()
         self.app_cursor = False
 
-    # -- Stream in ---------------------------------------------------------
-
     def feed(self, data: bytes) -> None:
-        """Feed raw PTY output bytes into the emulator."""
-        # Sniff mouse / cursor-mode toggles. We only look at DECSET/DECRST
-        # sequences; everything else flows through pyte untouched.
         for m in _DECSET_RE.finditer(data):
             params = [int(p) for p in m.group(1).split(b";") if p]
             on = m.group(2) == b"h"
             for p in params:
                 self._apply_decset(p, on)
-        # Strip private CSI variants pyte mishandles (see _PRIVATE_CSI_RE).
         data = _PRIVATE_CSI_RE.sub(b"", data)
         self._stream.feed(data)
 
@@ -102,15 +82,8 @@ class TerminalScreen:
     def cursor(self) -> Tuple[int, int]:
         return (self._screen.cursor.x, self._screen.cursor.y)
 
-    # -- Rendering ---------------------------------------------------------
-
     def render_lines(self) -> List[Text]:
-        """Render the current screen buffer as a list of rich.Text lines.
-
-        Scrollback is not included — that's the visible frame only. (The
-        scrollback API on pyte.HistoryScreen uses prev_page/next_page; we
-        can expose a scrolled offset later if needed.)
-        """
+        """Render the visible frame as rich.Text (no scrollback)."""
         lines: List[Text] = []
         screen = self._screen
         cursor_x, cursor_y = self._screen.cursor.x, self._screen.cursor.y
@@ -119,21 +92,17 @@ class TerminalScreen:
         for y in range(self._rows):
             line = Text()
             buffer_line = screen.buffer[y]
-            # pyte stores a sparse dict by x; iterate columns densely.
             x = 0
             while x < self._cols:
                 char: Char = buffer_line[x]
-                # Coalesce runs of identical-style chars into one segment.
                 run_start = x
                 run_style = _char_style(char)
                 while x < self._cols:
-                    nxt = buffer_line[x]
-                    if _char_style(nxt) != run_style:
+                    if _char_style(buffer_line[x]) != run_style:
                         break
                     x += 1
                 text = "".join(buffer_line[i].data for i in range(run_start, x))
                 line.append(text, style=run_style)
-            # Cursor overlay: invert one cell unless the child hid the cursor.
             if not cursor_hidden and y == cursor_y and 0 <= cursor_x < self._cols:
                 line.stylize("reverse", cursor_x, cursor_x + 1)
             lines.append(line)
@@ -165,23 +134,15 @@ _HEX_RE = re.compile(r"^#?[0-9a-fA-F]{6}$")
 
 
 def _resolve_color(color: str) -> str | None:
-    """Map a pyte color string to a rich-compatible color spec.
-
-    Pyte emits:
-      - 'default'           — terminal default (return None → rich skips)
-      - named colors        — 'red', 'brightblue', etc.
-      - 6-char hex          — 'RRGGBB' or '#RRGGBB' (truecolor SGR)
-      - 1-3 digit numeric   — '42' (256-palette SGR)
-    """
+    """Pyte emits 'default', named colors, 'RRGGBB' truecolor (no '#'),
+    and 1-3 digit 256-palette indices. Order matters: the hex check must
+    precede the digit check ('999999' is both 6 digits and a hex string)."""
     if color is None or color == "default":
         return None
     if color in _PYTE_COLOR_ALIASES:
         return _PYTE_COLOR_ALIASES[color]
-    # Truecolor: hex string with or without the leading '#'.
     if _HEX_RE.match(color):
         return color if color.startswith("#") else f"#{color}"
-    # 256-palette index. isdigit() also matches hex digit strings like
-    # '999999' — the hex check above must run first.
     if color.isdigit() and 0 <= int(color) <= 255:
         return f"color({color})"
     return None
@@ -194,21 +155,15 @@ def _char_style(char: Char) -> Style:
         fg, bg = bg, fg
     try:
         return Style(
-            color=fg,
-            bgcolor=bg,
-            bold=char.bold,
-            italic=char.italics,
+            color=fg, bgcolor=bg,
+            bold=char.bold, italic=char.italics,
             underline=char.underscore,
-            strike=char.strikethrough,
-            blink=char.blink,
+            strike=char.strikethrough, blink=char.blink,
         )
     except Exception:
-        # Any unexpected color string (new pyte encoding, malformed sequence)
-        # should degrade to plain text rather than crash the render loop.
+        # Unknown color encoding: drop color rather than crash render.
         return Style(
-            bold=char.bold,
-            italic=char.italics,
+            bold=char.bold, italic=char.italics,
             underline=char.underscore,
-            strike=char.strikethrough,
-            blink=char.blink,
+            strike=char.strikethrough, blink=char.blink,
         )

--- a/src/actor/watch/interactive/screen.py
+++ b/src/actor/watch/interactive/screen.py
@@ -7,6 +7,7 @@ past so the input layer can adjust its encoding.
 from __future__ import annotations
 
 import re
+from dataclasses import replace
 from typing import List, Tuple
 
 import pyte
@@ -68,14 +69,17 @@ class TerminalScreen:
     def _apply_decset(self, param: int, on: bool) -> None:
         if param == 1:          # DECCKM — application cursor keys
             self.app_cursor = on
-        elif param == 1000:     # X10 / VT200 button-event tracking
-            self.mouse_mode.tracking = on
+            return
+        # MouseMode is frozen; replace wholesale rather than mutate.
+        mode = self.mouse_mode
+        if param == 1000:       # X10 / VT200 button-event tracking
+            self.mouse_mode = replace(mode, tracking=on)
         elif param == 1002:     # button-event tracking with drag
-            self.mouse_mode.drag = on
+            self.mouse_mode = replace(mode, drag=on)
         elif param == 1003:     # any-event tracking
-            self.mouse_mode.any_motion = on
+            self.mouse_mode = replace(mode, any_motion=on)
         elif param == 1006:     # SGR extended mouse coordinates
-            self.mouse_mode.sgr = on
+            self.mouse_mode = replace(mode, sgr=on)
 
     # -- Geometry ----------------------------------------------------------
 

--- a/src/actor/watch/interactive/screen.py
+++ b/src/actor/watch/interactive/screen.py
@@ -36,6 +36,10 @@ class TerminalScreen:
         self._stream = pyte.ByteStream(self._screen)
         self.mouse_mode = MouseMode()
         self.app_cursor = False
+        # DECSET 1049 (or 47 / 1047) swaps to an alternate screen buffer.
+        # When active, scrollback is meaningless — the child owns the view
+        # and page-up/down shouldn't scroll local history.
+        self.alt_screen = False
 
     def feed(self, data: bytes) -> None:
         for m in _DECSET_RE.finditer(data):
@@ -50,6 +54,9 @@ class TerminalScreen:
         if param == 1:          # DECCKM — application cursor keys
             self.app_cursor = on
             return
+        if param in (47, 1047, 1049):  # alt-screen variants
+            self.alt_screen = on
+            return
         # MouseMode is frozen; replace wholesale rather than mutate.
         mode = self.mouse_mode
         if param == 1000:       # X10 / VT200 button-event tracking
@@ -60,6 +67,29 @@ class TerminalScreen:
             self.mouse_mode = replace(mode, any_motion=on)
         elif param == 1006:     # SGR extended mouse coordinates
             self.mouse_mode = replace(mode, sgr=on)
+
+    def history_up(self, lines: int = 1) -> bool:
+        """Scroll the visible frame up by `lines` history rows. Returns
+        True if anything actually moved. Pyte's HistoryScreen uses pages;
+        we call prev_page() once per full page worth of lines."""
+        moved = False
+        pages = max(1, lines // max(1, self._rows))
+        for _ in range(pages):
+            before = len(self._screen.history.top)
+            self._screen.prev_page()
+            if len(self._screen.history.top) != before:
+                moved = True
+        return moved
+
+    def history_down(self, lines: int = 1) -> bool:
+        moved = False
+        pages = max(1, lines // max(1, self._rows))
+        for _ in range(pages):
+            before = len(self._screen.history.bottom)
+            self._screen.next_page()
+            if len(self._screen.history.bottom) != before:
+                moved = True
+        return moved
 
     # -- Geometry ----------------------------------------------------------
 

--- a/src/actor/watch/interactive/screen.py
+++ b/src/actor/watch/interactive/screen.py
@@ -114,14 +114,33 @@ class TerminalScreen:
 
     def render_lines(self) -> List[Text]:
         """Render the visible frame as rich.Text (no scrollback)."""
+        return self._render_rows(self._screen.buffer, cursor=True)
+
+    def history_size(self) -> int:
+        """Lines of scrollback above the visible frame."""
+        return len(self._screen.history.top)
+
+    def render_all_lines(self) -> List[Text]:
+        """Full virtual content: scrollback-top rows followed by the
+        visible frame. Used by the Textual-native scroll path so
+        virtual_size can be set correctly and render_line indexes
+        across the combined range."""
+        lines: List[Text] = list(self._render_history(self._screen.history.top))
+        lines.extend(self._render_rows(self._screen.buffer, cursor=True))
+        return lines
+
+    def _render_rows(self, rows, cursor: bool) -> List[Text]:
         lines: List[Text] = []
         screen = self._screen
-        cursor_x, cursor_y = self._screen.cursor.x, self._screen.cursor.y
+        cursor_x, cursor_y = screen.cursor.x, screen.cursor.y
         cursor_hidden = screen.cursor.hidden
-
         for y in range(self._rows):
             line = Text()
-            buffer_line = screen.buffer[y]
+            try:
+                buffer_line = rows[y]
+            except (KeyError, IndexError):
+                lines.append(line)
+                continue
             x = 0
             while x < self._cols:
                 char: Char = buffer_line[x]
@@ -133,8 +152,36 @@ class TerminalScreen:
                     x += 1
                 text = "".join(buffer_line[i].data for i in range(run_start, x))
                 line.append(text, style=run_style)
-            if not cursor_hidden and y == cursor_y and 0 <= cursor_x < self._cols:
+            if cursor and not cursor_hidden and y == cursor_y and 0 <= cursor_x < self._cols:
                 line.stylize("reverse", cursor_x, cursor_x + 1)
+            lines.append(line)
+        return lines
+
+    def _render_history(self, history) -> List[Text]:
+        """Render pyte history rows (list of dicts) as rich.Text. These
+        rows never show a cursor since they're already scrolled off."""
+        lines: List[Text] = []
+        for buffer_line in history:
+            line = Text()
+            x = 0
+            while x < self._cols:
+                char = buffer_line.get(x)
+                if char is None:
+                    line.append(" ")
+                    x += 1
+                    continue
+                run_start = x
+                run_style = _char_style(char)
+                while x < self._cols:
+                    nxt = buffer_line.get(x)
+                    if nxt is None or _char_style(nxt) != run_style:
+                        break
+                    x += 1
+                text = "".join(
+                    (buffer_line.get(i).data if buffer_line.get(i) is not None else " ")
+                    for i in range(run_start, x)
+                )
+                line.append(text, style=run_style)
             lines.append(line)
         return lines
 

--- a/src/actor/watch/interactive/screen.py
+++ b/src/actor/watch/interactive/screen.py
@@ -134,6 +134,16 @@ class TerminalScreen:
         screen = self._screen
         cursor_x, cursor_y = screen.cursor.x, screen.cursor.y
         cursor_hidden = screen.cursor.hidden
+        # Cmdlane-style: respect DECTCEM (\x1b[?25l). Additionally,
+        # don't overlay our own reverse on a cell that already has
+        # reverse set — the child is painting its own cursor and
+        # stacking reverses would cancel it out (invisible cursor).
+        cursor_cell_reverse = False
+        if not cursor_hidden and 0 <= cursor_y < self._rows and 0 <= cursor_x < self._cols:
+            try:
+                cursor_cell_reverse = bool(rows[cursor_y][cursor_x].reverse)
+            except (KeyError, IndexError, AttributeError):
+                cursor_cell_reverse = False
         for y in range(self._rows):
             line = Text()
             try:
@@ -152,7 +162,13 @@ class TerminalScreen:
                     x += 1
                 text = "".join(buffer_line[i].data for i in range(run_start, x))
                 line.append(text, style=run_style)
-            if cursor and not cursor_hidden and y == cursor_y and 0 <= cursor_x < self._cols:
+            if (
+                cursor
+                and not cursor_hidden
+                and not cursor_cell_reverse
+                and y == cursor_y
+                and 0 <= cursor_x < self._cols
+            ):
                 line.stylize("reverse", cursor_x, cursor_x + 1)
             lines.append(line)
         return lines
@@ -228,14 +244,13 @@ def _resolve_color(color: str) -> str | None:
 def _char_style(char: Char) -> Style:
     fg = _resolve_color(char.fg)
     bg = _resolve_color(char.bg)
-    if char.reverse:
-        fg, bg = bg, fg
     try:
         return Style(
             color=fg, bgcolor=bg,
             bold=char.bold, italic=char.italics,
             underline=char.underscore,
             strike=char.strikethrough, blink=char.blink,
+            reverse=char.reverse,
         )
     except (ValueError, TypeError):
         # Unknown color encoding from rich: drop color rather than crash.
@@ -245,4 +260,5 @@ def _char_style(char: Char) -> Style:
             bold=char.bold, italic=char.italics,
             underline=char.underscore,
             strike=char.strikethrough, blink=char.blink,
+            reverse=char.reverse,
         )

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -1,0 +1,216 @@
+"""Textual widget glueing PtySession + TerminalScreen + input translation.
+
+The widget holds the live pyte screen, receives output from the session,
+and translates user key/mouse events into bytes written to the session.
+Rendering is coalesced through RefreshBatcher so bursty output doesn't
+flicker.
+
+Ctrl+Z is intercepted by the widget (not forwarded to the PTY) and emits
+an `ExitInteractive` message so the host app can swap back to the log
+view. Every other key / mouse event routes through to the child.
+"""
+from __future__ import annotations
+
+import time
+from typing import List, Optional
+
+from rich.console import ConsoleOptions, RenderResult
+from rich.text import Text
+from textual import events
+from textual.message import Message
+from textual.reactive import reactive
+from textual.strip import Strip
+from textual.widget import Widget
+
+from .batcher import RefreshBatcher
+from .diagnostics import DiagnosticRecorder, EventKind
+from .input import (
+    MouseButton,
+    key_to_bytes,
+    mouse_press_to_bytes,
+    mouse_release_to_bytes,
+)
+from .pty_session import PtySession
+from .screen import TerminalScreen
+
+
+class TerminalWidget(Widget, can_focus=True):
+    """An embedded terminal view bound to a PtySession."""
+
+    DEFAULT_CSS = """
+    TerminalWidget {
+        background: $background;
+        color: $foreground;
+    }
+    """
+
+    class ExitRequested(Message):
+        """User hit Ctrl+Z to leave interactive mode."""
+
+        def __init__(self, widget: "TerminalWidget") -> None:
+            self.widget = widget
+            super().__init__()
+
+    class SessionExited(Message):
+        """The PtySession's child process exited."""
+
+        def __init__(self, widget: "TerminalWidget", exit_code: int) -> None:
+            self.widget = widget
+            self.exit_code = exit_code
+            super().__init__()
+
+    # Expose pending output as a reactive so Textual re-renders on change.
+    _frame_counter: reactive[int] = reactive(0)
+
+    def __init__(
+        self,
+        session: PtySession,
+        screen: TerminalScreen,
+        *,
+        recorder: Optional[DiagnosticRecorder] = None,
+        name: Optional[str] = None,
+        id: Optional[str] = None,
+        classes: Optional[str] = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._session = session
+        self._screen = screen
+        self._batcher = RefreshBatcher()
+        self._recorder = recorder
+        self._exit_code: Optional[int] = None
+        # Wire the session callbacks once at construction time so that
+        # unmounting and re-mounting (e.g. when the user switches actors
+        # and comes back) doesn't lose output or miss the exit event.
+        # The screen is updated unconditionally; render refresh only
+        # happens while we're mounted (post_message is a no-op otherwise).
+        session._on_output = self._on_pty_output  # type: ignore[attr-defined]
+        session._on_exit = self._on_pty_exit      # type: ignore[attr-defined]
+
+    # -- session callbacks -------------------------------------------------
+
+    def _on_pty_output(self, data: bytes) -> None:
+        if self._recorder is not None:
+            self._recorder.record(EventKind.READ, data)
+        self._screen.feed(data)
+        now = time.monotonic()
+        self._batcher.on_bytes(len(data), now)
+        if self._batcher.should_refresh_now(now):
+            self._flush_refresh(now)
+        else:
+            # Schedule a delayed check so max_defer still fires if bytes stop.
+            self.set_timer(self._batcher.max_defer, self._check_deferred_refresh)
+
+    def _check_deferred_refresh(self) -> None:
+        now = time.monotonic()
+        if self._batcher.should_refresh_now(now):
+            self._flush_refresh(now)
+
+    def _flush_refresh(self, now: float) -> None:
+        self._batcher.mark_refreshed(now)
+        if self._recorder is not None:
+            self._recorder.record(EventKind.REFRESH)
+        self._frame_counter += 1
+
+    def _on_pty_exit(self, exit_code: int) -> None:
+        if self._recorder is not None:
+            self._recorder.record(EventKind.EXIT, note=f"code={exit_code}")
+        self._exit_code = exit_code
+        self.post_message(self.SessionExited(self, exit_code))
+
+    # -- rendering ---------------------------------------------------------
+
+    def render_line(self, y: int) -> Strip:
+        lines = self._cached_lines()
+        if 0 <= y < len(lines):
+            return Strip(lines[y].render(self.app.console))
+        return Strip.blank(self.size.width)
+
+    def _cached_lines(self) -> List[Text]:
+        return self._screen.render_lines()
+
+    # -- resize ------------------------------------------------------------
+
+    def on_resize(self, event: events.Resize) -> None:
+        rows = max(1, event.size.height)
+        cols = max(1, event.size.width)
+        if rows == self._screen.rows and cols == self._screen.cols:
+            return
+        self._screen.resize(rows=rows, cols=cols)
+        self._session.resize(rows=rows, cols=cols)
+        if self._recorder is not None:
+            self._recorder.record(EventKind.RESIZE, note=f"{rows}x{cols}")
+
+    # -- key input ---------------------------------------------------------
+
+    async def on_key(self, event: events.Key) -> None:
+        # Intercept Ctrl+Z — that's our "leave interactive mode" shortcut.
+        if event.key == "ctrl+z":
+            event.stop()
+            event.prevent_default()
+            self.post_message(self.ExitRequested(self))
+            return
+
+        data = key_to_bytes(
+            event.key,
+            event.character,
+            app_cursor=self._screen.app_cursor,
+        )
+        if data is None:
+            return
+        event.stop()
+        event.prevent_default()
+        if self._recorder is not None:
+            self._recorder.record(EventKind.WRITE, data)
+        self._session.write(data)
+
+    # -- mouse input -------------------------------------------------------
+
+    async def on_click(self, event: events.Click) -> None:
+        self._handle_mouse_press(event.x, event.y, button=event.button)
+
+    async def on_mouse_down(self, event: events.MouseDown) -> None:
+        self._handle_mouse_press(event.x, event.y, button=event.button)
+
+    async def on_mouse_up(self, event: events.MouseUp) -> None:
+        data = mouse_release_to_bytes(event.x, event.y, self._screen.mouse_mode)
+        if data is None:
+            return
+        event.stop()
+        if self._recorder is not None:
+            self._recorder.record(EventKind.WRITE, data)
+        self._session.write(data)
+
+    async def on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
+        data = mouse_press_to_bytes(
+            MouseButton.WHEEL_UP, event.x, event.y, self._screen.mouse_mode,
+        )
+        if data is None:
+            return
+        event.stop()
+        if self._recorder is not None:
+            self._recorder.record(EventKind.WRITE, data)
+        self._session.write(data)
+
+    async def on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
+        data = mouse_press_to_bytes(
+            MouseButton.WHEEL_DOWN, event.x, event.y, self._screen.mouse_mode,
+        )
+        if data is None:
+            return
+        event.stop()
+        if self._recorder is not None:
+            self._recorder.record(EventKind.WRITE, data)
+        self._session.write(data)
+
+    def _handle_mouse_press(self, x: int, y: int, button: int) -> None:
+        # Textual button: 1=left, 2=middle, 3=right.
+        btn_map = {1: MouseButton.LEFT, 2: MouseButton.MIDDLE, 3: MouseButton.RIGHT}
+        mbtn = btn_map.get(button)
+        if mbtn is None:
+            return
+        data = mouse_press_to_bytes(mbtn, x, y, self._screen.mouse_mode)
+        if data is None:
+            return
+        if self._recorder is not None:
+            self._recorder.record(EventKind.WRITE, data)
+        self._session.write(data)

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -26,10 +26,15 @@ from .screen import TerminalScreen
 class TerminalWidget(Widget, can_focus=True):
     """An embedded terminal view bound to a PtySession."""
 
+    # overflow-y: auto gives us Textual's native scrolling: wheel +
+    # PageUp/PageDown drive self.scroll_y and render_line is called
+    # with virtual-y coords.
     DEFAULT_CSS = """
     TerminalWidget {
         background: $background;
         color: $foreground;
+        overflow-y: auto;
+        scrollbar-size-vertical: 1;
     }
     """
 
@@ -109,7 +114,28 @@ class TerminalWidget(Widget, can_focus=True):
         self._batcher.mark_refreshed(now)
         if self._recorder is not None:
             self._recorder.record(EventKind.REFRESH)
+        # Auto-follow live output if the user is at (or very near) the
+        # bottom of the scrollback; if they've scrolled up to look at
+        # history, respect their position.
+        was_following = self._is_following_bottom()
         self._frame_counter += 1
+        self._update_virtual_size()
+        if was_following:
+            self.scroll_end(animate=False)
+
+    def _update_virtual_size(self) -> None:
+        from textual.geometry import Size
+        rows = self._screen.rows + self._screen.history_size()
+        cols = max(self.size.width, self._screen.cols)
+        if self.virtual_size != Size(cols, rows):
+            self.virtual_size = Size(cols, rows)
+
+    def _is_following_bottom(self) -> bool:
+        # Near-bottom if within a couple rows of the max scroll. Newly
+        # mounted widgets have max_scroll_y == 0, which also counts as
+        # following so first output lands visible.
+        max_y = self.max_scroll_y
+        return max_y == 0 or self.scroll_y >= max_y - 1
 
     def _on_pty_exit(self, exit_code: int) -> None:
         if self._recorder is not None:
@@ -132,6 +158,7 @@ class TerminalWidget(Widget, can_focus=True):
         if not self._first_output_received:
             return self._placeholder_line(y)
         strips = self._get_strips()
+        # y here is a *virtual* row index (covers scrollback + visible).
         if 0 <= y < len(strips):
             return strips[y]
         return Strip.blank(self.size.width)
@@ -157,9 +184,11 @@ class TerminalWidget(Widget, can_focus=True):
         if self._cached_at_frame == self._frame_counter and self._cached_strips is not None:
             return self._cached_strips
         console = self.app.console
+        # render_all_lines covers scrollback + the visible buffer; virtual
+        # row y maps 1:1 into this list.
         self._cached_strips = [
             Strip(list(line.render(console)))
-            for line in self._screen.render_lines()
+            for line in self._screen.render_all_lines()
         ]
         self._cached_at_frame = self._frame_counter
         return self._cached_strips
@@ -196,22 +225,12 @@ class TerminalWidget(Widget, can_focus=True):
             self.post_message(self.ExitRequested(self))
             return
 
-        # PageUp/PageDown scroll local scrollback when the child isn't in
-        # alt-screen (no scrollback ownership) and doesn't want to handle
-        # mouse/cursor events itself. Always consume the event in this
-        # mode: forwarding PageUp to a shell when nothing moved would
-        # silently "do something else" in tools like less or the python
-        # REPL, which is worse than a visible no-op.
+        # PageUp/PageDown scroll the widget natively (Textual handles it
+        # via overflow-y: auto) unless the child is in alt-screen or has
+        # mouse tracking on — in which case it owns the viewport and we
+        # forward the escape sequence. Non-forwarded case: fall through
+        # without consuming the event so Textual's default binding scrolls.
         if event.key in ("pageup", "pagedown") and self._should_scroll_locally():
-            event.stop()
-            event.prevent_default()
-            moved = (
-                self._screen.history_up(self._screen.rows)
-                if event.key == "pageup"
-                else self._screen.history_down(self._screen.rows)
-            )
-            if moved:
-                self._frame_counter += 1
             return
 
         data = key_to_bytes(
@@ -248,18 +267,14 @@ class TerminalWidget(Widget, can_focus=True):
         self._session.write(data)
 
     async def on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
+        # Let Textual's native wheel-scroll handle local scroll; when
+        # the child has mouse tracking enabled, forward instead.
         if self._should_scroll_locally():
-            if self._screen.history_up(3):
-                event.stop()
-                self._frame_counter += 1
             return
         self._emit_mouse(MouseButton.WHEEL_UP, event.x, event.y, event)
 
     async def on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
         if self._should_scroll_locally():
-            if self._screen.history_down(3):
-                event.stop()
-                self._frame_counter += 1
             return
         self._emit_mouse(MouseButton.WHEEL_DOWN, event.x, event.y, event)
 

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -1,25 +1,14 @@
-"""Textual widget glueing PtySession + TerminalScreen + input translation.
-
-The widget holds the live pyte screen, receives output from the session,
-and translates user key/mouse events into bytes written to the session.
-Rendering is coalesced through RefreshBatcher so bursty output doesn't
-flicker.
-
-Ctrl+Z is intercepted by the widget (not forwarded to the PTY) and emits
-an `ExitInteractive` message so the host app can swap back to the log
-view. Every other key / mouse event routes through to the child.
-"""
+"""Textual widget glueing PtySession + TerminalScreen + input translation."""
 from __future__ import annotations
 
 import time
-from typing import List, Optional
+from typing import Optional
 
-from rich.console import ConsoleOptions, RenderResult
-from rich.text import Text
 from textual import events
 from textual.message import Message
 from textual.reactive import reactive
 from textual.strip import Strip
+from textual.timer import Timer
 from textual.widget import Widget
 
 from .batcher import RefreshBatcher
@@ -45,21 +34,16 @@ class TerminalWidget(Widget, can_focus=True):
     """
 
     class ExitRequested(Message):
-        """User hit Ctrl+Z to leave interactive mode."""
-
         def __init__(self, widget: "TerminalWidget") -> None:
             self.widget = widget
             super().__init__()
 
     class SessionExited(Message):
-        """The PtySession's child process exited."""
-
         def __init__(self, widget: "TerminalWidget", exit_code: int) -> None:
             self.widget = widget
             self.exit_code = exit_code
             super().__init__()
 
-    # Expose pending output as a reactive so Textual re-renders on change.
     _frame_counter: reactive[int] = reactive(0)
 
     def __init__(
@@ -78,18 +62,16 @@ class TerminalWidget(Widget, can_focus=True):
         self._batcher = RefreshBatcher()
         self._recorder = recorder
         self._exit_code: Optional[int] = None
-        # Render cache: render_line(y) is called once per visible row per
-        # frame. Without this, a 24-row widget walks the pyte buffer 24×
-        # per frame (and the pyte walk itself is the bottleneck).
         self._cached_strips: Optional[list[Strip]] = None
         self._cached_at_frame: int = -1
-        # Wire the session callbacks once at construction time so that
-        # unmounting and re-mounting (e.g. when the user switches actors
-        # and comes back) doesn't lose output or miss the exit event.
-        # The screen is updated unconditionally; render refresh only
-        # happens while we're mounted (post_message is a no-op otherwise).
-        session._on_output = self._on_pty_output  # type: ignore[attr-defined]
-        session._on_exit = self._on_pty_exit      # type: ignore[attr-defined]
+        # Single pending timer for deferred refresh — stacking N timers on
+        # bursty output would waste memory and re-render cycles.
+        self._deferred_timer: Optional[Timer] = None
+        # Callbacks set once at construction; surviving unmount/remount
+        # (the manager owns lifetime, not the DOM). Both callbacks are
+        # set via `set_callbacks` so consumers that need additional hooks
+        # (manager's DB finalize) can chain without clobbering the widget's.
+        session.set_callbacks(on_output=self._on_pty_output, on_exit=self._on_pty_exit)
 
     # -- session callbacks -------------------------------------------------
 
@@ -102,10 +84,17 @@ class TerminalWidget(Widget, can_focus=True):
         if self._batcher.should_refresh_now(now):
             self._flush_refresh(now)
         else:
-            # Schedule a delayed check so max_defer still fires if bytes stop.
-            self.set_timer(self._batcher.max_defer, self._check_deferred_refresh)
+            self._schedule_deferred_refresh()
+
+    def _schedule_deferred_refresh(self) -> None:
+        if self._deferred_timer is not None:
+            return
+        self._deferred_timer = self.set_timer(
+            self._batcher.max_defer, self._check_deferred_refresh,
+        )
 
     def _check_deferred_refresh(self) -> None:
+        self._deferred_timer = None
         now = time.monotonic()
         if self._batcher.should_refresh_now(now):
             self._flush_refresh(now)
@@ -131,7 +120,6 @@ class TerminalWidget(Widget, can_focus=True):
         return Strip.blank(self.size.width)
 
     def _get_strips(self) -> list[Strip]:
-        """Render all lines to Strips once per frame, then reuse."""
         if self._cached_at_frame == self._frame_counter and self._cached_strips is not None:
             return self._cached_strips
         console = self.app.console
@@ -157,7 +145,6 @@ class TerminalWidget(Widget, can_focus=True):
     # -- key input ---------------------------------------------------------
 
     async def on_key(self, event: events.Key) -> None:
-        # Intercept Ctrl+Z — that's our "leave interactive mode" shortcut.
         if event.key == "ctrl+z":
             event.stop()
             event.prevent_default()
@@ -178,9 +165,9 @@ class TerminalWidget(Widget, can_focus=True):
         self._session.write(data)
 
     # -- mouse input -------------------------------------------------------
-
-    async def on_click(self, event: events.Click) -> None:
-        self._handle_mouse_press(event.x, event.y, button=event.button)
+    # Textual fires MouseDown -> MouseUp -> Click. on_click is intentionally
+    # NOT handled here: it would double-send press bytes since on_mouse_down
+    # already emits them.
 
     async def on_mouse_down(self, event: events.MouseDown) -> None:
         self._handle_mouse_press(event.x, event.y, button=event.button)
@@ -195,36 +182,24 @@ class TerminalWidget(Widget, can_focus=True):
         self._session.write(data)
 
     async def on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
-        data = mouse_press_to_bytes(
-            MouseButton.WHEEL_UP, event.x, event.y, self._screen.mouse_mode,
-        )
-        if data is None:
-            return
-        event.stop()
-        if self._recorder is not None:
-            self._recorder.record(EventKind.WRITE, data)
-        self._session.write(data)
+        self._emit_mouse(MouseButton.WHEEL_UP, event.x, event.y, event)
 
     async def on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
-        data = mouse_press_to_bytes(
-            MouseButton.WHEEL_DOWN, event.x, event.y, self._screen.mouse_mode,
-        )
-        if data is None:
-            return
-        event.stop()
-        if self._recorder is not None:
-            self._recorder.record(EventKind.WRITE, data)
-        self._session.write(data)
+        self._emit_mouse(MouseButton.WHEEL_DOWN, event.x, event.y, event)
 
     def _handle_mouse_press(self, x: int, y: int, button: int) -> None:
-        # Textual button: 1=left, 2=middle, 3=right.
         btn_map = {1: MouseButton.LEFT, 2: MouseButton.MIDDLE, 3: MouseButton.RIGHT}
         mbtn = btn_map.get(button)
         if mbtn is None:
             return
-        data = mouse_press_to_bytes(mbtn, x, y, self._screen.mouse_mode)
+        self._emit_mouse(mbtn, x, y)
+
+    def _emit_mouse(self, button: MouseButton, x: int, y: int, event: Optional[events.Event] = None) -> None:
+        data = mouse_press_to_bytes(button, x, y, self._screen.mouse_mode)
         if data is None:
             return
+        if event is not None:
+            event.stop()
         if self._recorder is not None:
             self._recorder.record(EventKind.WRITE, data)
         self._session.write(data)

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -117,14 +117,22 @@ class TerminalWidget(ScrollView, can_focus=True):
         self._batcher.mark_refreshed(now)
         if self._recorder is not None:
             self._recorder.record(EventKind.REFRESH)
-        # Auto-follow live output if the user is at (or very near) the
-        # bottom of the scrollback; if they've scrolled up to look at
-        # history, respect their position.
+        # Auto-follow live output unless the user has manually scrolled
+        # up to look at history.
         was_following = self._is_following_bottom()
         self._frame_counter += 1
         self._update_virtual_size()
         if was_following:
-            self.scroll_end(animate=False)
+            # Defer scroll_end so it runs AFTER the layout pass has
+            # processed the new virtual_size (otherwise max_scroll_y is
+            # stale and scroll_end is a no-op — the symptom is the
+            # first frame appearing at the top of the viewport).
+            self.call_after_refresh(self._force_scroll_end)
+
+    def _force_scroll_end(self) -> None:
+        # scroll_end with force=True ignores current scroll target state
+        # and jumps to the current max_scroll_y.
+        self.scroll_end(animate=False, force=True)
 
     def _update_virtual_size(self) -> None:
         rows = self._screen.rows + self._screen.history_size()

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -5,11 +5,12 @@ import time
 from typing import Optional
 
 from textual import events
+from textual.geometry import Size
 from textual.message import Message
 from textual.reactive import reactive
+from textual.scroll_view import ScrollView
 from textual.strip import Strip
 from textual.timer import Timer
-from textual.widget import Widget
 
 from .batcher import RefreshBatcher
 from .diagnostics import DiagnosticRecorder, EventKind
@@ -23,17 +24,19 @@ from .pty_session import PtySession
 from .screen import TerminalScreen
 
 
-class TerminalWidget(Widget, can_focus=True):
-    """An embedded terminal view bound to a PtySession."""
+class TerminalWidget(ScrollView, can_focus=True):
+    """An embedded terminal view bound to a PtySession.
 
-    # overflow-y: auto gives us Textual's native scrolling: wheel +
-    # PageUp/PageDown drive self.scroll_y and render_line is called
-    # with virtual-y coords.
+    Inherits from ScrollView so PageUp/PageDown/wheel drive Textual's
+    native scroll. render_line(y) receives viewport-relative y; we
+    translate via self.scroll_offset.y to index into the virtual row
+    list (pyte history + visible buffer).
+    """
+
     DEFAULT_CSS = """
     TerminalWidget {
         background: $background;
         color: $foreground;
-        overflow-y: auto;
         scrollbar-size-vertical: 1;
     }
     """
@@ -124,11 +127,11 @@ class TerminalWidget(Widget, can_focus=True):
             self.scroll_end(animate=False)
 
     def _update_virtual_size(self) -> None:
-        from textual.geometry import Size
         rows = self._screen.rows + self._screen.history_size()
         cols = max(self.size.width, self._screen.cols)
-        if self.virtual_size != Size(cols, rows):
-            self.virtual_size = Size(cols, rows)
+        new_size = Size(cols, rows)
+        if self.virtual_size != new_size:
+            self.virtual_size = new_size
 
     def _is_following_bottom(self) -> bool:
         # Near-bottom if within a couple rows of the max scroll. Newly
@@ -157,10 +160,11 @@ class TerminalWidget(Widget, can_focus=True):
             self._sync_size(self.size.height, self.size.width)
         if not self._first_output_received:
             return self._placeholder_line(y)
+        # ScrollView passes viewport-relative y; translate to virtual.
+        virtual_y = y + int(self.scroll_offset.y)
         strips = self._get_strips()
-        # y here is a *virtual* row index (covers scrollback + visible).
-        if 0 <= y < len(strips):
-            return strips[y]
+        if 0 <= virtual_y < len(strips):
+            return strips[virtual_y]
         return Strip.blank(self.size.width)
 
     def _placeholder_line(self, y: int) -> Strip:

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -78,6 +78,11 @@ class TerminalWidget(Widget, can_focus=True):
         self._batcher = RefreshBatcher()
         self._recorder = recorder
         self._exit_code: Optional[int] = None
+        # Render cache: render_line(y) is called once per visible row per
+        # frame. Without this, a 24-row widget walks the pyte buffer 24×
+        # per frame (and the pyte walk itself is the bottleneck).
+        self._cached_strips: Optional[list[Strip]] = None
+        self._cached_at_frame: int = -1
         # Wire the session callbacks once at construction time so that
         # unmounting and re-mounting (e.g. when the user switches actors
         # and comes back) doesn't lose output or miss the exit event.
@@ -120,13 +125,22 @@ class TerminalWidget(Widget, can_focus=True):
     # -- rendering ---------------------------------------------------------
 
     def render_line(self, y: int) -> Strip:
-        lines = self._cached_lines()
-        if 0 <= y < len(lines):
-            return Strip(lines[y].render(self.app.console))
+        strips = self._get_strips()
+        if 0 <= y < len(strips):
+            return strips[y]
         return Strip.blank(self.size.width)
 
-    def _cached_lines(self) -> List[Text]:
-        return self._screen.render_lines()
+    def _get_strips(self) -> list[Strip]:
+        """Render all lines to Strips once per frame, then reuse."""
+        if self._cached_at_frame == self._frame_counter and self._cached_strips is not None:
+            return self._cached_strips
+        console = self.app.console
+        self._cached_strips = [
+            Strip(list(line.render(console)))
+            for line in self._screen.render_lines()
+        ]
+        self._cached_at_frame = self._frame_counter
+        return self._cached_strips
 
     # -- resize ------------------------------------------------------------
 

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -153,18 +153,21 @@ class TerminalWidget(Widget, can_focus=True):
 
         # PageUp/PageDown scroll local scrollback when the child isn't in
         # alt-screen (no scrollback ownership) and doesn't want to handle
-        # mouse/cursor events itself.
+        # mouse/cursor events itself. Always consume the event in this
+        # mode: forwarding PageUp to a shell when nothing moved would
+        # silently "do something else" in tools like less or the python
+        # REPL, which is worse than a visible no-op.
         if event.key in ("pageup", "pagedown") and self._should_scroll_locally():
+            event.stop()
+            event.prevent_default()
             moved = (
                 self._screen.history_up(self._screen.rows)
                 if event.key == "pageup"
                 else self._screen.history_down(self._screen.rows)
             )
             if moved:
-                event.stop()
-                event.prevent_default()
                 self._frame_counter += 1
-                return
+            return
 
         data = key_to_bytes(
             event.key,

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -37,7 +37,7 @@ class TerminalWidget(ScrollView, can_focus=True):
     TerminalWidget {
         background: $background;
         color: $foreground;
-        scrollbar-size-vertical: 1;
+        scrollbar-size: 0 0;
     }
     """
 

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -67,6 +67,11 @@ class TerminalWidget(Widget, can_focus=True):
         # Single pending timer for deferred refresh — stacking N timers on
         # bursty output would waste memory and re-render cycles.
         self._deferred_timer: Optional[Timer] = None
+        # Don't render the empty pyte screen — the default cursor-at-(0,0)
+        # overlay + dark fill on unused columns briefly shows as a box on
+        # the right while Textual settles our size. Render blank until the
+        # child has produced its first frame.
+        self._first_output_received = False
         # Callbacks set once at construction; surviving unmount/remount
         # (the manager owns lifetime, not the DOM). Both callbacks are
         # set via `set_callbacks` so consumers that need additional hooks
@@ -79,6 +84,7 @@ class TerminalWidget(Widget, can_focus=True):
         if self._recorder is not None:
             self._recorder.record(EventKind.READ, data)
         self._screen.feed(data)
+        self._first_output_received = True
         now = time.monotonic()
         self._batcher.on_bytes(len(data), now)
         if self._batcher.should_refresh_now(now):
@@ -114,6 +120,8 @@ class TerminalWidget(Widget, can_focus=True):
     # -- rendering ---------------------------------------------------------
 
     def render_line(self, y: int) -> Strip:
+        if not self._first_output_received:
+            return Strip.blank(self.size.width)
         strips = self._get_strips()
         if 0 <= y < len(strips):
             return strips[y]
@@ -133,8 +141,19 @@ class TerminalWidget(Widget, can_focus=True):
     # -- resize ------------------------------------------------------------
 
     def on_resize(self, event: events.Resize) -> None:
-        rows = max(1, event.size.height)
-        cols = max(1, event.size.width)
+        self._sync_size(event.size.height, event.size.width)
+
+    def on_mount(self) -> None:
+        # Textual's first on_resize fires after initial layout; without
+        # this, pyte stays at the default 24x80 until the first resize
+        # event lands, which briefly renders a pyte-sized frame inside
+        # a larger detail pane. Syncing here closes that gap.
+        if self.size.height > 0 and self.size.width > 0:
+            self._sync_size(self.size.height, self.size.width)
+
+    def _sync_size(self, rows: int, cols: int) -> None:
+        rows = max(1, rows)
+        cols = max(1, cols)
         if rows == self._screen.rows and cols == self._screen.cols:
             return
         self._screen.resize(rows=rows, cols=cols)

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -151,6 +151,21 @@ class TerminalWidget(Widget, can_focus=True):
             self.post_message(self.ExitRequested(self))
             return
 
+        # PageUp/PageDown scroll local scrollback when the child isn't in
+        # alt-screen (no scrollback ownership) and doesn't want to handle
+        # mouse/cursor events itself.
+        if event.key in ("pageup", "pagedown") and self._should_scroll_locally():
+            moved = (
+                self._screen.history_up(self._screen.rows)
+                if event.key == "pageup"
+                else self._screen.history_down(self._screen.rows)
+            )
+            if moved:
+                event.stop()
+                event.prevent_default()
+                self._frame_counter += 1
+                return
+
         data = key_to_bytes(
             event.key,
             event.character,
@@ -163,6 +178,9 @@ class TerminalWidget(Widget, can_focus=True):
         if self._recorder is not None:
             self._recorder.record(EventKind.WRITE, data)
         self._session.write(data)
+
+    def _should_scroll_locally(self) -> bool:
+        return not self._screen.alt_screen and not self._screen.mouse_mode.should_report_click()
 
     # -- mouse input -------------------------------------------------------
     # Textual fires MouseDown -> MouseUp -> Click. on_click is intentionally
@@ -182,9 +200,19 @@ class TerminalWidget(Widget, can_focus=True):
         self._session.write(data)
 
     async def on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
+        if self._should_scroll_locally():
+            if self._screen.history_up(3):
+                event.stop()
+                self._frame_counter += 1
+            return
         self._emit_mouse(MouseButton.WHEEL_UP, event.x, event.y, event)
 
     async def on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
+        if self._should_scroll_locally():
+            if self._screen.history_down(3):
+                event.stop()
+                self._frame_counter += 1
+            return
         self._emit_mouse(MouseButton.WHEEL_DOWN, event.x, event.y, event)
 
     def _handle_mouse_press(self, x: int, y: int, button: int) -> None:

--- a/src/actor/watch/interactive/widget.py
+++ b/src/actor/watch/interactive/widget.py
@@ -120,12 +120,38 @@ class TerminalWidget(Widget, can_focus=True):
     # -- rendering ---------------------------------------------------------
 
     def render_line(self, y: int) -> Strip:
+        # Belt-and-suspenders: if on_mount fired with size=(0,0) and
+        # on_resize hasn't delivered a non-zero size yet, pyte stays at
+        # the default 24x80 forever. Resync here once we see a real size.
+        if (
+            self.size.width > 0 and self.size.height > 0
+            and (self._screen.rows != self.size.height
+                 or self._screen.cols != self.size.width)
+        ):
+            self._sync_size(self.size.height, self.size.width)
         if not self._first_output_received:
-            return Strip.blank(self.size.width)
+            return self._placeholder_line(y)
         strips = self._get_strips()
         if 0 <= y < len(strips):
             return strips[y]
         return Strip.blank(self.size.width)
+
+    def _placeholder_line(self, y: int) -> Strip:
+        """Rendered while waiting for the child's first frame. Shows a
+        centered "Connecting…" hint so a hung/slow startup isn't just
+        an inscrutable blank box."""
+        width = self.size.width
+        height = self.size.height
+        if width <= 0 or height <= 0 or y != height // 2:
+            return Strip.blank(width)
+        msg = "Connecting…"
+        pad = max(0, (width - len(msg)) // 2)
+        text = " " * pad + msg
+        text += " " * max(0, width - len(text))
+        from rich.text import Text
+        from rich.style import Style
+        line = Text(text, style=Style(dim=True))
+        return Strip(list(line.render(self.app.console)))
 
     def _get_strips(self) -> list[Strip]:
         if self._cached_at_frame == self._frame_counter and self._cached_strips is not None:

--- a/src/actor/watch/tree.py
+++ b/src/actor/watch/tree.py
@@ -15,9 +15,8 @@ RUNNING_FRAMES = ["♤", "♡", "♢", "♧"]
 class ActorTree(Tree[Actor]):
     """Left panel showing all actors as a tree."""
 
-    # Relabel Tree's default Enter binding so the footer shows a useful
-    # hint. The action (select_cursor) is inherited and posts NodeSelected,
-    # which the app handles to open an interactive session.
+    # Relabel Tree's inherited Enter binding so the footer shows the
+    # actor.sh-specific action name; select_cursor itself is inherited.
     BINDINGS = [
         Binding("enter", "select_cursor", "Interactive", show=True),
     ]

--- a/src/actor/watch/tree.py
+++ b/src/actor/watch/tree.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from textual.binding import Binding
 from textual.widgets import Tree
 
 from ..types import Actor, Status
@@ -13,6 +14,13 @@ RUNNING_FRAMES = ["♤", "♡", "♢", "♧"]
 
 class ActorTree(Tree[Actor]):
     """Left panel showing all actors as a tree."""
+
+    # Relabel Tree's default Enter binding so the footer shows a useful
+    # hint. The action (select_cursor) is inherited and posts NodeSelected,
+    # which the app handles to open an interactive session.
+    BINDINGS = [
+        Binding("enter", "select_cursor", "Interactive", show=True),
+    ]
 
     DEFAULT_CSS = """
     ActorTree {

--- a/src/actor/watch/tree.py
+++ b/src/actor/watch/tree.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from textual.binding import Binding
 from textual.widgets import Tree
 
 from ..types import Actor, Status
@@ -14,14 +13,6 @@ RUNNING_FRAMES = ["♤", "♡", "♢", "♧"]
 
 class ActorTree(Tree[Actor]):
     """Left panel showing all actors as a tree."""
-
-    # The Enter-on-tree path routes through Tree.NodeSelected → the
-    # app's action_enter_interactive. The footer entry is provided by
-    # the app-level `i` binding which sets key_display="⏎ / i", so we
-    # hide this one to avoid showing Interactive twice.
-    BINDINGS = [
-        Binding("enter", "select_cursor", "Interactive", show=False),
-    ]
 
     DEFAULT_CSS = """
     ActorTree {

--- a/src/actor/watch/tree.py
+++ b/src/actor/watch/tree.py
@@ -15,10 +15,12 @@ RUNNING_FRAMES = ["♤", "♡", "♢", "♧"]
 class ActorTree(Tree[Actor]):
     """Left panel showing all actors as a tree."""
 
-    # Relabel Tree's inherited Enter binding so the footer shows the
-    # actor.sh-specific action name; select_cursor itself is inherited.
+    # The Enter-on-tree path routes through Tree.NodeSelected → the
+    # app's action_enter_interactive. The footer entry is provided by
+    # the app-level `i` binding which sets key_display="⏎ / i", so we
+    # hide this one to avoid showing Interactive twice.
     BINDINGS = [
-        Binding("enter", "select_cursor", "Interactive", show=True),
+        Binding("enter", "select_cursor", "Interactive", show=False),
     ]
 
     DEFAULT_CSS = """

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -766,7 +766,8 @@ class TestCmdInteractive(unittest.TestCase):
         pm.mark_alive(999)
 
         agent = FakeAgent()
-        with self.assertRaises(Exception):
+        from actor.errors import IsRunningError
+        with self.assertRaises(IsRunningError):
             cmd_interactive(
                 db, agent, pm, name="test",
                 runner=lambda argv, cwd, env: 0,

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -20,6 +20,7 @@ from actor import (
     Database,
     # Commands
     cmd_new, cmd_run, cmd_list, cmd_show, cmd_stop, cmd_config, cmd_logs, cmd_discard,
+    cmd_interactive, INTERACTIVE_PROMPT,
     # Helpers
     truncate, format_duration,
 )
@@ -101,6 +102,9 @@ class FakeAgent(Agent):
             err = self.next_stop_error
             self.next_stop_error = None
             raise err
+
+    def interactive_argv(self, session_id, config):
+        return ["fake-agent", "--resume", session_id]
 
 
 class FakeGitCall:
@@ -682,6 +686,128 @@ class TestCmdRun(unittest.TestCase):
         self.assertIsNotNone(latest, "run row should exist marked as error")
         self.assertEqual(latest.status, Status.ERROR)
         self.assertEqual(latest.exit_code, -1)
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  Test: cmd_interactive
+# ──────────────────────────────────────────────────────────────────────
+
+class TestCmdInteractive(unittest.TestCase):
+
+    def _db(self) -> Database:
+        return Database.open(":memory:")
+
+    def _actor_with_session(self, db: Database, name: str = "test", session: str = "S1"):
+        create_actor(db, name)
+        db.update_actor_session(name, session)
+
+    def test_interactive_creates_run_and_marks_done_on_success(self):
+        db = self._db()
+        self._actor_with_session(db)
+        pm = FakeProcessManager()
+        agent = FakeAgent()
+        captured: dict = {}
+
+        def runner(argv, cwd, env):
+            captured["argv"] = argv
+            captured["cwd"] = cwd
+            captured["actor_name_env"] = env.get("ACTOR_NAME")
+            return 0
+
+        exit_code, _ = cmd_interactive(
+            db, agent, pm, name="test", runner=runner,
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(captured["argv"], ["fake-agent", "--resume", "S1"])
+        self.assertEqual(Path(captured["cwd"]).resolve(), Path("/tmp").resolve())
+        self.assertEqual(captured["actor_name_env"], "test")
+
+        latest = db.latest_run("test")
+        self.assertEqual(latest.prompt, INTERACTIVE_PROMPT)
+        self.assertEqual(latest.status, Status.DONE)
+        self.assertEqual(latest.exit_code, 0)
+
+    def test_interactive_nonzero_exit_marks_error(self):
+        db = self._db()
+        self._actor_with_session(db)
+        pm = FakeProcessManager()
+        agent = FakeAgent()
+
+        exit_code, _ = cmd_interactive(
+            db, agent, pm, name="test",
+            runner=lambda argv, cwd, env: 2,
+        )
+        self.assertEqual(exit_code, 2)
+        latest = db.latest_run("test")
+        self.assertEqual(latest.status, Status.ERROR)
+        self.assertEqual(latest.exit_code, 2)
+
+    def test_interactive_requires_session(self):
+        db = self._db()
+        create_actor(db, "test")  # no session
+        pm = FakeProcessManager()
+        agent = FakeAgent()
+        with self.assertRaises(ActorError):
+            cmd_interactive(
+                db, agent, pm, name="test",
+                runner=lambda argv, cwd, env: 0,
+            )
+
+    def test_interactive_rejects_running_actor(self):
+        db = self._db()
+        self._actor_with_session(db)
+        pm = FakeProcessManager()
+        run = Run(
+            id=0, actor_name="test", prompt="go", status=Status.RUNNING,
+            exit_code=None, pid=999, config={},
+            started_at="2026-01-01T00:00:00Z", finished_at=None,
+        )
+        db.insert_run(run)
+        pm.mark_alive(999)
+
+        agent = FakeAgent()
+        with self.assertRaises(Exception):
+            cmd_interactive(
+                db, agent, pm, name="test",
+                runner=lambda argv, cwd, env: 0,
+            )
+
+    def test_interactive_runner_exception_marks_error(self):
+        db = self._db()
+        self._actor_with_session(db)
+        pm = FakeProcessManager()
+        agent = FakeAgent()
+
+        def boom(argv, cwd, env):
+            raise RuntimeError("something went wrong")
+
+        with self.assertRaises(RuntimeError):
+            cmd_interactive(
+                db, agent, pm, name="test", runner=boom,
+            )
+        latest = db.latest_run("test")
+        self.assertEqual(latest.status, Status.ERROR)
+        self.assertEqual(latest.exit_code, -1)
+
+    def test_interactive_stopped_race_preserves_stopped_status(self):
+        """If cmd_stop marks the run STOPPED while interactive is running,
+        cmd_interactive must not overwrite it with DONE/ERROR on exit."""
+        db = self._db()
+        self._actor_with_session(db)
+        pm = FakeProcessManager()
+        agent = FakeAgent()
+
+        def stop_race(argv, cwd, env):
+            # Simulate the stop race: during the run, status flips to STOPPED
+            latest = db.latest_run("test")
+            db.update_run_status(latest.id, Status.STOPPED, -1)
+            return 0
+
+        cmd_interactive(
+            db, agent, pm, name="test", runner=stop_race,
+        )
+        latest = db.latest_run("test")
+        self.assertEqual(latest.status, Status.STOPPED)
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -126,6 +126,38 @@ class RunCommandTests(unittest.TestCase):
         cmd_run.assert_called_once()
         self.assertEqual(cmd_run.call_args.kwargs["config_pairs"], ["model=opus"])
 
+    def test_run_dash_i_dispatches_to_cmd_interactive(self):
+        """`actor run foo -i` must route through cmd_interactive, not cmd_run."""
+        cmd_interactive = MagicMock(return_value=(0, "ok"))
+        cmd_run = MagicMock(return_value="should-not-run")
+        fake_db = MagicMock()
+        with patch("actor.cli.cmd_interactive", cmd_interactive), \
+             patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.cli.Database") as db_cls, \
+             patch("actor.cli._create_agent", return_value=MagicMock()):
+            db_cls.open.return_value = fake_db
+            with patch("sys.stderr", io.StringIO()):
+                with self.assertRaises(SystemExit) as ctx:
+                    main(["run", "foo", "-i"])
+        self.assertEqual(ctx.exception.code, 0)
+        cmd_interactive.assert_called_once()
+        self.assertEqual(cmd_interactive.call_args.kwargs.get("name"), "foo")
+        cmd_run.assert_not_called()
+
+    def test_run_dash_i_maps_signal_to_posix_exit(self):
+        """Negative exit code from cmd_interactive (signal) → 128 + signum."""
+        import signal as _sig
+        cmd_interactive = MagicMock(return_value=(-_sig.SIGTERM, "stopped"))
+        fake_db = MagicMock()
+        with patch("actor.cli.cmd_interactive", cmd_interactive), \
+             patch("actor.cli.Database") as db_cls, \
+             patch("actor.cli._create_agent", return_value=MagicMock()):
+            db_cls.open.return_value = fake_db
+            with patch("sys.stderr", io.StringIO()):
+                with self.assertRaises(SystemExit) as ctx:
+                    main(["run", "foo", "-i"])
+        self.assertEqual(ctx.exception.code, 128 + _sig.SIGTERM)
+
     def test_run_without_prompt_and_tty_exits_nonzero(self):
         fake_db = MagicMock()
         with patch("actor.cli.Database") as db_cls:

--- a/tests/test_interactive_manager.py
+++ b/tests/test_interactive_manager.py
@@ -1,0 +1,261 @@
+"""Tests for InteractiveSessionManager.
+
+Manager coordinates three moving parts: PtySession lifetime, TerminalWidget
+chain-of-callbacks, and DB Run finalization. These are the cases
+multi-reviewer calls flagged as a coverage gap.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+if sys.platform == "win32":
+    raise unittest.SkipTest("PTY not available on Windows")
+
+from actor import INTERACTIVE_PROMPT
+from actor.db import Database
+from actor.types import Config, Status
+from actor.watch.interactive.manager import InteractiveSessionManager
+from actor.watch.interactive.diagnostics import DiagnosticRecorder, EventKind
+
+
+def _find_binary(name: str) -> str:
+    for base in ("/bin", "/usr/bin"):
+        p = os.path.join(base, name)
+        if os.path.exists(p):
+            return p
+    path = shutil.which(name)
+    if path is None:
+        raise unittest.SkipTest(f"{name} not found on PATH")
+    return path
+
+
+class _FakeAgent:
+    """Minimal Agent implementation for manager tests. Only interactive_argv
+    is exercised; the rest raises to catch unintended uses."""
+
+    def __init__(self, argv: list[str]) -> None:
+        self._argv = argv
+
+    def interactive_argv(self, session_id: str, config: Config) -> list[str]:
+        return list(self._argv)
+
+    def start(self, *a, **k):  # pragma: no cover
+        raise AssertionError("start should not be called in manager tests")
+
+    def resume(self, *a, **k):  # pragma: no cover
+        raise AssertionError("resume should not be called")
+
+    def wait(self, *a, **k):  # pragma: no cover
+        raise AssertionError("wait should not be called")
+
+    def read_logs(self, *a, **k):  # pragma: no cover
+        return []
+
+    def stop(self, *a, **k):  # pragma: no cover
+        raise AssertionError("stop should not be called")
+
+
+def _ensure_actor(db: Database, name: str, session: str = "sess-1") -> None:
+    """Insert an actor row the manager needs for its Run insert + touch."""
+    import json
+    db._conn.execute(
+        """INSERT INTO actors (name, agent, agent_session, dir, source_repo,
+                               base_branch, worktree, parent, config,
+                               created_at, updated_at)
+           VALUES (?, 'claude', ?, '/tmp', NULL, NULL, 0, NULL, '{}',
+                   '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')""",
+        (name, session),
+    )
+    db._conn.commit()
+
+
+class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
+    """Uses /bin/cat as the real subprocess so PTY spawn/exit paths are exercised."""
+
+    def setUp(self) -> None:
+        # Use a file-backed sqlite so each db_opener() call can open a
+        # fresh connection (the manager uses `with opener()` which closes
+        # the connection on exit).
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._db_path = str(Path(self._tmpdir.name) / "actor.db")
+        # Seed the schema + actors via one connection, then discard it.
+        with Database.open(self._db_path) as db:
+            _ensure_actor(db, "alice")
+            _ensure_actor(db, "bob")
+        self.db = Database.open(self._db_path)  # reader for assertions
+        self.recorder = DiagnosticRecorder(capacity=100)
+        self.manager = InteractiveSessionManager(
+            db_opener=lambda: Database.open(self._db_path),
+            recorder=self.recorder,
+        )
+
+    def tearDown(self) -> None:
+        self.db.close()
+        self._tmpdir.cleanup()
+
+    async def test_create_spawns_and_inserts_run(self):
+        cat = _find_binary("cat")
+        info = self.manager.create(
+            actor_name="alice",
+            agent=_FakeAgent([cat]),
+            session_id="sess-1",
+            cwd=Path("/tmp"),
+            config={},
+        )
+        self.assertTrue(self.manager.has("alice"))
+        self.assertIs(self.manager.get("alice"), info)
+        self.assertIsNotNone(info.session.pid)
+        run = self.db.get_run(info.run_id)
+        self.assertIsNotNone(run)
+        self.assertEqual(run.prompt, INTERACTIVE_PROMPT)
+        self.assertEqual(run.status, Status.RUNNING)
+        self.manager.close("alice")
+
+    async def test_duplicate_create_raises(self):
+        cat = _find_binary("cat")
+        first = self.manager.create(
+            actor_name="alice", agent=_FakeAgent([cat]),
+            session_id="s", cwd=Path("/tmp"), config={},
+        )
+        try:
+            with self.assertRaises(RuntimeError):
+                self.manager.create(
+                    actor_name="alice", agent=_FakeAgent([cat]),
+                    session_id="s", cwd=Path("/tmp"), config={},
+                )
+            # The original session is still registered and alive.
+            self.assertIs(self.manager.get("alice"), first)
+        finally:
+            self.manager.close("alice")
+
+    async def test_close_marks_run_stopped(self):
+        cat = _find_binary("cat")
+        info = self.manager.create(
+            actor_name="alice", agent=_FakeAgent([cat]),
+            session_id="s", cwd=Path("/tmp"), config={},
+        )
+        self.manager.close("alice")
+        self.assertFalse(self.manager.has("alice"))
+        run = self.db.get_run(info.run_id)
+        self.assertEqual(
+            run.status, Status.STOPPED,
+            "app-initiated close should mark the run STOPPED, not ERROR",
+        )
+
+    async def test_natural_exit_marks_run_error_on_nonzero(self):
+        sh = _find_binary("sh")
+        info = self.manager.create(
+            actor_name="alice", agent=_FakeAgent([sh, "-c", "exit 3"]),
+            session_id="s", cwd=Path("/tmp"), config={},
+        )
+        # Let child exit and on_exit chain run.
+        for _ in range(200):
+            run = self.db.get_run(info.run_id)
+            if run and run.status != Status.RUNNING:
+                break
+            await asyncio.sleep(0.01)
+        run = self.db.get_run(info.run_id)
+        self.assertEqual(run.status, Status.ERROR)
+        self.assertEqual(run.exit_code, 3)
+        # Session entry should eventually be removed via the app's
+        # on_terminal_widget_session_exited handler. The manager alone
+        # doesn't pop on natural exit, so we pop it ourselves.
+        if self.manager.has("alice"):
+            self.manager.close("alice")
+
+    async def test_natural_exit_marks_done_on_zero(self):
+        sh = _find_binary("sh")
+        info = self.manager.create(
+            actor_name="alice", agent=_FakeAgent([sh, "-c", "exit 0"]),
+            session_id="s", cwd=Path("/tmp"), config={},
+        )
+        for _ in range(200):
+            run = self.db.get_run(info.run_id)
+            if run and run.status != Status.RUNNING:
+                break
+            await asyncio.sleep(0.01)
+        run = self.db.get_run(info.run_id)
+        self.assertEqual(run.status, Status.DONE)
+        self.assertEqual(run.exit_code, 0)
+        if self.manager.has("alice"):
+            self.manager.close("alice")
+
+    async def test_close_all_kills_every_session(self):
+        cat = _find_binary("cat")
+        alice = self.manager.create(
+            actor_name="alice", agent=_FakeAgent([cat]),
+            session_id="s1", cwd=Path("/tmp"), config={},
+        )
+        bob = self.manager.create(
+            actor_name="bob", agent=_FakeAgent([cat]),
+            session_id="s2", cwd=Path("/tmp"), config={},
+        )
+        self.manager.close_all()
+        self.assertEqual(self.manager.live_names(), [])
+        for info in (alice, bob):
+            run = self.db.get_run(info.run_id)
+            self.assertEqual(run.status, Status.STOPPED)
+            self.assertTrue(info.session.exited)
+
+    async def test_finalize_does_not_overwrite_existing_terminal_status(self):
+        cat = _find_binary("cat")
+        info = self.manager.create(
+            actor_name="alice", agent=_FakeAgent([cat]),
+            session_id="s", cwd=Path("/tmp"), config={},
+        )
+        # Simulate external stop marking the row DONE before our on_exit.
+        self.db.update_run_status(info.run_id, Status.DONE, 0)
+        self.manager.close("alice")
+        run = self.db.get_run(info.run_id)
+        self.assertEqual(run.status, Status.DONE,
+                         "finalize must not overwrite terminal status")
+
+
+class ManagerDiagnosticsTests(unittest.IsolatedAsyncioTestCase):
+    def test_close_all_failure_recorded(self):
+        recorder = DiagnosticRecorder()
+
+        class _BadClose:
+            """Stand-in session whose close() always raises."""
+            exit_code = None
+            exited = False
+
+            def close(self):
+                raise RuntimeError("boom")
+
+        from actor.watch.interactive.manager import (
+            InteractiveSession, InteractiveSessionManager,
+        )
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        db_path = str(Path(tmp.name) / "actor.db")
+        with Database.open(db_path) as seed:
+            _ensure_actor(seed, "alice")
+        mgr = InteractiveSessionManager(
+            db_opener=lambda: Database.open(db_path), recorder=recorder,
+        )
+        # Plant a fake session directly so close_all exercises the except path.
+        fake = InteractiveSession(
+            actor_name="alice",
+            session=_BadClose(),   # type: ignore[arg-type]
+            screen=None,           # type: ignore[arg-type]
+            widget=None,           # type: ignore[arg-type]
+            run_id=999,
+        )
+        mgr._sessions["alice"] = fake
+        mgr.close_all()
+        events = [e for e in recorder.recent() if e.kind == EventKind.ERROR]
+        self.assertTrue(
+            any("close_all" in e.note for e in events),
+            f"expected an ERROR diagnostic for failed close; got {events!r}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interactive_manager.py
+++ b/tests/test_interactive_manager.py
@@ -62,17 +62,16 @@ class _FakeAgent:
 
 
 def _ensure_actor(db: Database, name: str, session: str = "sess-1") -> None:
-    """Insert an actor row the manager needs for its Run insert + touch."""
-    import json
-    db._conn.execute(
-        """INSERT INTO actors (name, agent, agent_session, dir, source_repo,
-                               base_branch, worktree, parent, config,
-                               created_at, updated_at)
-           VALUES (?, 'claude', ?, '/tmp', NULL, NULL, 0, NULL, '{}',
-                   '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')""",
-        (name, session),
+    """Insert an actor via the public cmd_new so we don't hardcode schema."""
+    from actor import cmd_new
+    from tests.test_actor import FakeGit
+    git = FakeGit()
+    cmd_new(
+        db, git,
+        name=name, dir="/tmp", no_worktree=True, base=None,
+        agent_name="claude", config_pairs=[],
     )
-    db._conn.commit()
+    db.update_actor_session(name, session)
 
 
 class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_interactive_manager.py
+++ b/tests/test_interactive_manager.py
@@ -185,6 +185,45 @@ class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
         if self.manager.has("alice"):
             self.manager.close("alice")
 
+    async def test_create_updates_run_pid(self):
+        """The Run row must record the PTY's pid so resolve_actor_status
+        sees the child as alive (otherwise it flips to ERROR)."""
+        cat = _find_binary("cat")
+        info = self.manager.create(
+            actor_name="alice", agent=_FakeAgent([cat]),
+            session_id="s", cwd=Path("/tmp"), config={},
+        )
+        try:
+            run = self.db.get_run(info.run_id)
+            self.assertEqual(
+                run.pid, info.session.pid,
+                "Run.pid should match the spawned PTY pid",
+            )
+            # And resolve_actor_status agrees the actor is RUNNING.
+            from actor.process import RealProcessManager
+            status = self.db.resolve_actor_status("alice", RealProcessManager())
+            self.assertEqual(status, Status.RUNNING)
+        finally:
+            self.manager.close("alice")
+
+    async def test_shutdown_marks_runs_stopped_without_blocking(self):
+        import time, signal
+        sleep_bin = _find_binary("sleep")
+        info = self.manager.create(
+            actor_name="alice", agent=_FakeAgent([sleep_bin, "100"]),
+            session_id="s", cwd=Path("/tmp"), config={},
+        )
+        start = time.monotonic()
+        self.manager.shutdown()
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, 0.3, f"shutdown must not block; took {elapsed:.3f}s")
+        self.assertEqual(self.manager.live_names(), [])
+        run = self.db.get_run(info.run_id)
+        self.assertEqual(
+            run.status, Status.STOPPED,
+            "shutdown should mark every live Run as STOPPED",
+        )
+
     async def test_close_all_kills_every_session(self):
         cat = _find_binary("cat")
         alice = self.manager.create(

--- a/tests/test_interactive_pty.py
+++ b/tests/test_interactive_pty.py
@@ -200,5 +200,64 @@ class PtySessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn(b"hello-pty-env", b"".join(received))
 
 
+class PtySessionFailurePathsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_exec_failure_yields_exit_127(self):
+        """A bogus binary should surface via on_exit with code 127 rather
+        than hanging or raising in the parent."""
+        exit_codes: list[int] = []
+        session = PtySession(
+            argv=["/nonexistent/binary-xyz-nope"],
+            cwd=pathlib.Path("/tmp"),
+            on_exit=lambda code: exit_codes.append(code),
+        )
+        session.spawn()
+        for _ in range(200):
+            if exit_codes:
+                break
+            await asyncio.sleep(0.01)
+        self.assertEqual(exit_codes, [127])
+
+    async def test_write_handles_eagain(self):
+        """os.write raising EAGAIN must queue the bytes rather than crash;
+        the drainer flushes them once the fd is writable."""
+        from unittest.mock import patch
+        import errno as _errno
+
+        cat = _find_binary("cat")
+        session = PtySession(
+            argv=[cat],
+            cwd=pathlib.Path("/tmp"),
+        )
+        session.spawn()
+        try:
+            # Make the first write raise EAGAIN. Later writes (via drainer)
+            # fall through to the real os.write so the session stays alive.
+            real_write = os.write
+            call = {"n": 0}
+
+            def fake_write(fd, data):
+                call["n"] += 1
+                if call["n"] == 1:
+                    raise OSError(_errno.EAGAIN, "fake")
+                return real_write(fd, data)
+
+            with patch("actor.watch.interactive.pty_session.os.write",
+                       side_effect=fake_write):
+                session.write(b"hello\n")
+                # The initial write got EAGAIN → queued.
+                self.assertEqual(
+                    bytes(session._write_queue), b"hello\n",
+                    "EAGAIN should have queued the bytes",
+                )
+                # Let the add_writer drainer fire.
+                for _ in range(50):
+                    if not session._write_queue:
+                        break
+                    await asyncio.sleep(0.01)
+            self.assertEqual(session._write_queue, bytearray())
+        finally:
+            session.close()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_interactive_pty.py
+++ b/tests/test_interactive_pty.py
@@ -87,44 +87,65 @@ class PtySessionTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_resize_changes_winsize(self):
         sh = _find_binary("sh")
-        # Print LINES / COLUMNS after a resize happens.
+        # Use `read` so the shell blocks between the two stty size calls —
+        # no race between our resize and the first print.
         received: list[bytes] = []
         session = PtySession(
-            argv=[sh, "-c", "stty size; sleep 0.3; stty size"],
+            argv=[sh, "-c", "stty size && read _ && stty size"],
             cwd=pathlib.Path("/tmp"),
             rows=24, cols=80,
             on_output=lambda data: received.append(data),
         )
         session.spawn()
         try:
-            # Let first stty size print.
-            await asyncio.sleep(0.05)
+            # Wait until the first stty prints (one newline).
+            for _ in range(200):
+                if b"\n" in b"".join(received):
+                    break
+                await asyncio.sleep(0.01)
             session.resize(rows=40, cols=120)
-            # Wait for the second stty size.
-            for _ in range(100):
-                joined = b"".join(received)
-                if joined.count(b"\n") >= 2:
+            # Unblock the shell so the second stty runs.
+            session.write(b"x\n")
+            for _ in range(200):
+                if b"".join(received).count(b"\n") >= 2:
                     break
                 await asyncio.sleep(0.01)
         finally:
             session.close()
         joined = b"".join(received).decode("ascii", errors="replace")
-        # At least one occurrence of the new size in the output.
-        self.assertIn("40 120", joined, f"output was: {joined!r}")
+        lines = [ln.strip() for ln in joined.splitlines() if ln.strip()]
+        self.assertEqual(
+            lines[0], "24 80",
+            f"first stty should see initial winsize; got {lines!r}",
+        )
+        self.assertIn(
+            "40 120", lines,
+            f"post-resize stty should see new winsize; got {lines!r}",
+        )
 
     async def test_close_kills_running_child(self):
+        import signal
         sh = _find_binary("sh")
+        # Shell must NOT trap SIGTERM — we want to verify the signal landed.
+        # Some systems' /bin/sh is dash which already passes signals to its
+        # own process group; spawning `sleep` directly keeps the chain simple.
+        sleep_bin = _find_binary("sleep")
         exit_codes: list[int] = []
         session = PtySession(
-            argv=[sh, "-c", "sleep 10"],
+            argv=[sleep_bin, "100"],
             cwd=pathlib.Path("/tmp"),
             on_exit=lambda code: exit_codes.append(code),
         )
         session.spawn()
+        start = asyncio.get_event_loop().time()
         session.close()  # SIGTERM
-        # Exit code is -15 (SIGTERM) or a nonzero code depending on shell.
-        self.assertIsNotNone(session.exit_code)
-        self.assertEqual(len(exit_codes), 1)
+        elapsed = asyncio.get_event_loop().time() - start
+        self.assertLess(elapsed, 2.0, "close() should not block for seconds")
+        self.assertEqual(
+            session.exit_code, -signal.SIGTERM,
+            f"expected -{signal.SIGTERM} (SIGTERM), got {session.exit_code}",
+        )
+        self.assertEqual(exit_codes, [-signal.SIGTERM])
 
     async def test_write_after_exit_is_noop(self):
         sh = _find_binary("sh")

--- a/tests/test_interactive_pty.py
+++ b/tests/test_interactive_pty.py
@@ -200,6 +200,39 @@ class PtySessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn(b"hello-pty-env", b"".join(received))
 
 
+class PtySessionShutdownKillTests(unittest.IsolatedAsyncioTestCase):
+    """shutdown_kill is the non-blocking variant for Textual's on_unmount."""
+
+    async def test_shutdown_kill_returns_fast_for_running_child(self):
+        import time, signal
+        sleep_bin = _find_binary("sleep")
+        session = PtySession(
+            argv=[sleep_bin, "100"],
+            cwd=pathlib.Path("/tmp"),
+        )
+        session.spawn()
+        start = time.monotonic()
+        session.shutdown_kill()
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, 0.2,
+                        f"shutdown_kill must not block; took {elapsed:.3f}s")
+        # exit_code may be None (zombie) or -SIGKILL (reaped in time).
+        # Either way, _exit_fired is set so the session is done.
+        self.assertTrue(session._exit_fired)
+
+    async def test_shutdown_kill_idempotent(self):
+        sleep_bin = _find_binary("sleep")
+        session = PtySession(
+            argv=[sleep_bin, "100"],
+            cwd=pathlib.Path("/tmp"),
+        )
+        session.spawn()
+        session.shutdown_kill()
+        # Second call is a no-op.
+        session.shutdown_kill()
+        self.assertTrue(session._exit_fired)
+
+
 class PtySessionFailurePathsTests(unittest.IsolatedAsyncioTestCase):
     async def test_exec_failure_yields_exit_127(self):
         """A bogus binary should surface via on_exit with code 127 rather

--- a/tests/test_interactive_pty.py
+++ b/tests/test_interactive_pty.py
@@ -1,0 +1,183 @@
+"""Integration tests for PtySession against real processes.
+
+Uses /bin/cat and /bin/sh as the target commands so we exercise the full
+fork + exec + read + write + resize + reap pipeline end-to-end.
+
+These tests are slower (real subprocess + real fd) but still under a
+second each. Skipped on non-POSIX systems.
+"""
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import os
+import pathlib
+import shutil
+import struct
+import sys
+import termios
+import unittest
+
+if sys.platform == "win32":
+    raise unittest.SkipTest("PTY not available on Windows")
+
+from actor.watch.interactive.pty_session import PtySession
+
+
+def _find_binary(name: str) -> str:
+    for base in ("/bin", "/usr/bin"):
+        p = os.path.join(base, name)
+        if os.path.exists(p):
+            return p
+    path = shutil.which(name)
+    if path is None:
+        raise unittest.SkipTest(f"{name} not found on PATH")
+    return path
+
+
+class PtySessionTests(unittest.IsolatedAsyncioTestCase):
+    async def _drain_until(self, session: PtySession, received: list[bytes], target: bytes, timeout: float = 3.0) -> None:
+        async def waiter():
+            while True:
+                joined = b"".join(received)
+                if target in joined:
+                    return
+                await asyncio.sleep(0.01)
+        await asyncio.wait_for(waiter(), timeout=timeout)
+
+    async def test_cat_echoes_input(self):
+        cat = _find_binary("cat")
+        received: list[bytes] = []
+        exit_codes: list[int] = []
+        session = PtySession(
+            argv=[cat],
+            cwd=pathlib.Path("/tmp"),
+            rows=24, cols=80,
+            on_output=lambda data: received.append(data),
+            on_exit=lambda code: exit_codes.append(code),
+        )
+        session.spawn()
+        try:
+            session.write(b"hello world\n")
+            await self._drain_until(session, received, b"hello world")
+        finally:
+            session.close()
+
+        # Close is synchronous — the exit callback fired.
+        self.assertEqual(len(exit_codes), 1)
+        self.assertIsNotNone(session.exit_code)
+        self.assertTrue(session.exited)
+
+    async def test_child_exit_triggers_on_exit_callback(self):
+        sh = _find_binary("sh")
+        exit_codes: list[int] = []
+        session = PtySession(
+            argv=[sh, "-c", "exit 7"],
+            cwd=pathlib.Path("/tmp"),
+            on_exit=lambda code: exit_codes.append(code),
+        )
+        session.spawn()
+        # Wait up to 3s for the child to exit and the reader to notice.
+        for _ in range(300):
+            if exit_codes:
+                break
+            await asyncio.sleep(0.01)
+        self.assertEqual(exit_codes, [7])
+        self.assertEqual(session.exit_code, 7)
+
+    async def test_resize_changes_winsize(self):
+        sh = _find_binary("sh")
+        # Print LINES / COLUMNS after a resize happens.
+        received: list[bytes] = []
+        session = PtySession(
+            argv=[sh, "-c", "stty size; sleep 0.3; stty size"],
+            cwd=pathlib.Path("/tmp"),
+            rows=24, cols=80,
+            on_output=lambda data: received.append(data),
+        )
+        session.spawn()
+        try:
+            # Let first stty size print.
+            await asyncio.sleep(0.05)
+            session.resize(rows=40, cols=120)
+            # Wait for the second stty size.
+            for _ in range(100):
+                joined = b"".join(received)
+                if joined.count(b"\n") >= 2:
+                    break
+                await asyncio.sleep(0.01)
+        finally:
+            session.close()
+        joined = b"".join(received).decode("ascii", errors="replace")
+        # At least one occurrence of the new size in the output.
+        self.assertIn("40 120", joined, f"output was: {joined!r}")
+
+    async def test_close_kills_running_child(self):
+        sh = _find_binary("sh")
+        exit_codes: list[int] = []
+        session = PtySession(
+            argv=[sh, "-c", "sleep 10"],
+            cwd=pathlib.Path("/tmp"),
+            on_exit=lambda code: exit_codes.append(code),
+        )
+        session.spawn()
+        session.close()  # SIGTERM
+        # Exit code is -15 (SIGTERM) or a nonzero code depending on shell.
+        self.assertIsNotNone(session.exit_code)
+        self.assertEqual(len(exit_codes), 1)
+
+    async def test_write_after_exit_is_noop(self):
+        sh = _find_binary("sh")
+        session = PtySession(
+            argv=[sh, "-c", "exit 0"],
+            cwd=pathlib.Path("/tmp"),
+        )
+        session.spawn()
+        for _ in range(100):
+            if session.exited:
+                break
+            await asyncio.sleep(0.01)
+        # Should not raise.
+        session.write(b"hello\n")
+
+    async def test_cwd_is_applied(self):
+        sh = _find_binary("sh")
+        received: list[bytes] = []
+        session = PtySession(
+            argv=[sh, "-c", "pwd"],
+            cwd=pathlib.Path("/tmp"),
+            on_output=lambda data: received.append(data),
+        )
+        session.spawn()
+        for _ in range(200):
+            if b"\n" in b"".join(received):
+                break
+            await asyncio.sleep(0.01)
+        session.close()
+        joined = b"".join(received).decode("ascii", errors="replace")
+        # macOS resolves /tmp → /private/tmp inside the child.
+        self.assertTrue(
+            "/tmp" in joined or "/private/tmp" in joined,
+            f"pwd output was: {joined!r}",
+        )
+
+    async def test_env_is_passed(self):
+        sh = _find_binary("sh")
+        received: list[bytes] = []
+        session = PtySession(
+            argv=[sh, "-c", "echo $MY_MARKER"],
+            cwd=pathlib.Path("/tmp"),
+            env={"MY_MARKER": "hello-pty-env", "PATH": os.environ.get("PATH", "")},
+            on_output=lambda data: received.append(data),
+        )
+        session.spawn()
+        for _ in range(200):
+            if b"hello-pty-env" in b"".join(received):
+                break
+            await asyncio.sleep(0.01)
+        session.close()
+        self.assertIn(b"hello-pty-env", b"".join(received))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interactive_pty.py
+++ b/tests/test_interactive_pty.py
@@ -214,7 +214,10 @@ class PtySessionShutdownKillTests(unittest.IsolatedAsyncioTestCase):
         start = time.monotonic()
         session.shutdown_kill()
         elapsed = time.monotonic() - start
-        self.assertLess(elapsed, 0.2,
+        # Budget is generous to survive loaded CI runners; the real
+        # threshold that matters is "not seconds," which close() would
+        # hit via its 500ms deadline + blocking waitpid.
+        self.assertLess(elapsed, 0.4,
                         f"shutdown_kill must not block; took {elapsed:.3f}s")
         # exit_code may be None (zombie) or -SIGKILL (reaped in time).
         # Either way, _exit_fired is set so the session is done.

--- a/tests/test_interactive_pure.py
+++ b/tests/test_interactive_pure.py
@@ -18,7 +18,7 @@ from actor.watch.interactive.input import (
     mouse_press_to_bytes,
     mouse_release_to_bytes,
 )
-from actor.watch.interactive.screen import TerminalScreen
+from actor.watch.interactive.screen import TerminalScreen, _resolve_color
 
 
 # --- Screen ---------------------------------------------------------------
@@ -78,6 +78,35 @@ class TerminalScreenTests(unittest.TestCase):
         self.assertTrue(s.mouse_mode.sgr)
         s.feed(b"\x1b[?1000l")
         self.assertFalse(s.mouse_mode.tracking)
+
+    def test_resolve_color_handles_pyte_encodings(self):
+        # Named pyte aliases
+        self.assertEqual(_resolve_color("red"), "color(1)")
+        self.assertEqual(_resolve_color("brightgreen"), "color(10)")
+        # "default" is terminal default — no color.
+        self.assertIsNone(_resolve_color("default"))
+        self.assertIsNone(_resolve_color(None))
+        # Truecolor hex: digit-only (was the crash case — '999999' must not
+        # be treated as a 256-palette index).
+        self.assertEqual(_resolve_color("999999"), "#999999")
+        self.assertEqual(_resolve_color("ff00aa"), "#ff00aa")
+        # With leading '#' too.
+        self.assertEqual(_resolve_color("#123456"), "#123456")
+        # 256-palette index (1-3 digits, <=255).
+        self.assertEqual(_resolve_color("42"), "color(42)")
+        self.assertEqual(_resolve_color("255"), "color(255)")
+        # Out-of-range palette index falls back to None.
+        self.assertIsNone(_resolve_color("256"))
+        # Garbage degrades to None, not crash.
+        self.assertIsNone(_resolve_color("not-a-color"))
+
+    def test_rendering_tolerates_truecolor_fg(self):
+        """Regression: claude uses truecolor — ensure render_lines doesn't crash."""
+        s = TerminalScreen(rows=2, cols=10)
+        # 24-bit SGR: CSI 38 ; 2 ; R ; G ; B m
+        s.feed(b"\x1b[38;2;153;153;153mX\x1b[0m")
+        lines = s.render_lines()
+        self.assertEqual(lines[0].plain[0], "X")
 
     def test_cursor_overlay_inverts_single_cell(self):
         s = TerminalScreen(rows=2, cols=5)

--- a/tests/test_interactive_pure.py
+++ b/tests/test_interactive_pure.py
@@ -100,6 +100,20 @@ class TerminalScreenTests(unittest.TestCase):
         # Garbage degrades to None, not crash.
         self.assertIsNone(_resolve_color("not-a-color"))
 
+    def test_private_csi_variants_are_stripped(self):
+        """Regression: claude-code emits \\x1b[>4;2m (modifyOtherKeys) at
+        startup. Pyte's parser drops the '>' and reads it as plain SGR
+        4 (underline), leaving every subsequent cell underlined."""
+        s = TerminalScreen(rows=2, cols=20)
+        s.feed(b"\x1b[>4;2m")  # would underline everything if not stripped
+        s.feed(b"hello")
+        # No cells should be underlined.
+        for x in range(5):
+            self.assertFalse(
+                s._screen.buffer[0][x].underscore,
+                f"cell {x} got wrongly underlined from private CSI",
+            )
+
     def test_rendering_tolerates_truecolor_fg(self):
         """Regression: claude uses truecolor — ensure render_lines doesn't crash."""
         s = TerminalScreen(rows=2, cols=10)

--- a/tests/test_interactive_pure.py
+++ b/tests/test_interactive_pure.py
@@ -155,6 +155,31 @@ class TerminalScreenTests(unittest.TestCase):
         # No scrollback yet — nothing to page up to.
         self.assertFalse(s.history_up(10))
 
+    def test_cursor_overlay_suppressed_when_child_reverses_the_cell(self):
+        """If the child paints its own cursor via reverse SGR, our
+        overlay must not re-reverse — stacking cancels and the cursor
+        becomes invisible."""
+        s = TerminalScreen(rows=2, cols=10)
+        # Write "XY" where X is at (0,0) with reverse=ON, then move
+        # the cursor back onto that cell.
+        s.feed(b"\x1b[7mX\x1b[0m")     # reverse X, attributes reset
+        s.feed(b"\x1b[1;1H")            # move cursor to (1,1) which is (0,0) 0-indexed
+        # Cursor is now over the reversed X. Our overlay should NOT
+        # fire, so the rendered cell retains the child's reverse.
+        lines = s.render_lines()
+        # The first span (x=0) should be reverse-styled from the child.
+        spans = list(lines[0].spans)
+        # Find the span at x=0 — if we double-reversed, reverse==False.
+        cell_reverse = None
+        for sp in spans:
+            if sp.start <= 0 < sp.end:
+                cell_reverse = "reverse" in str(sp.style)
+                break
+        self.assertTrue(
+            cell_reverse,
+            f"child's reverse must win; got spans {spans!r}",
+        )
+
     def test_cursor_overlay_inverts_single_cell(self):
         s = TerminalScreen(rows=2, cols=5)
         s.feed(b"abc")  # cursor now at (3, 0)

--- a/tests/test_interactive_pure.py
+++ b/tests/test_interactive_pure.py
@@ -1,0 +1,322 @@
+"""Unit tests for the PURE interactive-terminal modules.
+
+Covers screen.py, input.py, batcher.py, diagnostics.py — no subprocess,
+no event loop, no Textual harness. If anything here breaks, flicker /
+keyboard / mouse behaviour is broken, and we want the signal before
+spawning real processes.
+"""
+from __future__ import annotations
+
+import unittest
+
+from actor.watch.interactive.batcher import RefreshBatcher
+from actor.watch.interactive.diagnostics import DiagnosticRecorder, EventKind
+from actor.watch.interactive.input import (
+    MouseButton,
+    MouseMode,
+    key_to_bytes,
+    mouse_press_to_bytes,
+    mouse_release_to_bytes,
+)
+from actor.watch.interactive.screen import TerminalScreen
+
+
+# --- Screen ---------------------------------------------------------------
+
+class TerminalScreenTests(unittest.TestCase):
+    def test_plain_text_lands_at_cursor(self):
+        s = TerminalScreen(rows=4, cols=10)
+        s.feed(b"hello")
+        lines = s.render_lines()
+        self.assertEqual(lines[0].plain, "hello     ")
+        self.assertEqual(s.cursor, (5, 0))
+
+    def test_ansi_color_preserved(self):
+        s = TerminalScreen(rows=2, cols=10)
+        s.feed(b"\x1b[31mR\x1b[32mG\x1b[0m")
+        lines = s.render_lines()
+        # Two distinct-style spans in line 0. Iterate spans via .spans.
+        spans = [sp for sp in lines[0].spans]
+        # At least one span with red and one with green
+        styles = [str(sp.style) for sp in spans]
+        self.assertTrue(any("red" in st or "color(1)" in st for st in styles),
+                        f"no red span in {styles!r}")
+        self.assertTrue(any("green" in st or "color(2)" in st for st in styles),
+                        f"no green span in {styles!r}")
+
+    def test_newline_advances_cursor(self):
+        s = TerminalScreen(rows=4, cols=10)
+        s.feed(b"line1\r\nline2")
+        lines = s.render_lines()
+        self.assertEqual(lines[0].plain.rstrip(), "line1")
+        self.assertEqual(lines[1].plain.rstrip(), "line2")
+
+    def test_resize_keeps_cursor_valid(self):
+        s = TerminalScreen(rows=4, cols=10)
+        s.feed(b"hello")
+        s.resize(rows=6, cols=20)
+        self.assertEqual(s.rows, 6)
+        self.assertEqual(s.cols, 20)
+        lines = s.render_lines()
+        self.assertEqual(len(lines), 6)
+        self.assertEqual(len(lines[0].plain), 20)
+
+    def test_app_cursor_mode_tracked(self):
+        s = TerminalScreen()
+        self.assertFalse(s.app_cursor)
+        s.feed(b"\x1b[?1h")
+        self.assertTrue(s.app_cursor)
+        s.feed(b"\x1b[?1l")
+        self.assertFalse(s.app_cursor)
+
+    def test_mouse_modes_tracked(self):
+        s = TerminalScreen()
+        self.assertFalse(s.mouse_mode.tracking)
+        self.assertFalse(s.mouse_mode.sgr)
+        s.feed(b"\x1b[?1000;1006h")
+        self.assertTrue(s.mouse_mode.tracking)
+        self.assertTrue(s.mouse_mode.sgr)
+        s.feed(b"\x1b[?1000l")
+        self.assertFalse(s.mouse_mode.tracking)
+
+    def test_cursor_overlay_inverts_single_cell(self):
+        s = TerminalScreen(rows=2, cols=5)
+        s.feed(b"abc")  # cursor now at (3, 0)
+        lines = s.render_lines()
+        # The cell at cursor has a "reverse" style applied.
+        # Find the span covering cursor_x=3.
+        cursor_x = s.cursor[0]
+        inverted = False
+        for sp in lines[0].spans:
+            if sp.start <= cursor_x < sp.end and "reverse" in str(sp.style):
+                inverted = True
+                break
+        self.assertTrue(inverted, "cursor cell should be reverse-styled")
+
+
+# --- Input (keys) ---------------------------------------------------------
+
+class KeyTranslationTests(unittest.TestCase):
+    def test_printable(self):
+        self.assertEqual(key_to_bytes("a", "a"), b"a")
+
+    def test_enter_is_cr(self):
+        self.assertEqual(key_to_bytes("enter"), b"\r")
+
+    def test_backspace_is_del(self):
+        self.assertEqual(key_to_bytes("backspace"), b"\x7f")
+
+    def test_tab_and_shift_tab(self):
+        self.assertEqual(key_to_bytes("tab"), b"\t")
+        self.assertEqual(key_to_bytes("shift+tab"), b"\x1b[Z")
+
+    def test_arrow_default_is_csi(self):
+        self.assertEqual(key_to_bytes("up"), b"\x1b[A")
+        self.assertEqual(key_to_bytes("down"), b"\x1b[B")
+        self.assertEqual(key_to_bytes("right"), b"\x1b[C")
+        self.assertEqual(key_to_bytes("left"), b"\x1b[D")
+
+    def test_arrow_app_cursor_uses_ss3(self):
+        self.assertEqual(key_to_bytes("up", app_cursor=True), b"\x1bOA")
+        self.assertEqual(key_to_bytes("left", app_cursor=True), b"\x1bOD")
+
+    def test_ctrl_letter(self):
+        self.assertEqual(key_to_bytes("ctrl+c"), b"\x03")
+        self.assertEqual(key_to_bytes("ctrl+a"), b"\x01")
+        self.assertEqual(key_to_bytes("ctrl+z"), b"\x1a")
+
+    def test_alt_letter(self):
+        self.assertEqual(key_to_bytes("alt+x"), b"\x1bx")
+
+    def test_function_keys(self):
+        self.assertEqual(key_to_bytes("f1"), b"\x1bOP")
+        self.assertEqual(key_to_bytes("f12"), b"\x1b[24~")
+
+    def test_unknown_returns_none(self):
+        self.assertIsNone(key_to_bytes("weird-key"))
+
+    def test_unicode_character(self):
+        self.assertEqual(key_to_bytes("é", "é"), "é".encode("utf-8"))
+
+
+# --- Input (mouse) --------------------------------------------------------
+
+class MouseEncodingTests(unittest.TestCase):
+    def test_no_tracking_no_bytes(self):
+        mode = MouseMode()  # all off
+        self.assertIsNone(
+            mouse_press_to_bytes(MouseButton.LEFT, 5, 3, mode)
+        )
+
+    def test_sgr_left_click(self):
+        mode = MouseMode(tracking=True, sgr=True)
+        # 0-based (5,3) -> 1-based (6,4)
+        self.assertEqual(
+            mouse_press_to_bytes(MouseButton.LEFT, 5, 3, mode),
+            b"\x1b[<0;6;4M",
+        )
+
+    def test_sgr_release(self):
+        mode = MouseMode(tracking=True, sgr=True)
+        self.assertEqual(
+            mouse_release_to_bytes(5, 3, mode),
+            b"\x1b[<0;6;4m",
+        )
+
+    def test_sgr_wheel_up(self):
+        mode = MouseMode(tracking=True, sgr=True)
+        self.assertEqual(
+            mouse_press_to_bytes(MouseButton.WHEEL_UP, 0, 0, mode),
+            b"\x1b[<64;1;1M",
+        )
+
+    def test_sgr_wheel_down(self):
+        mode = MouseMode(tracking=True, sgr=True)
+        self.assertEqual(
+            mouse_press_to_bytes(MouseButton.WHEEL_DOWN, 0, 0, mode),
+            b"\x1b[<65;1;1M",
+        )
+
+    def test_legacy_x10_format(self):
+        mode = MouseMode(tracking=True, sgr=False)
+        got = mouse_press_to_bytes(MouseButton.LEFT, 5, 3, mode)
+        # ESC [ M  <cb>  <cx>  <cy>  -- all offset by 32
+        self.assertEqual(got[:3], b"\x1b[M")
+        self.assertEqual(got[3], 32 + 0)
+        self.assertEqual(got[4], 32 + 6)
+        self.assertEqual(got[5], 32 + 4)
+
+    def test_legacy_clamps_to_protocol_max(self):
+        mode = MouseMode(tracking=True, sgr=False)
+        got = mouse_press_to_bytes(MouseButton.LEFT, 500, 500, mode)
+        # Legacy can't exceed 223, so should clamp.
+        self.assertEqual(got[4], 32 + 223)
+        self.assertEqual(got[5], 32 + 223)
+
+
+# --- Batcher --------------------------------------------------------------
+
+class RefreshBatcherTests(unittest.TestCase):
+    def test_no_bytes_no_refresh(self):
+        b = RefreshBatcher()
+        self.assertFalse(b.should_refresh_now(now=0.0))
+
+    def test_first_chunk_refreshes_immediately(self):
+        b = RefreshBatcher(min_interval=0.01, max_defer=0.05)
+        b.on_bytes(10, now=0.0)
+        self.assertTrue(b.should_refresh_now(now=0.0))
+
+    def test_rapid_chunks_coalesce_under_min_interval(self):
+        b = RefreshBatcher(min_interval=0.01, max_defer=0.05)
+        b.on_bytes(10, now=0.0)
+        self.assertTrue(b.should_refresh_now(now=0.0))
+        b.mark_refreshed(now=0.0)
+        # New bytes arrive quickly — should NOT refresh.
+        b.on_bytes(10, now=0.002)
+        self.assertFalse(b.should_refresh_now(now=0.002))
+        b.on_bytes(10, now=0.004)
+        self.assertFalse(b.should_refresh_now(now=0.004))
+        # After min_interval elapses, refresh fires.
+        self.assertTrue(b.should_refresh_now(now=0.011))
+
+    def test_max_defer_fires_under_sustained_load(self):
+        b = RefreshBatcher(min_interval=0.01, max_defer=0.03)
+        b.on_bytes(10, now=0.0)
+        b.mark_refreshed(now=0.0)
+        b.on_bytes(10, now=0.001)
+        # We're still below min_interval...
+        self.assertFalse(b.should_refresh_now(now=0.005))
+        # ...but max_defer measured since pending_since forces a refresh.
+        self.assertTrue(b.should_refresh_now(now=0.031))
+
+    def test_mark_refreshed_clears_pending(self):
+        b = RefreshBatcher()
+        b.on_bytes(42, now=0.0)
+        self.assertEqual(b.pending_bytes(), 42)
+        flushed = b.mark_refreshed(now=0.0)
+        self.assertEqual(flushed, 42)
+        self.assertEqual(b.pending_bytes(), 0)
+
+    def test_coalesce_count(self):
+        """10 tiny chunks inside min_interval → exactly 1 refresh."""
+        b = RefreshBatcher(min_interval=0.01, max_defer=0.05)
+        refresh_count = 0
+        for i in range(10):
+            t = 0.0 + i * 0.0005   # 0.0, 0.0005, ... all under 0.005
+            b.on_bytes(1, now=t)
+            if b.should_refresh_now(t):
+                b.mark_refreshed(t)
+                refresh_count += 1
+        # Drain anything remaining at end.
+        if b.should_refresh_now(0.02):
+            b.mark_refreshed(0.02)
+            refresh_count += 1
+        self.assertEqual(refresh_count, 2,
+            "expected 1 initial + 1 drain refresh, got %d" % refresh_count)
+
+
+# --- Diagnostics ---------------------------------------------------------
+
+class DiagnosticRecorderTests(unittest.TestCase):
+    def test_records_preview(self):
+        r = DiagnosticRecorder(capacity=10)
+        r.record(EventKind.READ, b"hello world")
+        events = r.recent()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].kind, EventKind.READ)
+        self.assertEqual(events[0].size, 11)
+        self.assertEqual(events[0].preview, b"hello world")
+
+    def test_preview_truncated(self):
+        r = DiagnosticRecorder()
+        long = b"x" * 200
+        r.record(EventKind.WRITE, long)
+        ev = r.recent()[0]
+        self.assertEqual(ev.size, 200)
+        self.assertEqual(len(ev.preview), 32)
+
+    def test_ring_buffer_overwrites(self):
+        r = DiagnosticRecorder(capacity=3)
+        for i in range(5):
+            r.record(EventKind.READ, str(i).encode())
+        events = r.recent()
+        self.assertEqual(len(events), 3)
+        self.assertEqual(events[0].preview, b"2")
+        self.assertEqual(events[-1].preview, b"4")
+
+    def test_recent_limit(self):
+        r = DiagnosticRecorder(capacity=10)
+        for i in range(5):
+            r.record(EventKind.READ, str(i).encode())
+        last2 = r.recent(limit=2)
+        self.assertEqual(len(last2), 2)
+        self.assertEqual(last2[0].preview, b"3")
+        self.assertEqual(last2[1].preview, b"4")
+
+    def test_clear(self):
+        r = DiagnosticRecorder()
+        r.record(EventKind.READ, b"x")
+        r.clear()
+        self.assertEqual(len(r), 0)
+
+    def test_format_produces_readable_text(self):
+        r = DiagnosticRecorder(now=lambda: 12.345)
+        r.record(EventKind.READ, b"hi", note="test")
+        out = r.format()
+        self.assertIn("read", out)
+        self.assertIn("size=    2", out)
+        self.assertIn("test", out)
+
+    def test_injectable_clock(self):
+        t = [0.0]
+        r = DiagnosticRecorder(now=lambda: t[0])
+        r.record(EventKind.READ, b"a")
+        t[0] = 5.0
+        r.record(EventKind.WRITE, b"b")
+        events = r.recent()
+        self.assertEqual(events[0].t, 0.0)
+        self.assertEqual(events[1].t, 5.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interactive_pure.py
+++ b/tests/test_interactive_pure.py
@@ -122,6 +122,39 @@ class TerminalScreenTests(unittest.TestCase):
         lines = s.render_lines()
         self.assertEqual(lines[0].plain[0], "X")
 
+    def test_alt_screen_tracked(self):
+        s = TerminalScreen()
+        self.assertFalse(s.alt_screen)
+        s.feed(b"\x1b[?1049h")
+        self.assertTrue(s.alt_screen)
+        s.feed(b"\x1b[?1049l")
+        self.assertFalse(s.alt_screen)
+        # Legacy variants (47 / 1047) also count.
+        s.feed(b"\x1b[?47h")
+        self.assertTrue(s.alt_screen)
+        s.feed(b"\x1b[?47l")
+        self.assertFalse(s.alt_screen)
+
+    def test_history_scroll_up_then_down(self):
+        s = TerminalScreen(rows=3, cols=10)
+        # Fill more lines than the visible rows so history has content.
+        for i in range(10):
+            s.feed(f"line{i}\r\n".encode())
+        lines_bottom = [l.plain.rstrip() for l in s.render_lines()]
+        moved_up = s.history_up(s.rows)
+        self.assertTrue(moved_up, "history_up should move when we have scrollback")
+        lines_scrolled = [l.plain.rstrip() for l in s.render_lines()]
+        self.assertNotEqual(
+            lines_bottom, lines_scrolled,
+            "history_up must change the rendered frame",
+        )
+
+    def test_history_up_without_scrollback_returns_false(self):
+        s = TerminalScreen(rows=10, cols=20)
+        s.feed(b"hello")
+        # No scrollback yet — nothing to page up to.
+        self.assertFalse(s.history_up(10))
+
     def test_cursor_overlay_inverts_single_cell(self):
         s = TerminalScreen(rows=2, cols=5)
         s.feed(b"abc")  # cursor now at (3, 0)

--- a/tests/test_interactive_pure.py
+++ b/tests/test_interactive_pure.py
@@ -307,16 +307,16 @@ class DiagnosticRecorderTests(unittest.TestCase):
         events = r.recent()
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].kind, EventKind.READ)
-        self.assertEqual(events[0].size, 11)
-        self.assertEqual(events[0].preview, b"hello world")
+        self.assertEqual(events[0].full_size, 11)
+        self.assertEqual(events[0].preview_bytes, b"hello world")
 
     def test_preview_truncated(self):
         r = DiagnosticRecorder()
         long = b"x" * 200
         r.record(EventKind.WRITE, long)
         ev = r.recent()[0]
-        self.assertEqual(ev.size, 200)
-        self.assertEqual(len(ev.preview), 32)
+        self.assertEqual(ev.full_size, 200)
+        self.assertEqual(len(ev.preview_bytes), 32)
 
     def test_ring_buffer_overwrites(self):
         r = DiagnosticRecorder(capacity=3)
@@ -324,8 +324,8 @@ class DiagnosticRecorderTests(unittest.TestCase):
             r.record(EventKind.READ, str(i).encode())
         events = r.recent()
         self.assertEqual(len(events), 3)
-        self.assertEqual(events[0].preview, b"2")
-        self.assertEqual(events[-1].preview, b"4")
+        self.assertEqual(events[0].preview_bytes, b"2")
+        self.assertEqual(events[-1].preview_bytes, b"4")
 
     def test_recent_limit(self):
         r = DiagnosticRecorder(capacity=10)
@@ -333,8 +333,8 @@ class DiagnosticRecorderTests(unittest.TestCase):
             r.record(EventKind.READ, str(i).encode())
         last2 = r.recent(limit=2)
         self.assertEqual(len(last2), 2)
-        self.assertEqual(last2[0].preview, b"3")
-        self.assertEqual(last2[1].preview, b"4")
+        self.assertEqual(last2[0].preview_bytes, b"3")
+        self.assertEqual(last2[1].preview_bytes, b"4")
 
     def test_clear(self):
         r = DiagnosticRecorder()

--- a/tests/test_interactive_widget.py
+++ b/tests/test_interactive_widget.py
@@ -139,6 +139,81 @@ class TerminalWidgetIntegrationTests(unittest.IsolatedAsyncioTestCase):
             app._session.close()
 
 
+class LocalScrollTests(unittest.IsolatedAsyncioTestCase):
+    """PageUp/PageDown/wheel scroll the pyte history locally when the
+    child isn't in alt-screen and hasn't enabled mouse tracking."""
+
+    async def test_pageup_scrolls_history_when_no_alt_screen(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            written: list[bytes] = []
+            orig = app.widget._session.write
+            app.widget._session.write = lambda data, _orig=orig, w=written: (
+                w.append(data), _orig(data),
+            )[1]
+            # Generate enough lines to fill the scrollback.
+            for i in range(30):
+                app.widget._screen.feed(f"line{i}\r\n".encode())
+            await pilot.press("pageup")
+            await pilot.pause(0.02)
+            self.assertEqual(
+                written, [],
+                f"pageup should scroll locally, not forward bytes; got {written!r}",
+            )
+            app._session.close()
+
+    async def test_pageup_forwarded_when_alt_screen(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            # Simulate child entering alt-screen.
+            app.widget._screen.feed(b"\x1b[?1049h")
+            written: list[bytes] = []
+            orig = app.widget._session.write
+            app.widget._session.write = lambda data, _orig=orig, w=written: (
+                w.append(data), _orig(data),
+            )[1]
+            await pilot.press("pageup")
+            await pilot.pause(0.02)
+            self.assertEqual(
+                written, [b"\x1b[5~"],
+                f"alt-screen pageup must forward to child; got {written!r}",
+            )
+            app._session.close()
+
+    async def test_scroll_wheel_scrolls_history_not_child(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            for i in range(30):
+                app.widget._screen.feed(f"row{i}\r\n".encode())
+            written: list[bytes] = []
+            orig = app.widget._session.write
+            app.widget._session.write = lambda data, _orig=orig, w=written: (
+                w.append(data), _orig(data),
+            )[1]
+            from actor.watch.interactive.input import MouseButton
+            # Pre-scroll: emit wheel-up via the widget's emit path. Since
+            # should_scroll_locally is True, _emit_mouse won't be called —
+            # we need to invoke via the on_mouse_scroll_up handler. Go
+            # through the widget's internals to simulate.
+            # Direct handler call: scroll history instead of emitting bytes.
+            before_bottom_count = 0  # we don't measure directly; just assert no bytes
+            import textual.events as _evs
+            # Build event with minimal required fields.
+            event_cls = _evs.MouseScrollUp
+            # Just use the underlying routing logic — we already verified
+            # scroll-wheel mouse emit in MouseInputTests; here we assert
+            # the opposite branch.
+            # _should_scroll_locally is True (no alt_screen, no tracking).
+            self.assertTrue(app.widget._should_scroll_locally())
+            # Call history_up + bump counter to simulate the handler body.
+            moved = app.widget._screen.history_up(3)
+            self.assertTrue(moved, "should have history to scroll to")
+            app._session.close()
+
+
 class RenderCacheTests(unittest.IsolatedAsyncioTestCase):
     """The widget's render_line cache should build the strip list once
     per _frame_counter and reuse it for every visible row."""

--- a/tests/test_interactive_widget.py
+++ b/tests/test_interactive_widget.py
@@ -1,0 +1,117 @@
+"""Pilot-driven integration tests for TerminalWidget.
+
+These spin up a minimal Textual app hosting a TerminalWidget backed by a
+real PtySession running /bin/cat (or /bin/sh). They verify keystrokes
+reach the child, output is rendered into the pyte buffer, Ctrl+Z posts
+ExitRequested, and child exit posts SessionExited.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import shutil
+import sys
+import unittest
+
+if sys.platform == "win32":
+    raise unittest.SkipTest("PTY not available on Windows")
+
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+
+from actor.watch.interactive.pty_session import PtySession
+from actor.watch.interactive.screen import TerminalScreen
+from actor.watch.interactive.widget import TerminalWidget
+
+
+def _find_binary(name: str) -> str:
+    for base in ("/bin", "/usr/bin"):
+        p = os.path.join(base, name)
+        if os.path.exists(p):
+            return p
+    path = shutil.which(name)
+    if path is None:
+        raise unittest.SkipTest(f"{name} not found on PATH")
+    return path
+
+
+class _HostApp(App):
+    CSS = "Screen { background: $background; }"
+
+    def __init__(self, argv, cwd):
+        super().__init__()
+        self._session = PtySession(argv=argv, cwd=cwd, rows=10, cols=40)
+        self._screen = TerminalScreen(rows=10, cols=40)
+        self.widget = TerminalWidget(self._session, self._screen, id="term")
+        self.exit_requests = 0
+        self.session_exits = []
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(self.widget)
+
+    def on_mount(self) -> None:
+        self._session.spawn()
+        self.widget.focus()
+
+    def on_terminal_widget_exit_requested(self, message):
+        self.exit_requests += 1
+
+    def on_terminal_widget_session_exited(self, message):
+        self.session_exits.append(message.exit_code)
+
+
+class TerminalWidgetIntegrationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_keystroke_reaches_child_and_output_rendered(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            await pilot.press("h", "i", "enter")
+            # Let cat echo back.
+            for _ in range(50):
+                await pilot.pause(0.02)
+                plain = "\n".join(l.plain for l in app._screen.render_lines())
+                if "hi" in plain:
+                    break
+            plain = "\n".join(l.plain for l in app._screen.render_lines())
+            self.assertIn("hi", plain, f"screen did not contain echo; got:\n{plain}")
+            app._session.close()
+
+    async def test_ctrl_z_posts_exit_requested(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            await pilot.press("ctrl+z")
+            # Give the message loop a moment to deliver.
+            await pilot.pause(0.05)
+            self.assertEqual(app.exit_requests, 1)
+            # Session stayed alive — ctrl+z is not forwarded.
+            self.assertFalse(app._session.exited)
+            app._session.close()
+
+    async def test_child_exit_posts_session_exited(self):
+        sh = _find_binary("sh")
+        app = _HostApp([sh, "-c", "exit 3"], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            # Wait for child to exit and message to propagate.
+            for _ in range(100):
+                if app.session_exits:
+                    break
+                await pilot.pause(0.02)
+            self.assertEqual(app.session_exits, [3])
+
+    async def test_resize_changes_both_screen_and_pty(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            # Give the widget its natural size; on_resize was fired once.
+            await pilot.pause(0.02)
+            rows = app._screen.rows
+            cols = app._screen.cols
+            self.assertGreater(rows, 0)
+            self.assertGreater(cols, 0)
+            app._session.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interactive_widget.py
+++ b/tests/test_interactive_widget.py
@@ -212,7 +212,10 @@ class LocalScrollTests(unittest.IsolatedAsyncioTestCase):
             )
             app._session.close()
 
-    async def test_scroll_wheel_scrolls_history_not_child(self):
+    async def test_scroll_wheel_does_not_forward_bytes_in_local_mode(self):
+        """In local-scroll mode the widget defers to Textual's native
+        scrolling (driven by `overflow-y: auto` CSS). What we must
+        guarantee: no mouse bytes are written to the child."""
         cat = _find_binary("cat")
         app = _HostApp([cat], pathlib.Path("/tmp"))
         async with app.run_test(size=(40, 10)) as pilot:
@@ -223,16 +226,19 @@ class LocalScrollTests(unittest.IsolatedAsyncioTestCase):
             app.widget._session.write = lambda data, _orig=orig, w=written: (
                 w.append(data), _orig(data),
             )[1]
-            # Build + dispatch a real MouseScrollUp through the handler.
+            self.assertTrue(app.widget._should_scroll_locally())
             from unittest.mock import MagicMock
             fake = MagicMock(spec_set=["x", "y", "stop"])
             fake.x, fake.y = 1, 1
             await app.widget.on_mouse_scroll_up(fake)
-            fake.stop.assert_called_once()
             self.assertEqual(
                 written, [],
                 "scroll-wheel-up in local mode must not forward bytes to child",
             )
+            # event.stop() is NOT called — Textual's default scroll handler
+            # needs to see the event. (That's the whole point of deferring
+            # to native scrolling.)
+            fake.stop.assert_not_called()
             app._session.close()
 
 
@@ -245,13 +251,13 @@ class RenderCacheTests(unittest.IsolatedAsyncioTestCase):
         app = _HostApp([cat], pathlib.Path("/tmp"))
         async with app.run_test(size=(40, 10)) as pilot:
             calls = {"n": 0}
-            real = app.widget._screen.render_lines
+            real = app.widget._screen.render_all_lines
 
             def counting_render_lines():
                 calls["n"] += 1
                 return real()
 
-            app.widget._screen.render_lines = counting_render_lines  # type: ignore
+            app.widget._screen.render_all_lines = counting_render_lines  # type: ignore
             # Invalidate any cache Textual populated during pilot setup.
             app.widget._cached_strips = None
             app.widget._cached_at_frame = -1
@@ -273,13 +279,13 @@ class RenderCacheTests(unittest.IsolatedAsyncioTestCase):
         app = _HostApp([cat], pathlib.Path("/tmp"))
         async with app.run_test(size=(40, 10)) as pilot:
             calls = {"n": 0}
-            real = app.widget._screen.render_lines
+            real = app.widget._screen.render_all_lines
 
             def counting_render_lines():
                 calls["n"] += 1
                 return real()
 
-            app.widget._screen.render_lines = counting_render_lines  # type: ignore
+            app.widget._screen.render_all_lines = counting_render_lines  # type: ignore
             app.widget._cached_strips = None
             app.widget._cached_at_frame = -1
             app.widget._first_output_received = True

--- a/tests/test_interactive_widget.py
+++ b/tests/test_interactive_widget.py
@@ -20,6 +20,7 @@ if sys.platform == "win32":
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
 
+from actor.watch.interactive.input import MouseMode
 from actor.watch.interactive.pty_session import PtySession
 from actor.watch.interactive.screen import TerminalScreen
 from actor.watch.interactive.widget import TerminalWidget
@@ -67,14 +68,22 @@ class TerminalWidgetIntegrationTests(unittest.IsolatedAsyncioTestCase):
         app = _HostApp([cat], pathlib.Path("/tmp"))
         async with app.run_test(size=(40, 10)) as pilot:
             await pilot.press("h", "i", "enter")
-            # Let cat echo back.
+            # Cat echoes input; wait for two lines ("hi" on the typed row,
+            # "hi" echoed on the next) or up to 1s.
             for _ in range(50):
                 await pilot.pause(0.02)
-                plain = "\n".join(l.plain for l in app._screen.render_lines())
-                if "hi" in plain:
+                lines = [l.plain.rstrip() for l in app._screen.render_lines()]
+                if lines[0] == "hi" and lines[1] == "hi":
                     break
-            plain = "\n".join(l.plain for l in app._screen.render_lines())
-            self.assertIn("hi", plain, f"screen did not contain echo; got:\n{plain}")
+            lines = [l.plain.rstrip() for l in app._screen.render_lines()]
+            self.assertEqual(
+                lines[0], "hi",
+                f"first row should contain the typed input; got {lines!r}",
+            )
+            self.assertEqual(
+                lines[1], "hi",
+                f"second row should contain cat's echo; got {lines!r}",
+            )
             app._session.close()
 
     async def test_ctrl_z_posts_exit_requested(self):
@@ -82,11 +91,14 @@ class TerminalWidgetIntegrationTests(unittest.IsolatedAsyncioTestCase):
         app = _HostApp([cat], pathlib.Path("/tmp"))
         async with app.run_test(size=(40, 10)) as pilot:
             await pilot.press("ctrl+z")
-            # Give the message loop a moment to deliver.
-            await pilot.pause(0.05)
+            # Poll rather than rely on a fixed timing budget.
+            for _ in range(50):
+                if app.exit_requests >= 1:
+                    break
+                await pilot.pause(0.01)
             self.assertEqual(app.exit_requests, 1)
-            # Session stayed alive — ctrl+z is not forwarded.
-            self.assertFalse(app._session.exited)
+            self.assertFalse(app._session.exited,
+                             "ctrl+z must not forward to the PTY")
             app._session.close()
 
     async def test_child_exit_posts_session_exited(self):
@@ -101,15 +113,84 @@ class TerminalWidgetIntegrationTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(app.session_exits, [3])
 
     async def test_resize_changes_both_screen_and_pty(self):
+        import fcntl, struct, termios
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(60, 20)) as pilot:
+            # First on_resize has fired; widget should have adopted the
+            # available cell size from its mounted container.
+            await pilot.pause(0.02)
+            first_rows = app._screen.rows
+            first_cols = app._screen.cols
+
+            # Pilot can't cleanly shrink a sub-widget; call the same methods
+            # on_resize would call, then verify the PTY's winsize updated.
+            app.widget._screen.resize(rows=12, cols=30)
+            app.widget._session.resize(rows=12, cols=30)
+            await pilot.pause(0.01)
+            packed = fcntl.ioctl(
+                app._session.fd, termios.TIOCGWINSZ, b"\0" * 8,
+            )
+            rows, cols, _, _ = struct.unpack("HHHH", packed)
+            self.assertEqual((rows, cols), (12, 30),
+                             f"PTY winsize not updated; initial was ({first_rows}, {first_cols})")
+            self.assertEqual(app.widget._screen.rows, 12)
+            self.assertEqual(app.widget._screen.cols, 30)
+            app._session.close()
+
+
+class MouseInputTests(unittest.IsolatedAsyncioTestCase):
+    """Verify Textual mouse events reach the PTY as SGR-encoded bytes, and
+    that we don't double-send on click (MouseDown + Click in Textual)."""
+
+    async def test_mouse_down_writes_once(self):
         cat = _find_binary("cat")
         app = _HostApp([cat], pathlib.Path("/tmp"))
         async with app.run_test(size=(40, 10)) as pilot:
-            # Give the widget its natural size; on_resize was fired once.
-            await pilot.pause(0.02)
-            rows = app._screen.rows
-            cols = app._screen.cols
-            self.assertGreater(rows, 0)
-            self.assertGreater(cols, 0)
+            # Enable SGR click tracking as if the child had sent DECSET 1000/1006.
+            app._screen.feed(b"\x1b[?1000;1006h")
+            written: list[bytes] = []
+            orig = app.widget._session.write
+            app.widget._session.write = lambda data, _orig=orig, w=written: (
+                w.append(data), _orig(data),
+            )[1]
+            await pilot.click("#term", offset=(5, 3))
+            await pilot.pause(0.05)
+            press = [b for b in written if b.startswith(b"\x1b[<0;") and b.endswith(b"M")]
+            release = [b for b in written if b.startswith(b"\x1b[<") and b.endswith(b"m")]
+            # Exactly one press per click; no doubles.
+            self.assertEqual(
+                len(press), 1,
+                f"expected one press sequence, got {len(press)}: {written!r}",
+            )
+            self.assertEqual(
+                len(release), 1,
+                f"expected one release sequence, got {len(release)}: {written!r}",
+            )
+            app._session.close()
+
+    async def test_scroll_wheel_emits_wheel_sequence(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            app._screen.feed(b"\x1b[?1000;1006h")
+            written: list[bytes] = []
+            orig = app.widget._session.write
+            app.widget._session.write = lambda data, _orig=orig, w=written: (
+                w.append(data), _orig(data),
+            )[1]
+            app.widget.post_message(
+                __import__("textual.events", fromlist=["MouseScrollUp"]).MouseScrollUp(
+                    widget=app.widget,
+                    x=1, y=1, delta_x=0, delta_y=-1,
+                    button=0, shift=False, meta=False, ctrl=False,
+                    screen_x=1, screen_y=1,
+                )
+            )
+            # Skip if the Textual signature differs across versions; the
+            # important behavior is exercised in pure tests.
+
+            # At a minimum, make sure no exception escaped.
             app._session.close()
 
 

--- a/tests/test_interactive_widget.py
+++ b/tests/test_interactive_widget.py
@@ -169,6 +169,37 @@ class InitialRenderTests(unittest.IsolatedAsyncioTestCase):
             app._session.close()
 
 
+class NativeScrollTests(unittest.IsolatedAsyncioTestCase):
+    """Verify the widget uses ScrollView natively: virtual_size grows
+    with scrollback, render_line indexes via scroll_offset, and live
+    output auto-follows the bottom."""
+
+    async def test_virtual_size_grows_with_scrollback(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(60, 10)) as pilot:
+            await pilot.pause(0.02)
+            # Feed enough lines to exceed the viewport; each _flush_refresh
+            # recomputes virtual_size.
+            for i in range(50):
+                app.widget._on_pty_output(f"line{i:03d}\r\n".encode())
+            await pilot.pause(0.1)
+            rows, _cols = app.widget._screen.rows, app.widget._screen.cols
+            vh = app.widget.virtual_size.height
+            self.assertGreater(
+                vh, rows,
+                f"virtual_size.height={vh} should exceed visible rows={rows} "
+                f"once scrollback exists",
+            )
+            # Scroll to the top — render_line(0) must now show a history row.
+            app.widget.scroll_y = 0.0
+            await pilot.pause(0.02)
+            strip = app.widget.render_line(0)
+            self.assertIn("line0", strip.text,
+                          f"top of scrolled view should show oldest line; got {strip.text!r}")
+            app._session.close()
+
+
 class LocalScrollTests(unittest.IsolatedAsyncioTestCase):
     """PageUp/PageDown/wheel scroll the pyte history locally when the
     child isn't in alt-screen and hasn't enabled mouse tracking."""

--- a/tests/test_interactive_widget.py
+++ b/tests/test_interactive_widget.py
@@ -145,14 +145,24 @@ class InitialRenderTests(unittest.IsolatedAsyncioTestCase):
     fill briefly flashes as a dark box while Textual's first layout
     settles."""
 
-    async def test_blank_until_first_output(self):
+    async def test_placeholder_before_first_output(self):
+        """Before the child produces its first frame, non-centered rows
+        render blank and the middle row shows a "Connecting…" hint so a
+        hung startup isn't an inscrutable blank box."""
         cat = _find_binary("cat")
         app = _HostApp([cat], pathlib.Path("/tmp"))
         async with app.run_test(size=(40, 10)) as pilot:
             app.widget._first_output_received = False
-            strip = app.widget.render_line(0)
-            self.assertEqual(strip.text, " " * app.widget.size.width,
-                             "first render must be blank before any PTY output")
+            top = app.widget.render_line(0)
+            self.assertTrue(
+                top.text.strip() == "",
+                f"non-center rows should be blank; got {top.text!r}",
+            )
+            middle = app.widget.render_line(app.widget.size.height // 2)
+            self.assertIn(
+                "Connecting", middle.text,
+                f"center row should show the placeholder; got {middle.text!r}",
+            )
             # After feeding a byte, subsequent renders use the pyte frame.
             app.widget._on_pty_output(b"X")
             self.assertTrue(app.widget._first_output_received)

--- a/tests/test_interactive_widget.py
+++ b/tests/test_interactive_widget.py
@@ -139,6 +139,26 @@ class TerminalWidgetIntegrationTests(unittest.IsolatedAsyncioTestCase):
             app._session.close()
 
 
+class InitialRenderTests(unittest.IsolatedAsyncioTestCase):
+    """Before the child has produced any output, the widget should
+    render as blank — otherwise the empty pyte cursor + unused column
+    fill briefly flashes as a dark box while Textual's first layout
+    settles."""
+
+    async def test_blank_until_first_output(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            app.widget._first_output_received = False
+            strip = app.widget.render_line(0)
+            self.assertEqual(strip.text, " " * app.widget.size.width,
+                             "first render must be blank before any PTY output")
+            # After feeding a byte, subsequent renders use the pyte frame.
+            app.widget._on_pty_output(b"X")
+            self.assertTrue(app.widget._first_output_received)
+            app._session.close()
+
+
 class LocalScrollTests(unittest.IsolatedAsyncioTestCase):
     """PageUp/PageDown/wheel scroll the pyte history locally when the
     child isn't in alt-screen and hasn't enabled mouse tracking."""
@@ -225,6 +245,9 @@ class RenderCacheTests(unittest.IsolatedAsyncioTestCase):
             # Invalidate any cache Textual populated during pilot setup.
             app.widget._cached_strips = None
             app.widget._cached_at_frame = -1
+            # Skip the pre-first-output blank-render guard for the cache
+            # test: we want to exercise the strip-builder path.
+            app.widget._first_output_received = True
             calls["n"] = 0
             for y in range(app.widget._screen.rows):
                 app.widget.render_line(y)
@@ -249,6 +272,7 @@ class RenderCacheTests(unittest.IsolatedAsyncioTestCase):
             app.widget._screen.render_lines = counting_render_lines  # type: ignore
             app.widget._cached_strips = None
             app.widget._cached_at_frame = -1
+            app.widget._first_output_received = True
             calls["n"] = 0
             app.widget.render_line(0)
             app.widget._frame_counter += 1

--- a/tests/test_interactive_widget.py
+++ b/tests/test_interactive_widget.py
@@ -193,24 +193,16 @@ class LocalScrollTests(unittest.IsolatedAsyncioTestCase):
             app.widget._session.write = lambda data, _orig=orig, w=written: (
                 w.append(data), _orig(data),
             )[1]
-            from actor.watch.interactive.input import MouseButton
-            # Pre-scroll: emit wheel-up via the widget's emit path. Since
-            # should_scroll_locally is True, _emit_mouse won't be called —
-            # we need to invoke via the on_mouse_scroll_up handler. Go
-            # through the widget's internals to simulate.
-            # Direct handler call: scroll history instead of emitting bytes.
-            before_bottom_count = 0  # we don't measure directly; just assert no bytes
-            import textual.events as _evs
-            # Build event with minimal required fields.
-            event_cls = _evs.MouseScrollUp
-            # Just use the underlying routing logic — we already verified
-            # scroll-wheel mouse emit in MouseInputTests; here we assert
-            # the opposite branch.
-            # _should_scroll_locally is True (no alt_screen, no tracking).
-            self.assertTrue(app.widget._should_scroll_locally())
-            # Call history_up + bump counter to simulate the handler body.
-            moved = app.widget._screen.history_up(3)
-            self.assertTrue(moved, "should have history to scroll to")
+            # Build + dispatch a real MouseScrollUp through the handler.
+            from unittest.mock import MagicMock
+            fake = MagicMock(spec_set=["x", "y", "stop"])
+            fake.x, fake.y = 1, 1
+            await app.widget.on_mouse_scroll_up(fake)
+            fake.stop.assert_called_once()
+            self.assertEqual(
+                written, [],
+                "scroll-wheel-up in local mode must not forward bytes to child",
+            )
             app._session.close()
 
 

--- a/tests/test_interactive_widget.py
+++ b/tests/test_interactive_widget.py
@@ -139,6 +139,60 @@ class TerminalWidgetIntegrationTests(unittest.IsolatedAsyncioTestCase):
             app._session.close()
 
 
+class RenderCacheTests(unittest.IsolatedAsyncioTestCase):
+    """The widget's render_line cache should build the strip list once
+    per _frame_counter and reuse it for every visible row."""
+
+    async def test_cache_hits_across_rows_in_same_frame(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            calls = {"n": 0}
+            real = app.widget._screen.render_lines
+
+            def counting_render_lines():
+                calls["n"] += 1
+                return real()
+
+            app.widget._screen.render_lines = counting_render_lines  # type: ignore
+            # Invalidate any cache Textual populated during pilot setup.
+            app.widget._cached_strips = None
+            app.widget._cached_at_frame = -1
+            calls["n"] = 0
+            for y in range(app.widget._screen.rows):
+                app.widget.render_line(y)
+            self.assertEqual(
+                calls["n"], 1,
+                "render_line should build once per frame and cache; "
+                f"got {calls['n']} calls for {app.widget._screen.rows} rows",
+            )
+            app._session.close()
+
+    async def test_cache_invalidates_on_frame_bump(self):
+        cat = _find_binary("cat")
+        app = _HostApp([cat], pathlib.Path("/tmp"))
+        async with app.run_test(size=(40, 10)) as pilot:
+            calls = {"n": 0}
+            real = app.widget._screen.render_lines
+
+            def counting_render_lines():
+                calls["n"] += 1
+                return real()
+
+            app.widget._screen.render_lines = counting_render_lines  # type: ignore
+            app.widget._cached_strips = None
+            app.widget._cached_at_frame = -1
+            calls["n"] = 0
+            app.widget.render_line(0)
+            app.widget._frame_counter += 1
+            app.widget.render_line(0)
+            self.assertEqual(
+                calls["n"], 2,
+                f"frame bump should invalidate the cache; got {calls['n']} calls",
+            )
+            app._session.close()
+
+
 class MouseInputTests(unittest.IsolatedAsyncioTestCase):
     """Verify Textual mouse events reach the PTY as SGR-encoded bytes, and
     that we don't double-send on click (MouseDown + Click in Textual)."""
@@ -179,18 +233,16 @@ class MouseInputTests(unittest.IsolatedAsyncioTestCase):
             app.widget._session.write = lambda data, _orig=orig, w=written: (
                 w.append(data), _orig(data),
             )[1]
-            app.widget.post_message(
-                __import__("textual.events", fromlist=["MouseScrollUp"]).MouseScrollUp(
-                    widget=app.widget,
-                    x=1, y=1, delta_x=0, delta_y=-1,
-                    button=0, shift=False, meta=False, ctrl=False,
-                    screen_x=1, screen_y=1,
-                )
+            # Invoke the handler directly rather than forging a Textual event —
+            # the event signature varies across versions, but the handler is
+            # the part we own.
+            from actor.watch.interactive.input import MouseButton
+            app.widget._emit_mouse(MouseButton.WHEEL_UP, x=2, y=3)
+            await pilot.pause(0.02)
+            self.assertEqual(
+                written, [b"\x1b[<64;3;4M"],
+                f"expected SGR wheel-up sequence at (x+1=3, y+1=4); got {written!r}",
             )
-            # Skip if the Textual signature differs across versions; the
-            # important behavior is exercised in pure tests.
-
-            # At a minimum, make sure no exception escaped.
             app._session.close()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ name = "actor-sh"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
+    { name = "pyte" },
     { name = "textual" },
     { name = "textual-serve" },
 ]
@@ -14,6 +15,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=1.0" },
+    { name = "pyte", specifier = ">=0.8.1" },
     { name = "textual", specifier = ">=1.0" },
     { name = "textual-serve", specifier = ">=1.0" },
 ]
@@ -1217,6 +1219,18 @@ crypto = [
 ]
 
 [[package]]
+name = "pyte"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ab/b599762933eba04de7dc5b31ae083112a6c9a9db15b01d3109ad797559d9/pyte-0.8.2.tar.gz", hash = "sha256:5af970e843fa96a97149d64e170c984721f20e52227a2f57f0a54207f08f083f", size = 92301, upload-time = "2023-11-12T09:33:43.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/d0/bb522283b90853afbf506cd5b71c650cf708829914efd0003d615cf426cd/pyte-0.8.2-py3-none-any.whl", hash = "sha256:85db42a35798a5aafa96ac4d8da78b090b2c933248819157fc0e6f78876a0135", size = 31627, upload-time = "2023-11-12T09:33:41.096Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1506,6 +1520,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #5. Adds an embedded terminal to `actor watch` so you can resume any actor's Claude/Codex session live inside the TUI, and replaces the old `os.execvp`-based `actor run -i` with a tracked subprocess that records a Run row.

## Commits

1. **`Add cmd_interactive, replace execvp-based -i`** — CLI path switches to `subprocess.Popen` with TTY inheritance. Each interactive run gets a Run row with prompt `*interactive*`, exit code, and STOPPED-race handling. New `Agent.interactive_argv(session_id, config)` builds the per-agent resume argv so `cmd_interactive` is agent-agnostic.

2. **`Add pure terminal-emulator core`** — four unit-testable modules under `src/actor/watch/interactive/`:
   - `screen.py`: pyte.HistoryScreen + rich.Text rendering, DECSET sniffing (mouse tracking, app cursor)
   - `input.py`: key translation (CSI / SS3 / ctrl / alt) + mouse encoder (SGR + legacy X10, click / release / wheel)
   - `batcher.py`: refresh coalescer with min-interval and max-defer
   - `diagnostics.py`: ring buffer of timestamped I/O events
   - **38 unit tests** — no subprocess, no Textual harness.

3. **`Add PtySession`** — `pty.fork` + `execvpe`, non-blocking fd with `asyncio.add_reader`, write / resize / kill / reap. Guarantees `on_exit` fires exactly once. **7 integration tests** using `/bin/cat` and `/bin/sh`.

4. **`Embed live Claude/Codex sessions in actor watch`** — `TerminalWidget` + `InteractiveSessionManager` + `Database.get_run` helper. Watch gets an Enter binding (start/show interactive for selected actor), Ctrl+Z leaves without killing the subprocess, Ctrl+Shift+D dumps the diagnostics ring buffer to stderr, all subprocesses are killed on watch quit. **4 Pilot-driven widget tests**.

5. **`Document interactive mode in SKILL.md and CLAUDE.md`**.

## Behavior

- **Preconditions** (Enter): actor not RUNNING, has a session, agent binary on PATH. Otherwise → error toast.
- **Ctrl+Z**: leave widget, session stays alive in background; reselect the actor to come back.
- **Multiple actors**: each has its own PtySession + pyte screen; switching the tree selection switches the mounted widget. Background sessions keep consuming output so scrollback isn't lost.
- **Process exit**: widget posts `SessionExited`, manager closes the session, Run row marked DONE or ERROR based on exit code.
- **Watch quit**: `on_unmount` → `manager.close_all()` SIGTERMs everything; Run rows finalized.
- **Serve mode**: should work out of the box — the widget renders rich.Text into the Textual tree, textual-serve serializes that over websocket; mouse + scroll events flow back through Textual's normal event path.

## Testability

The pure layer is the bulk of the logic and fully unit-testable. Flicker, mouse encoding, scrollback, resize semantics all have unit tests with exact byte-level assertions. The `DiagnosticRecorder` is always on at zero cost and provides post-mortem ability via Ctrl+Shift+D.

Integration tests spin up real `/bin/cat` and `/bin/sh` subprocesses to verify the fork/exec/read/write/resize/reap pipeline end-to-end.

## Test plan

- [ ] CI green on this PR (`.venv/bin/python -m unittest discover tests` → 261 tests, 2s locally)
- [ ] Manual: `actor watch`, select an actor with a session, press Enter → terminal appears; type; Ctrl+Z returns to logs; Enter again reopens. Select a different actor, come back — session still alive.
- [ ] Manual: `actor run <name> -i` — interactive session in the calling terminal, Run row appears in `actor show`.
- [ ] Manual: `actor watch --serve`, open browser, repeat the above through the web UI.