### PR TITLE
Footer: hide non-quit bindings on splash (recompose after settle)

### DIFF
--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -280,16 +280,6 @@ class ActorWatchApp(App):
             # a stale layout and keeps showing the full set.
             self.call_after_refresh(self._refresh_footer_bindings)
 
-    def _refresh_footer_bindings(self) -> None:
-        self.refresh_bindings()
-        # Belt-and-suspenders: force the Footer to recompose so
-        # check_action is re-evaluated for every binding.
-        try:
-            footer = self.query_one(Footer)
-            footer.refresh(recompose=True)
-        except Exception:
-            pass
-
         running = sum(1 for s in statuses.values() if s == Status.RUNNING)
         done = sum(1 for s in statuses.values() if s == Status.DONE)
         errors = sum(1 for s in statuses.values() if s == Status.ERROR)
@@ -301,6 +291,16 @@ class ActorWatchApp(App):
         )
 
         self._refresh_detail()
+
+    def _refresh_footer_bindings(self) -> None:
+        self.refresh_bindings()
+        # Belt-and-suspenders: force the Footer to recompose so
+        # check_action is re-evaluated for every binding.
+        try:
+            footer = self.query_one(Footer)
+            footer.refresh(recompose=True)
+        except Exception:
+            pass
 
     def _refresh_detail(self) -> None:
         actor_list = self.query_one(ActorTree)

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -275,7 +275,20 @@ class ActorWatchApp(App):
             splash.set_class(False, "-active")
             header.set_class(True, "-active")
         if was_splash != self._splash_active:
-            self.refresh_bindings()
+            # Defer so the class-toggle above has settled through the
+            # DOM first; otherwise the Footer re-queries bindings from
+            # a stale layout and keeps showing the full set.
+            self.call_after_refresh(self._refresh_footer_bindings)
+
+    def _refresh_footer_bindings(self) -> None:
+        self.refresh_bindings()
+        # Belt-and-suspenders: force the Footer to recompose so
+        # check_action is re-evaluated for every binding.
+        try:
+            footer = self.query_one(Footer)
+            footer.refresh(recompose=True)
+        except Exception:
+            pass
 
         running = sum(1 for s in statuses.values() if s == Status.RUNNING)
         done = sum(1 for s in statuses.values() if s == Status.DONE)


### PR DESCRIPTION
## Bug

Discarding the last actor puts the UI on the splash screen but the footer still showed the full binding set (\`a Actors  p Palette  i Interactive  l Logs  d Diff  ? Info\`) until the user clicked something in the app. Reported as a regression.

## Cause

We already had:

\`\`\`python
def check_action(self, action, parameters):
    if self._splash_active and action != \"quit\":
        return False
    return True
\`\`\`

and called \`self.refresh_bindings()\` when \`_splash_active\` toggled. That should be enough, but \`refresh_bindings()\` was running in the same tick as the class toggles on \`#main-layout\`, \`#splash\`, and \`#app-header\` — the Footer re-queried bindings against a DOM that hadn't finished reacting to the splash-activation, so \`check_action\` returned before the relevant state was visible, and the old bindings stuck around.

## Fix

Move the refresh into \`call_after_refresh\` so the layout settles first, then both \`refresh_bindings()\` AND an explicit \`footer.refresh(recompose=True)\` — the latter forces the Footer to rebuild its entries and call \`check_action\` again per binding.

## Test plan

- [ ] \`actor watch\`, create an actor, discard it → splash appears and only \`q Quit\` remains in the footer (no click needed).
- [ ] Recreate an actor → all bindings return.