### PR TITLE
Dim panel borders when unfocused (#25)

### DIFF
--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -51,7 +51,11 @@ class ActorWatchApp(App):
     }
     #actor-panel {
         width: 33;
-        border: blank;
+        /* Dim separator when unfocused so the two panels are visually
+           distinct even when focus is outside the app (modal open,
+           command palette, OS-level blur). Same round shape as the
+           focused state so there's no layout jitter on transition. */
+        border: round $foreground 30%;
         padding: 0 1;
         background: ansi_default;
     }
@@ -67,7 +71,7 @@ class ActorWatchApp(App):
     }
     #detail-panel {
         width: 1fr;
-        border: blank;
+        border: round $foreground 30%;
     }
     #detail-panel:focus-within {
         border: round $primary;

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -14,6 +14,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import (
     DataTable,
     Footer,
+    Header,
     RichLog,
     Static,
     TabbedContent,
@@ -62,12 +63,21 @@ class ActorWatchApp(App):
     #actor-panel:focus-within {
         border: round $primary;
     }
-    #actor-title {
-        text-style: bold;
-        color: $secondary;
-        height: 1;
-        margin-bottom: 1;
+    #app-header {
+        display: none;
         background: ansi_default;
+    }
+    #app-header.-active {
+        display: block;
+    }
+    /* HeaderIcon doubles as the command-palette trigger — we don't
+       want either. HeaderClockSpace reserves 10 cols on the right
+       even when show_clock is False; hiding both keeps the title
+       genuinely centered. */
+    #app-header HeaderIcon,
+    #app-header HeaderClockSpace,
+    #app-header HeaderClock {
+        display: none;
     }
     #detail-panel {
         width: 1fr;
@@ -124,6 +134,8 @@ class ActorWatchApp(App):
         Binding("ctrl+shift+d", "dump_diagnostics", show=False),
     ]
 
+    TITLE = "★ actor.sh"
+
     _prev_statuses: dict[str, Status] = {}
     _current_actors: list[Actor] = []
     _diff_loaded_for: str | None = None
@@ -146,9 +158,9 @@ class ActorWatchApp(App):
         return True
 
     def compose(self) -> ComposeResult:
+        yield Header(id="app-header")
         with Horizontal(id="main-layout"):
             with Vertical(id="actor-panel"):
-                yield Static(" ★ ACTOR.SH", id="actor-title")
                 yield ActorTree()
             with Vertical(id="detail-panel"):
                 with TabbedContent(id="tabs"):
@@ -251,14 +263,17 @@ class ActorWatchApp(App):
 
         main = self.query_one("#main-layout")
         splash = self.query_one("#splash")
+        header = self.query_one("#app-header")
         was_splash = self._splash_active
         self._splash_active = not actors
         if self._splash_active:
             main.set_class(False, "-active")
             splash.set_class(True, "-active")
+            header.set_class(False, "-active")
         else:
             main.set_class(True, "-active")
             splash.set_class(False, "-active")
+            header.set_class(True, "-active")
         if was_splash != self._splash_active:
             self.refresh_bindings()
 


### PR DESCRIPTION
## Summary

Both \`#actor-panel\` and \`#detail-panel\` used \`border: blank\` by default and only showed a border via \`:focus-within\`. When focus was outside the app (modal / command palette / OS blur / split-tty) both panels lost all visual distinction.

Switch the default to a dim round border (\`\$foreground 30%\`) and keep the primary-colored round border on focus. Same border shape in both states — no layout jitter when focus moves; just a color change.

## Not in this PR

Issue comment mentions 2-col → 1-col shared divider between panels. That's a separate refactor: needs a shared widget + partial-border CSS + careful handling of rounded corners on focus. Left for a follow-up.

## Focus edge cases considered

- Startup (tree auto-focus) → left bright, right dim ✓
- Tab shortcut switches focus to detail → right bright, left dim ✓
- \`set_focus(None)\` + \`call_after_refresh(tree.focus)\` transition → one-frame both-dim, then left bright. No visual regression vs before (was both blank-invisible) ✓
- Command palette / notifications take focus → both dim (now visible as separate regions) ✓
- Interactive terminal focused → \`:focus-within\` cascades through \`#tabs\` → right panel lights ✓
- Splash screen active → \`main-layout.display=none\`; borders don't render ✓
- No layout jitter because \`blank\` already reserved 1 col per edge

## Test plan

- [ ] CI green
- [ ] \`actor watch\` — borders visible as dim frames when the app first launches; focus moves bright frame between tree and detail as you switch
- [ ] Open a notification → both frames go dim (visible)
- [ ] Close notification → prior pane lights up again