### PR TITLE
Add --version / -V flag to actor CLI

### DIFF
--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -5,6 +5,7 @@ import os
 import sys
 from typing import List, Optional
 
+from . import __version__
 from .errors import ActorError
 from .interfaces import Agent
 from .types import AgentKind, Status
@@ -46,6 +47,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="actor",
         description="Manage coding agents in parallel",
+    )
+    parser.add_argument(
+        "--version", "-V",
+        action="version",
+        version=f"actor-sh {__version__}",
     )
     sub = parser.add_subparsers(dest="command")
 

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -11,8 +11,33 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
+from actor import __version__
 from actor.cli import main
 from actor.errors import ActorError
+
+
+class VersionFlagTests(unittest.TestCase):
+    """`actor --version` / `-V` prints the installed version and exits 0."""
+
+    def _run(self, argv):
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            try:
+                main(argv)
+                code = 0
+            except SystemExit as e:
+                code = e.code if isinstance(e.code, int) else 1
+        return buf.getvalue(), code
+
+    def test_long_flag_prints_version(self):
+        out, code = self._run(["--version"])
+        self.assertEqual(code, 0)
+        self.assertIn(f"actor-sh {__version__}", out)
+
+    def test_short_flag_prints_version(self):
+        out, code = self._run(["-V"])
+        self.assertEqual(code, 0)
+        self.assertIn(f"actor-sh {__version__}", out)
 
 
 class NewCommandTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- The bundled skill (`src/actor/_skill/cli.md`, `SKILL.md`) tells users to run `actor --version` as a liveness check, but the flag was never wired up — it errored out with `unrecognized arguments`.
- Adds `--version` / `-V` via argparse's built-in version action, sourcing the string from `actor.__version__` so the CLI matches the MCP server's announced version and the SKILL.md deploy stamp (all three derive from hatch-vcs).

Output: `actor-sh 0.1.2.dev8+g433cedf1c` (or whatever the installed build resolves to).

## Test plan
- [x] `uv run python -m unittest discover tests` — 295 passed
- [x] `uv run actor --version` prints version, exits 0
- [x] `uv run actor -V` prints version, exits 0
- [x] `uv run actor --help` shows `--version` in usage line

🤖 Generated with [Claude Code](https://claude.com/claude-code)