### PR TITLE
Config file system + actor templates (#29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Manages multiple Claude/Codex agents running in isolated git worktrees.
 src/actor/               # Python package
   cli.py                 # argparse CLI, command dispatch
   commands.py            # Command implementations (cmd_new, cmd_run, cmd_list, etc.)
+  config.py              # KDL loader for ~/.actor/settings.kdl + <repo>/.actor/settings.kdl — templates
   setup.py               # 'actor setup' / 'actor update' — deploy bundled skill + register MCP
   server.py              # MCP server entry point
   db.py                  # SQLite database layer (~/.actor/actor.db)
@@ -114,6 +115,35 @@ Local dev installs (`uv sync`) get a PEP 440 dev version like
 `0.1.4.dev3+g1a2b3c4` derived from git state at install time, so
 `actor --version`, the MCP server's announced version, and the deployed
 SKILL.md all agree and the drift check still works.
+
+## Config files & templates
+
+`actor new` reads `~/.actor/settings.kdl` (user-wide) and
+`<repo>/.actor/settings.kdl` (project-local, discovered by walking up from
+CWD). Project values win when the same key appears in both. Missing files
+are ignored silently; malformed KDL raises `ConfigError` with the path.
+
+Templates are named presets for `actor new`:
+
+```kdl
+template "qa" {
+    agent "claude"
+    model "opus"
+    prompt "You're a QA engineer. Write tests for the changed code."
+}
+```
+
+Usage: `actor new foo --template qa` applies the template's agent + config +
+prompt. Explicit CLI flags (`--agent`, `--model`, `--config`, positional
+prompt / stdin) override the template. `agent` and `prompt` are promoted to
+top-level fields; every other child is stored as a config key (values
+coerced to strings).
+
+Unknown top-level nodes (e.g. `hooks`, `agent`, `alias`) are silently
+ignored for forward-compat with follow-up tickets.
+
+Load programmatically via `actor.config.load_config(cwd=..., home=...)` —
+both args default to `Path.cwd()` / `$HOME` so tests can inject temp dirs.
 
 ## Interactive mode
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,10 @@ tests/
   test_*.py              # unittest suites
 spec/
   V2.md                  # V2 vision (MCP server, channels, dashboard, plugin)
+  PLAN.md                # Plan root index
   PLAN-STAGE1.md         # Stage 1 implementation plan (minimal MCP server)
+  PLAN-CONFIG-SYSTEM.md  # Config / templates implementation plan
+  DASHBOARD.md           # Watch dashboard spec
 ```
 
 ## Development setup
@@ -83,7 +86,8 @@ actor update                                      # refreshes deployed skill fil
 ## Running tests
 
 ```bash
-uv run python -m unittest tests.test_actor
+uv run python -m unittest discover tests      # full suite
+uv run python -m unittest tests.test_actor    # single module
 ```
 
 Tests use in-memory SQLite and fake implementations (FakeAgent, FakeGit, FakeProcessManager) — no real processes or git repos needed.
@@ -167,6 +171,6 @@ dumps the DiagnosticRecorder ring buffer to stderr for post-mortems.
 ## Architecture notes
 
 - Commands are pure functions that take a `Database` + interfaces and return strings. Side effects go through the `Agent`, `GitOps`, and `ProcessManager` ABCs — this is what makes everything testable with fakes.
-- No dependencies beyond Python 3.9+ stdlib for the core package.
+- Requires Python 3.10+. Runtime deps: `kdl-py` (config parser), `mcp` (MCP server), `pyte` / `textual` / `textual-serve` (watch dashboard + embedded TTYs).
 - Actors spawned by other actors are tracked via the `parent` column. The `ACTOR_NAME` env var is set before launching an agent, so child actors automatically record their parent. `discard` cascades recursively — stops running children, then deletes.
 - DB migrations run on open (see `db.py` after schema creation). New columns are added via `ALTER TABLE` if missing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,10 @@ SKILL.md all agree and the drift check still works.
 CWD). Project values win when the same key appears in both. Missing files
 are ignored silently; malformed KDL raises `ConfigError` with the path.
 
+There is no `actor init` — create the file by hand (the `.actor/`
+directory is also used for worktrees and the SQLite DB, so it typically
+already exists).
+
 Templates are named presets for `actor new`:
 
 ```kdl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
     { name = "Markus Ecker" },
 ]
 dependencies = [
+    "kdl-py>=1.2.0",
     "mcp>=1.0",
     "pyte>=0.8.1",
     "textual>=1.0",

--- a/spec/PLAN-CONFIG-SYSTEM.md
+++ b/spec/PLAN-CONFIG-SYSTEM.md
@@ -1,0 +1,1102 @@
+# Config File System + Templates — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `~/.actor/settings.kdl` + `<project>/.actor/settings.kdl` config files, a `Template` system, and a `--template` flag for `actor new`.
+
+**Architecture:** New pure-Python module `src/actor/config.py` loads KDL files via the `kdl-py` parser, exposes an `AppConfig` dataclass with `templates: dict[str, Template]`. The CLI layer (`cli.py`) calls `load_config()` once per invocation and passes the result down to `cmd_new`. Project file is found by walking up from cwd (git-style). Project templates of the same name override user templates.
+
+**Tech Stack:** Python 3.10+, `kdl-py>=1.2.0` (pure-python KDL v1 parser), `unittest`, `dataclasses`, `pathlib`. No other new dependencies.
+
+**Scope strictly per ticket #29:** config files + templates + `--template` CLI flag.
+
+**Out of scope (follow-ups):**
+- Hooks (#30) — explicitly skip any `hooks { ... }` nodes at parse time with a comment noting the follow-up.
+- Per-agent `agent "claude" { default-config { ... } }` blocks (#31) — skip at parse time.
+- Aliases (#33) — skip at parse time.
+- Resources — dropped from the roadmap.
+- MCP `new_actor` tool keeps current signature — templates are CLI-only for now.
+
+---
+
+## File Structure
+
+**Files created:**
+- `src/actor/config.py` — parses KDL, exposes `AppConfig` / `Template` dataclasses and `load_config()`.
+- `tests/test_config.py` — unittest suite for `config.py`.
+- `tests/__init__.py` — empty marker file; prevents `kdl-py`'s bundled `tests/` package from shadowing the project's tests during `unittest discover`. (See "KDL parser packaging workaround" below.)
+
+**Files modified:**
+- `pyproject.toml` — add `kdl-py>=1.2.0` to `[project].dependencies`.
+- `src/actor/__init__.py` — export `AppConfig`, `Template`, `load_config` for test use.
+- `src/actor/commands.py` — `cmd_new` accepts optional `template_name` + `app_config` kwargs; applies template before CLI overrides.
+- `src/actor/cli.py` — add `--template` to `new` subparser; call `load_config()`; pass it to `cmd_new`; template prompt used as fallback when no CLI arg and no stdin.
+- `tests/test_actor.py` — new `TestCmdNewTemplate` class covering template application + CLI override precedence.
+- `tests/test_cli_and_mcp.py` — tests for `--template` argparse wiring.
+- `CLAUDE.md` — new "Config files" section describing layout + `--template`.
+- `src/actor/_skill/SKILL.md` — new section on templates so agents know how to surface them to users.
+
+---
+
+## KDL parser packaging workaround
+
+The `kdl-py` 1.2.0 wheel ships a top-level `tests/` package inside `site-packages` (`kdl_py-1.2.0-py3-none-any.whl` → `tests/__init__.py`, `tests/run.py`). Once installed, `import tests` resolves to that site-packages package, shadowing the project's `tests/` directory. `tests/test_interactive_manager.py:67` imports `from tests.test_actor import FakeGit`, which then fails.
+
+**Fix:** add an empty `tests/__init__.py` to the project. Making our `tests/` a real regular package (not a namespace package) gives it precedence on `sys.path[0]` (the cwd injected by `python -m unittest discover tests`). Verified locally: with `tests/__init__.py` present, all 295 tests pass with `kdl-py` installed.
+
+---
+
+## Data shapes
+
+```python
+# src/actor/config.py
+
+@dataclass
+class Template:
+    name: str
+    agent: Optional[str] = None      # "claude" | "codex" | None
+    prompt: Optional[str] = None     # default prompt for the first run
+    config: Dict[str, str] = field(default_factory=dict)  # model, effort, etc.
+
+
+@dataclass
+class AppConfig:
+    templates: Dict[str, Template] = field(default_factory=dict)
+
+
+def load_config(
+    cwd: Optional[Path] = None,
+    home: Optional[Path] = None,
+) -> AppConfig:
+    """Load user + project settings.kdl, with project winning.
+
+    cwd defaults to Path.cwd(); home defaults to Path(os.environ['HOME']).
+    Both kwargs exist for testability — tests pass tmp dirs.
+    Missing files are silently skipped. Malformed files raise ConfigError.
+    """
+```
+
+The loader is idempotent and pure (given the same disk state, same result). Every CLI invocation calls `load_config()` once and passes the result down.
+
+---
+
+## Precedence applied in `cmd_new`
+
+The ticket lists six layers. Out-of-scope layers (hooks, per-agent, aliases) are not implemented, so the layers that actually compose here are:
+
+1. Hard-coded defaults (existing — `AgentKind.from_str("claude")` default in `cli.py`, empty config dict).
+2. User `~/.actor/settings.kdl` templates.
+3. Project `.actor/settings.kdl` templates (overrides user templates of the same name).
+4. `--template X` applied in `cmd_new`: pulls the template's `agent`, `prompt`, `config` dict.
+5. `--config key=value` and `--agent` / `--model` CLI flags (these win over template values).
+6. Per-actor DB config (existing — unchanged).
+
+**Implementation:** `cmd_new` builds its `Config` dict by starting from the template's config (if any), then overlaying CLI pairs. For `agent_name`, `cli.py` changes the argparse default from `"claude"` to `None`; `cmd_new` resolves as: explicit `--agent` → template's `agent` → fallback `"claude"`. For the prompt, CLI arg / stdin still take precedence, and template.prompt is used only when neither is present.
+
+---
+
+## Task list
+
+### Task 1: Add `kdl-py` dependency and `tests/__init__.py`
+
+**Files:**
+- Modify: `pyproject.toml:16`
+- Create: `tests/__init__.py`
+
+- [ ] **Step 1: Add kdl-py to dependencies**
+
+Edit `pyproject.toml`, insert into `[project].dependencies` (after existing entries, before the closing `]`):
+
+```toml
+dependencies = [
+    "mcp>=1.0",
+    "pyte>=0.8.1",
+    "textual>=1.0",
+    "textual-serve>=1.0",
+    "kdl-py>=1.2.0",
+]
+```
+
+- [ ] **Step 2: Create empty `tests/__init__.py`**
+
+```bash
+touch tests/__init__.py
+```
+
+- [ ] **Step 3: Sync environment and verify no regressions**
+
+```bash
+uv sync
+uv run python -m unittest discover tests
+```
+
+Expected: `Ran 295 tests ... OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock tests/__init__.py
+git commit -m "chore: add kdl-py dep + tests/__init__.py for package discovery"
+```
+
+---
+
+### Task 2: Write failing tests for `load_config()` (empty state)
+
+**Files:**
+- Create: `tests/test_config.py`
+
+- [ ] **Step 1: Write the failing test file**
+
+```python
+#!/usr/bin/env python3
+"""Tests for src/actor/config.py — KDL loader + templates."""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from actor.config import AppConfig, Template, load_config
+from actor.errors import ConfigError
+
+
+class TestLoadConfigEmpty(unittest.TestCase):
+
+    def test_no_files_returns_empty_config(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIsInstance(cfg, AppConfig)
+            self.assertEqual(cfg.templates, {})
+
+    def test_missing_user_file_but_project_file_loads_project(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            proj = Path(cwd) / ".actor"
+            proj.mkdir()
+            (proj / "settings.kdl").write_text('template "qa" { agent "claude" }\n')
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("qa", cfg.templates)
+            self.assertEqual(cfg.templates["qa"].agent, "claude")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+uv run python -m unittest tests.test_config -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'actor.config'`.
+
+---
+
+### Task 3: Create minimal `config.py` to pass the empty-state tests
+
+**Files:**
+- Create: `src/actor/config.py`
+
+- [ ] **Step 1: Write the minimal module**
+
+```python
+"""Config file system for actor.sh.
+
+Loads ~/.actor/settings.kdl (user) and <project>/.actor/settings.kdl
+(project), merges them, and exposes the merged AppConfig with its
+templates map. Project config overrides user config on same-key conflict.
+
+Out of scope (see tickets #30 / #31 / #33): hooks, per-agent default-config
+blocks, aliases. Their nodes are skipped at parse time without error.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+import kdl
+
+from .errors import ConfigError
+
+
+@dataclass
+class Template:
+    name: str
+    agent: Optional[str] = None
+    prompt: Optional[str] = None
+    config: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class AppConfig:
+    templates: Dict[str, Template] = field(default_factory=dict)
+
+
+# Config keys that live at the top level of a template block and are
+# promoted to Template attributes rather than stored in Template.config.
+_TEMPLATE_RESERVED = {"agent", "prompt"}
+
+
+def _find_project_config(start: Path) -> Optional[Path]:
+    """Walk up from start looking for .actor/settings.kdl."""
+    try:
+        start = start.resolve(strict=False)
+    except OSError:
+        return None
+    for d in [start, *start.parents]:
+        p = d / ".actor" / "settings.kdl"
+        if p.is_file():
+            return p
+    return None
+
+
+def _parse_template(node, source: Path) -> Template:
+    if not node.args or not isinstance(node.args[0], str):
+        raise ConfigError(
+            f"template block in {source} must have a name (e.g. `template \"qa\" {{ ... }}`)"
+        )
+    name = node.args[0]
+    tpl = Template(name=name)
+    for child in node.nodes:
+        key = child.name
+        if not child.args:
+            raise ConfigError(
+                f"template '{name}' in {source}: '{key}' needs a value"
+            )
+        value = child.args[0]
+        # Coerce KDL types (bool/float/str) into plain strings for the
+        # existing config pipeline, which is stringly-typed.
+        if isinstance(value, bool):
+            value_str = "true" if value else "false"
+        elif isinstance(value, float):
+            # KDL parses all numbers as float; drop trailing .0 for
+            # round-number literals so `effort 2` stays "2" not "2.0".
+            value_str = str(int(value)) if value.is_integer() else str(value)
+        else:
+            value_str = str(value)
+        if key == "agent":
+            tpl.agent = value_str
+        elif key == "prompt":
+            tpl.prompt = value_str
+        else:
+            tpl.config[key] = value_str
+    return tpl
+
+
+def _parse_kdl_file(path: Path) -> AppConfig:
+    try:
+        text = path.read_text()
+    except OSError as e:
+        raise ConfigError(f"could not read {path}: {e}")
+    try:
+        doc = kdl.parse(text)
+    except Exception as e:
+        raise ConfigError(f"parse error in {path}: {e}")
+    cfg = AppConfig()
+    for node in doc.nodes:
+        if node.name == "template":
+            tpl = _parse_template(node, path)
+            cfg.templates[tpl.name] = tpl
+        # Silently ignore hooks / agent / alias — those belong to follow-up
+        # tickets #30 / #31 / #33 and are not implemented here.
+    return cfg
+
+
+def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
+    merged_templates = dict(base.templates)
+    merged_templates.update(over.templates)
+    return AppConfig(templates=merged_templates)
+
+
+def load_config(
+    cwd: Optional[Path] = None,
+    home: Optional[Path] = None,
+) -> AppConfig:
+    """Load user + project settings.kdl and return the merged AppConfig.
+
+    - cwd defaults to Path.cwd()
+    - home defaults to Path(os.environ['HOME']) (or AppConfig() if unset)
+
+    Missing files are skipped silently. Malformed files raise ConfigError.
+    """
+    if cwd is None:
+        cwd = Path.cwd()
+    if home is None:
+        env_home = os.environ.get("HOME")
+        home = Path(env_home) if env_home else None
+
+    merged = AppConfig()
+
+    if home is not None:
+        user_path = home / ".actor" / "settings.kdl"
+        if user_path.is_file():
+            merged = _merge(merged, _parse_kdl_file(user_path))
+
+    project_path = _find_project_config(cwd)
+    if project_path is not None:
+        merged = _merge(merged, _parse_kdl_file(project_path))
+
+    return merged
+```
+
+- [ ] **Step 2: Run the tests and confirm they pass**
+
+```bash
+uv run python -m unittest tests.test_config -v
+```
+
+Expected: 2 tests, both pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/actor/config.py tests/test_config.py
+git commit -m "feat: add config.py with AppConfig + Template + load_config()"
+```
+
+---
+
+### Task 4: Add tests + implementation for precedence, walk-up, parse errors
+
+**Files:**
+- Modify: `tests/test_config.py`
+- Modify: `src/actor/config.py` (only if tests surface a gap)
+
+- [ ] **Step 1: Write additional tests for load_config**
+
+Append to `tests/test_config.py`:
+
+```python
+class TestLoadConfigPrecedence(unittest.TestCase):
+
+    def _write(self, path: Path, body: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    def test_project_overrides_user_same_template_name(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'template "qa" { agent "claude"; model "sonnet" }\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'template "qa" { agent "codex"; model "opus" }\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.templates["qa"].agent, "codex")
+            self.assertEqual(cfg.templates["qa"].config["model"], "opus")
+
+    def test_user_and_project_both_contribute_distinct_templates(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'template "qa" { agent "claude" }\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'template "reviewer" { agent "claude" }\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("qa", cfg.templates)
+            self.assertIn("reviewer", cfg.templates)
+
+
+class TestLoadConfigWalkUp(unittest.TestCase):
+
+    def test_project_config_found_by_walking_up_from_cwd(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as root:
+            proj = Path(root) / ".actor"
+            proj.mkdir()
+            (proj / "settings.kdl").write_text('template "qa" { agent "claude" }\n')
+            deep = Path(root) / "src" / "nested" / "deeper"
+            deep.mkdir(parents=True)
+            cfg = load_config(cwd=deep, home=Path(home))
+            self.assertIn("qa", cfg.templates)
+
+
+class TestLoadConfigErrors(unittest.TestCase):
+
+    def test_malformed_kdl_raises_config_error_with_path(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            bad = Path(cwd) / ".actor" / "settings.kdl"
+            bad.parent.mkdir()
+            bad.write_text('template "qa" { unclosed\n')
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn(str(bad), str(ctx.exception))
+
+    def test_template_without_name_raises(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            bad = Path(cwd) / ".actor" / "settings.kdl"
+            bad.parent.mkdir()
+            bad.write_text("template { agent \"claude\" }\n")
+            with self.assertRaises(ConfigError):
+                load_config(cwd=Path(cwd), home=Path(home))
+
+    def test_template_child_without_value_raises(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            bad = Path(cwd) / ".actor" / "settings.kdl"
+            bad.parent.mkdir()
+            bad.write_text('template "qa" { agent }\n')
+            with self.assertRaises(ConfigError):
+                load_config(cwd=Path(cwd), home=Path(home))
+
+
+class TestLoadConfigParseShapes(unittest.TestCase):
+
+    def test_template_with_all_fields(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'template "qa" {\n'
+                '    agent "claude"\n'
+                '    model "opus"\n'
+                '    effort "max"\n'
+                '    prompt "You\\'re a QA engineer."\n'
+                '}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            tpl = cfg.templates["qa"]
+            self.assertEqual(tpl.agent, "claude")
+            self.assertEqual(tpl.prompt, "You're a QA engineer.")
+            self.assertEqual(tpl.config, {"model": "opus", "effort": "max"})
+
+    def test_bool_value_coerced_to_string(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text('template "x" { strip-api-keys true }\n')
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.templates["x"].config["strip-api-keys"], "true")
+
+    def test_int_value_coerced_without_trailing_zero(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text('template "x" { max-budget-usd 5 }\n')
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.templates["x"].config["max-budget-usd"], "5")
+
+    def test_unknown_top_level_nodes_are_ignored(self):
+        # Forward-compat: hooks/agent/alias exist in follow-up tickets but
+        # should parse as no-ops today rather than erroring.
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'hooks { on-start "echo hi" }\n'
+                'alias "max" template="qa"\n'
+                'template "qa" { agent "claude" }\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("qa", cfg.templates)
+            self.assertEqual(len(cfg.templates), 1)
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+uv run python -m unittest tests.test_config -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_config.py
+git commit -m "test: precedence, walk-up, parse errors for load_config"
+```
+
+---
+
+### Task 5: Re-export new types from the actor package
+
+**Files:**
+- Modify: `src/actor/__init__.py`
+
+- [ ] **Step 1: Add imports and __all__ entries**
+
+Insert under the existing `# Types` block in `src/actor/__init__.py`:
+
+```python
+from .config import AppConfig, Template, load_config
+```
+
+Add to `__all__` (in the "Types" or a new "Config" cluster):
+
+```python
+    # Config
+    "AppConfig",
+    "Template",
+    "load_config",
+```
+
+- [ ] **Step 2: Verify the package re-exports work**
+
+```bash
+uv run python -c "from actor import AppConfig, Template, load_config; print(AppConfig())"
+```
+
+Expected: `AppConfig(templates={})`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/actor/__init__.py
+git commit -m "feat: re-export AppConfig, Template, load_config from actor package"
+```
+
+---
+
+### Task 6: Write failing tests for `cmd_new` template application
+
+**Files:**
+- Modify: `tests/test_actor.py`
+
+- [ ] **Step 1: Add the test class**
+
+Append to `tests/test_actor.py` after the existing `TestCmdNew` class:
+
+```python
+class TestCmdNewTemplate(unittest.TestCase):
+
+    def _db(self) -> Database:
+        return Database.open(":memory:")
+
+    def _cfg_with_qa(self):
+        from actor import AppConfig, Template
+        return AppConfig(templates={
+            "qa": Template(
+                name="qa",
+                agent="codex",
+                prompt="you're qa",
+                config={"model": "opus", "effort": "max"},
+            ),
+        })
+
+    def test_template_applies_agent_and_config(self):
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="fix-auth",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name=None,
+            config_pairs=[],
+            template_name="qa",
+            app_config=self._cfg_with_qa(),
+        )
+        self.assertEqual(actor.agent, AgentKind.CODEX)
+        self.assertEqual(actor.config["model"], "opus")
+        self.assertEqual(actor.config["effort"], "max")
+
+    def test_cli_agent_overrides_template_agent(self):
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="fix-auth",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=[],
+            template_name="qa",
+            app_config=self._cfg_with_qa(),
+        )
+        self.assertEqual(actor.agent, AgentKind.CLAUDE)
+
+    def test_cli_config_pair_overrides_template_config(self):
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="fix-auth",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name=None,
+            config_pairs=["model=haiku"],
+            template_name="qa",
+            app_config=self._cfg_with_qa(),
+        )
+        self.assertEqual(actor.config["model"], "haiku")   # CLI wins
+        self.assertEqual(actor.config["effort"], "max")    # template retained
+
+    def test_unknown_template_raises_config_error(self):
+        from actor.errors import ConfigError
+        db = self._db()
+        git = FakeGit()
+        with self.assertRaises(ConfigError):
+            cmd_new(
+                db, git,
+                name="fix-auth",
+                dir="/tmp",
+                no_worktree=True,
+                base=None,
+                agent_name=None,
+                config_pairs=[],
+                template_name="does-not-exist",
+                app_config=self._cfg_with_qa(),
+            )
+
+    def test_no_template_backward_compatible(self):
+        """Calling cmd_new without template args behaves exactly as before."""
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="plain",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=["model=sonnet"],
+        )
+        self.assertEqual(actor.agent, AgentKind.CLAUDE)
+        self.assertEqual(actor.config["model"], "sonnet")
+
+    def test_agent_name_none_without_template_defaults_to_claude(self):
+        """New None default for --agent resolves to claude when no template."""
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="x",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name=None,
+            config_pairs=[],
+        )
+        self.assertEqual(actor.agent, AgentKind.CLAUDE)
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+uv run python -m unittest tests.test_actor.TestCmdNewTemplate -v
+```
+
+Expected: all 6 fail with `TypeError: cmd_new() got an unexpected keyword argument 'template_name'` (or similar).
+
+---
+
+### Task 7: Update `cmd_new` to accept template args
+
+**Files:**
+- Modify: `src/actor/commands.py:106-182` (the `cmd_new` function)
+
+- [ ] **Step 1: Update the `cmd_new` signature and body**
+
+Change `cmd_new` to:
+
+```python
+def cmd_new(
+    db: Database,
+    git: GitOps,
+    name: str,
+    dir: Optional[str],
+    no_worktree: bool,
+    base: Optional[str],
+    agent_name: Optional[str],
+    config_pairs: List[str],
+    template_name: Optional[str] = None,
+    app_config: Optional["AppConfig"] = None,
+) -> Actor:
+    validate_name(name)
+
+    # Resolve template (if any)
+    template = None
+    if template_name is not None:
+        if app_config is None or template_name not in app_config.templates:
+            raise ConfigError(f"unknown template: '{template_name}'")
+        template = app_config.templates[template_name]
+
+    # Agent: explicit CLI flag wins; otherwise template's agent; otherwise claude
+    if agent_name is None:
+        agent_name = template.agent if (template and template.agent) else "claude"
+    agent_kind = AgentKind.from_str(agent_name)
+
+    if not binary_exists(agent_kind.binary_name):
+        print(f"warning: '{agent_kind.binary_name}' not found on PATH", file=sys.stderr)
+
+    # Config: template's config as base; CLI pairs override
+    config: Dict[str, str] = dict(template.config) if template else {}
+    cli_pairs = parse_config(config_pairs)
+    for k, v in cli_pairs.items():
+        config[k] = v
+    config = _sorted_config(config)
+
+    # ...rest of cmd_new is unchanged (base_dir resolution, worktree, db insert, ...)
+```
+
+Then use `config` in the `Actor(..., config=config, ...)` construction instead of the previous `config = parse_config(config_pairs)`.
+
+The required import additions at the top of `commands.py`:
+
+```python
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from .config import AppConfig
+```
+
+And import `ConfigError` from `.errors` (already imported — verify).
+
+- [ ] **Step 2: Run the template tests and verify they pass**
+
+```bash
+uv run python -m unittest tests.test_actor.TestCmdNewTemplate -v
+```
+
+Expected: all 6 pass.
+
+- [ ] **Step 3: Run the full suite to verify no regressions**
+
+```bash
+uv run python -m unittest discover tests
+```
+
+Expected: `Ran 30X tests ... OK` (the new template tests push the count above 295).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/actor/commands.py tests/test_actor.py
+git commit -m "feat: cmd_new applies --template then CLI overrides"
+```
+
+---
+
+### Task 8: Wire `--template` in the CLI
+
+**Files:**
+- Modify: `src/actor/cli.py:59-84` (the `new` subparser) and `cli.py:334-371` (the `if args.command == "new":` branch).
+
+- [ ] **Step 1: Add the argparse flag and flip --agent default**
+
+In `_build_parser`, inside the `new` subparser block:
+
+```python
+p_new.add_argument("--agent", default=None, help="Coding agent (defaults to template's agent or 'claude')")
+p_new.add_argument("--template", default=None, help="Apply a template from settings.kdl")
+```
+
+Update the epilog to mention `--template`:
+
+```python
+  actor new my-feature --template qa                  Apply the 'qa' template
+```
+
+- [ ] **Step 2: Load app_config and pass template_name into cmd_new**
+
+In `main()`, at the top of the `if args.command == "new":` branch:
+
+```python
+elif args.command == "new":
+    from .config import load_config
+    app_config = load_config()
+    config_pairs = list(args.config)
+    if args.model is not None:
+        config_pairs.append(f"model={args.model}")
+    if not args.strip_api_keys:
+        config_pairs.append("strip-api-keys=false")
+    actor = cmd_new(
+        db, git,
+        name=args.name,
+        dir=args.dir,
+        no_worktree=args.no_worktree,
+        base=args.base,
+        agent_name=args.agent,
+        config_pairs=config_pairs,
+        template_name=args.template,
+        app_config=app_config,
+    )
+    print(f"{actor.name} created ({actor.dir})")
+
+    prompt = args.prompt
+    stdin_consumed = False
+    if prompt is None and not sys.stdin.isatty():
+        prompt = sys.stdin.read().strip()
+        stdin_consumed = True
+    if prompt is None and args.template is not None:
+        tpl = app_config.templates.get(args.template)
+        if tpl is not None and tpl.prompt:
+            prompt = tpl.prompt
+    if stdin_consumed and not prompt:
+        print("error: stdin was empty — expected a prompt", file=sys.stderr)
+        sys.exit(1)
+    if prompt:
+        # ...unchanged cmd_run block
+```
+
+(The `stdin_consumed and not prompt` check must come **after** the template fallback so a template's prompt doesn't mask the stdin-empty error. But note that if stdin was consumed and produced empty, we intentionally do NOT fall back to the template — explicit stdin empty is a user error, not a "no prompt provided" case. So the stdin check still precedes the template check semantically. Restructure as:
+
+```python
+    prompt = args.prompt
+    if prompt is None and not sys.stdin.isatty():
+        stdin_val = sys.stdin.read().strip()
+        if not stdin_val:
+            print("error: stdin was empty — expected a prompt", file=sys.stderr)
+            sys.exit(1)
+        prompt = stdin_val
+    if prompt is None and args.template is not None:
+        tpl = app_config.templates.get(args.template)
+        if tpl is not None and tpl.prompt:
+            prompt = tpl.prompt
+    if prompt:
+        # ...unchanged cmd_run block
+```
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+uv run python -m unittest discover tests
+```
+
+Expected: all tests pass. (test_cli_and_mcp.py uses `MagicMock` — not affected.)
+
+- [ ] **Step 4: Smoke test the CLI end-to-end (optional, not automated)**
+
+```bash
+uv run python -c "
+import tempfile, os
+from pathlib import Path
+with tempfile.TemporaryDirectory() as home:
+    os.environ['HOME'] = home
+    settings = Path(home) / '.actor' / 'settings.kdl'
+    settings.parent.mkdir()
+    settings.write_text('template \"qa\" { agent \"claude\"; model \"opus\" }\n')
+    from actor.config import load_config
+    print(load_config())
+"
+```
+
+Expected: prints an `AppConfig` with the `qa` template.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/actor/cli.py
+git commit -m "feat: wire --template flag in actor new"
+```
+
+---
+
+### Task 9: Add CLI argparse tests for `--template`
+
+**Files:**
+- Modify: `tests/test_cli_and_mcp.py`
+
+- [ ] **Step 1: Add tests that exercise the argparse surface**
+
+Insert into `tests/test_cli_and_mcp.py` inside the `NewCommandTests` class (continue the existing pattern):
+
+```python
+    def test_new_passes_template_arg_to_cmd_new(self):
+        fake_db = MagicMock()
+        fake_actor = MagicMock()
+        fake_actor.name = "foo"
+        fake_actor.dir = "/tmp/actor"
+        cmd_new = MagicMock(return_value=fake_actor)
+        cmd_run = MagicMock(return_value="done")
+
+        from actor import AppConfig, Template
+        fake_app_cfg = AppConfig(templates={
+            "qa": Template(name="qa", agent="claude", prompt="run tests"),
+        })
+
+        stdin = io.StringIO("")
+        stdin.isatty = lambda: True  # type: ignore[assignment]
+
+        with patch("actor.cli.cmd_new", cmd_new), \
+             patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.config.load_config", return_value=fake_app_cfg), \
+             patch("actor.cli.Database") as db_cls, \
+             patch("actor.cli._create_agent", return_value=MagicMock()), \
+             patch("sys.stdin", stdin):
+            db_cls.open.return_value = fake_db
+            try:
+                main(["new", "foo", "--template", "qa"])
+                code = 0
+            except SystemExit as e:
+                code = e.code if isinstance(e.code, int) else 1
+        cmd_new.assert_called_once()
+        kwargs = cmd_new.call_args.kwargs
+        self.assertEqual(kwargs["template_name"], "qa")
+        self.assertIsNotNone(kwargs["app_config"])
+        # Template's prompt becomes the first-run prompt when none given.
+        cmd_run.assert_called_once()
+        self.assertEqual(cmd_run.call_args.kwargs["prompt"], "run tests")
+        self.assertEqual(code, 0)
+
+    def test_new_cli_prompt_beats_template_prompt(self):
+        fake_db = MagicMock()
+        fake_actor = MagicMock()
+        fake_actor.name = "foo"
+        fake_actor.dir = "/tmp/actor"
+        cmd_new = MagicMock(return_value=fake_actor)
+        cmd_run = MagicMock(return_value="done")
+
+        from actor import AppConfig, Template
+        fake_app_cfg = AppConfig(templates={
+            "qa": Template(name="qa", agent="claude", prompt="template says run tests"),
+        })
+
+        stdin = io.StringIO("")
+        stdin.isatty = lambda: True  # type: ignore[assignment]
+
+        with patch("actor.cli.cmd_new", cmd_new), \
+             patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.config.load_config", return_value=fake_app_cfg), \
+             patch("actor.cli.Database") as db_cls, \
+             patch("actor.cli._create_agent", return_value=MagicMock()), \
+             patch("sys.stdin", stdin):
+            db_cls.open.return_value = fake_db
+            main(["new", "foo", "custom prompt", "--template", "qa"])
+        self.assertEqual(cmd_run.call_args.kwargs["prompt"], "custom prompt")
+```
+
+- [ ] **Step 2: Run the CLI tests**
+
+```bash
+uv run python -m unittest tests.test_cli_and_mcp.NewCommandTests -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run the full suite**
+
+```bash
+uv run python -m unittest discover tests
+```
+
+Expected: clean pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_cli_and_mcp.py
+git commit -m "test: CLI argparse wiring for --template"
+```
+
+---
+
+### Task 10: Update docs
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `src/actor/_skill/SKILL.md`
+
+- [ ] **Step 1: Add a "Config files" section to CLAUDE.md**
+
+Insert after the "Key runtime paths" section:
+
+```markdown
+## Config files
+
+User + project config live in `settings.kdl` files using the [KDL](https://kdl.dev) format:
+
+- `~/.actor/settings.kdl` — user-level defaults (applies everywhere).
+- `<project>/.actor/settings.kdl` — project-level; found by walking up from cwd (git-style).
+
+Loader: `src/actor/config.py` → `load_config() -> AppConfig`. Parses via
+`kdl-py`. The loader is called once per CLI invocation and passed into
+`cmd_new`.
+
+**Templates** are named bundles of agent defaults:
+
+\`\`\`kdl
+template "qa" {
+    agent "claude"
+    model "opus"
+    effort "max"
+    prompt "You're a QA engineer. Run tests, report findings."
+}
+\`\`\`
+
+Apply with: `actor new fix-auth --template qa`. Precedence: project overrides user
+for same template name; CLI `--config` and `--agent` flags override the template.
+
+**Not yet implemented (follow-up tickets):** lifecycle hooks (#30), per-agent
+`default-config` blocks (#31), aliases (#33). Unknown top-level nodes parse
+as no-ops today for forward compatibility.
+```
+
+- [ ] **Step 2: Add a brief note to `src/actor/_skill/SKILL.md`**
+
+Insert after the "Commands Reference" → "Create and run an actor" section:
+
+```markdown
+### Templates
+
+If the user has templates defined in `~/.actor/settings.kdl` or
+`<project>/.actor/settings.kdl`, apply one with the CLI:
+
+\`\`\`
+actor new fix-auth --template qa
+actor new fix-auth --template qa --config model=haiku    # template + CLI override
+\`\`\`
+
+The MCP `new_actor` tool does not yet accept a template parameter — use
+the CLI (Bash tool) when the user asks for a templated actor.
+```
+
+- [ ] **Step 3: Verify docs render sensibly**
+
+Skim both files locally. Ensure examples match actual CLI and KDL syntax (double-quoted strings, comment syntax `//` not `#`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md src/actor/_skill/SKILL.md
+git commit -m "docs: config files + templates"
+```
+
+---
+
+### Task 11: Final verification — full suite + smoke test
+
+**Files:** none
+
+- [ ] **Step 1: Clean cache and run full suite**
+
+```bash
+find . -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null
+uv run python -m unittest discover tests
+```
+
+Expected: `Ran 30X tests ... OK` (X = 295 + new tests; no regressions, no errors).
+
+- [ ] **Step 2: Smoke test --help**
+
+```bash
+uv run actor new --help
+```
+
+Expected: output includes `--template`, the new epilog line, and `--agent` default updated.
+
+- [ ] **Step 3: Smoke test load_config isolation**
+
+```bash
+uv run python -c "from actor.config import load_config; print(load_config())"
+```
+
+Expected: prints an `AppConfig` with whatever templates exist (empty or pre-existing — not an error).
+
+---
+
+## Self-review checklist
+
+- **Spec coverage:** New module ✓, KDL parser dependency ✓, precedence chain layers 1-5 implemented ✓ (6 unchanged), `--template` flag ✓, cmd_new consults Config.templates[name] ✓, `AppConfig` dataclass ✓, doc updates ✓, test plan ✓. Explicit scope-limiting notes for hooks/per-agent/aliases ✓.
+- **Placeholder scan:** No "TBD", no "handle edge cases" hand-waves — every step has the actual code it needs.
+- **Type consistency:** `AppConfig`, `Template`, `load_config` names match across all tasks. `template_name` / `app_config` kwargs consistent. `Config` (the existing `Dict[str, str]` alias) is kept for backward-compat; `AppConfig` is the new dataclass so they don't collide.

--- a/src/actor/__init__.py
+++ b/src/actor/__init__.py
@@ -34,6 +34,9 @@ from .types import (
     _sorted_config,
 )
 
+# Config
+from .config import AppConfig, Template, load_config
+
 # Interfaces
 from .interfaces import (
     LogEntryKind,
@@ -101,6 +104,10 @@ __all__ = [
     "Config",
     "validate_name",
     "parse_config",
+    # Config
+    "AppConfig",
+    "Template",
+    "load_config",
     # Interfaces
     "LogEntryKind",
     "LogEntry",

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -74,16 +74,71 @@ new_actor(name="fix-nav", prompt="...", config=["model=opus"])              # sa
 
 ### Templates
 
-If the user has templates defined in `~/.actor/settings.kdl` (user-wide)
-or `<project>/.actor/settings.kdl` (project-local), apply one via the CLI:
+Templates are named bundles of actor defaults. They live in KDL files that
+the user edits directly — there is no `actor init` command, so use the
+Read / Write / Edit tools when the user asks to view, add, or change a
+template.
+
+**File locations** (both optional; create whichever fits the user's ask):
+
+- `~/.actor/settings.kdl` — user-wide. Applies to every repo.
+- `<project>/.actor/settings.kdl` — project-scoped. Found by walking up
+  from the current directory (git-style), so any cwd inside the repo sees
+  it.
+
+**Precedence:** when the same template name appears in both files, the
+project file wins. Users can set a baseline template in `~/.actor/` and
+override it per-repo.
+
+**Template block syntax:**
+
+```kdl
+template "qa" {
+    agent "claude"
+    model "opus"
+    effort "max"
+    strip-api-keys true
+    prompt "You're a QA engineer. Run the tests, report what fails."
+}
+
+template "reviewer" {
+    agent "claude"
+    model "sonnet"
+    prompt "You're a code reviewer. Be concise."
+}
+```
+
+**Valid keys inside a template:**
+
+- `agent` (string) — `"claude"` or `"codex"`. Sets which CLI the actor runs.
+- `prompt` (string) — default prompt used when the user doesn't pass one
+  on the CLI.
+- Any key from the agent's config reference ([claude-config.md](claude-config.md),
+  [codex-config.md](codex-config.md)) — e.g. `model`, `effort`,
+  `strip-api-keys`, `max-budget-usd`. Values may be strings, booleans, or
+  numbers; they're all coerced to strings to match the actor config
+  pipeline.
+
+Unknown top-level nodes (`hooks`, `agent`, `alias`) parse as no-ops today —
+they're reserved for follow-up tickets. Malformed KDL raises an error
+with the file path.
+
+**Applying a template** (CLI only — see note below):
 
 ```bash
 actor new fix-auth --template qa                          # apply template
-actor new fix-auth --template qa --config model=haiku     # template + CLI override
+actor new fix-auth --template qa --config model=haiku     # CLI overrides template
+actor new fix-auth --template qa --agent codex            # CLI agent beats template
+actor new fix-auth --template qa "custom prompt"          # CLI prompt beats template
 ```
 
-The MCP `new_actor` tool does not yet accept a template parameter — use
-the CLI (Bash tool) when the user asks for a templated actor.
+Explicit CLI flags (`--agent`, `--model`, `--config`, positional prompt,
+stdin) always beat the template's values.
+
+**MCP note:** the `mcp__actor__new_actor` tool does not yet accept a
+`template` parameter. When the user asks for a templated actor, call
+`actor new … --template …` via the Bash tool instead. This is a known
+gap; a follow-up will add it to the MCP tool.
 
 ### Create without running
 

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -72,6 +72,19 @@ new_actor(name="fix-nav", prompt="...", no_worktree=True)                   # no
 new_actor(name="fix-nav", prompt="...", config=["model=opus"])              # saved defaults
 ```
 
+### Templates
+
+If the user has templates defined in `~/.actor/settings.kdl` (user-wide)
+or `<project>/.actor/settings.kdl` (project-local), apply one via the CLI:
+
+```bash
+actor new fix-auth --template qa                          # apply template
+actor new fix-auth --template qa --config model=haiku     # template + CLI override
+```
+
+The MCP `new_actor` tool does not yet accept a template parameter — use
+the CLI (Bash tool) when the user asks for a templated actor.
+
 ### Create without running
 
 ```

--- a/src/actor/_skill/cli.md
+++ b/src/actor/_skill/cli.md
@@ -36,8 +36,24 @@ actor new fix-nav --dir /path/to/repo "..."                                 # wo
 actor new fix-nav --no-worktree "..."                                       # no worktree
 actor new fix-nav --config model=opus "..."                                 # saved defaults
 actor new fix-nav --no-strip-api-keys "..."                                 # pass API keys through
+actor new fix-nav --template qa                                             # apply a template from settings.kdl
 echo "fix it" | actor new fix-nav                                           # prompt from stdin
 ```
+
+Templates come from `~/.actor/settings.kdl` (user) or
+`<repo>/.actor/settings.kdl` (project-local; project wins on overlap). A
+template can set the agent, prompt, and any config keys:
+
+```kdl
+template "qa" {
+    agent "claude"
+    model "opus"
+    prompt "You're a QA engineer. Write tests for the changed code."
+}
+```
+
+Any explicit flag on the CLI (`--agent`, `--model`, `--config`, positional
+prompt / stdin) beats the template's value.
 
 ## Create without running
 

--- a/src/actor/_skill/cli.md
+++ b/src/actor/_skill/cli.md
@@ -41,8 +41,10 @@ echo "fix it" | actor new fix-nav                                           # pr
 ```
 
 Templates come from `~/.actor/settings.kdl` (user) or
-`<repo>/.actor/settings.kdl` (project-local; project wins on overlap). A
-template can set the agent, prompt, and any config keys:
+`<repo>/.actor/settings.kdl` (project-local; project wins on overlap).
+These files don't exist by default — create them by hand when the user
+wants a template. A template can set the agent, prompt, and any config
+keys:
 
 ```kdl
 template "qa" {

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -84,8 +84,7 @@ Examples:
     # Tri-state: default None = "no override" so a template's strip-api-keys
     # value wins. Explicit --strip-api-keys / --no-strip-api-keys set True/
     # False and beat the template. When neither CLI nor template sets the
-    # key, it's omitted from config and the agent's own default applies
-    # (ClaudeAgent / CodexAgent both treat a missing key as "strip").
+    # key, it's omitted from config and the agent's own default applies.
     p_new.add_argument("--strip-api-keys", action="store_const", const=True, default=None, dest="strip_api_keys", help="Strip API keys from environment (default)")
     p_new.add_argument("--no-strip-api-keys", action="store_const", const=False, dest="strip_api_keys", help="Pass API keys through to the agent")
     p_new.add_argument("--config", dest="config", action="append", default=[], metavar="KEY=VALUE", help="Config key=value pair (repeat for multiple)")

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -70,6 +70,7 @@ Examples:
   actor new my-feature --dir /path/to/repo          Worktree from another repo
   actor new my-feature --base develop               Branch off develop
   actor new my-feature --config effort=max          Set agent config at creation
+  actor new my-feature --template qa                Apply the 'qa' template from settings.kdl
   echo "fix it" | actor new my-feature              Create and run with piped prompt""",
     )
     p_new.add_argument("name", help="Actor name")
@@ -80,10 +81,11 @@ Examples:
     p_new.add_argument("--agent", default=None, help="Coding agent to use (defaults to template's agent or 'claude')")
     p_new.add_argument("--template", default=None, help="Apply a template from settings.kdl")
     p_new.add_argument("--model", default=None, help="Model for the agent to use")
-    # Tri-state: default None means "no override" so a template's
-    # strip-api-keys value wins. Explicit --strip-api-keys / --no-strip-api-keys
-    # set True/False and beat the template (agents default to strip=true if
-    # neither CLI nor template sets it).
+    # Tri-state: default None = "no override" so a template's strip-api-keys
+    # value wins. Explicit --strip-api-keys / --no-strip-api-keys set True/
+    # False and beat the template. When neither CLI nor template sets the
+    # key, it's omitted from config and the agent's own default applies
+    # (ClaudeAgent / CodexAgent both treat a missing key as "strip").
     p_new.add_argument("--strip-api-keys", action="store_const", const=True, default=None, dest="strip_api_keys", help="Strip API keys from environment (default)")
     p_new.add_argument("--no-strip-api-keys", action="store_const", const=False, dest="strip_api_keys", help="Pass API keys through to the agent")
     p_new.add_argument("--config", dest="config", action="append", default=[], metavar="KEY=VALUE", help="Config key=value pair (repeat for multiple)")

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -80,8 +80,12 @@ Examples:
     p_new.add_argument("--agent", default=None, help="Coding agent to use (defaults to template's agent or 'claude')")
     p_new.add_argument("--template", default=None, help="Apply a template from settings.kdl")
     p_new.add_argument("--model", default=None, help="Model for the agent to use")
-    p_new.add_argument("--strip-api-keys", action="store_true", default=True, dest="strip_api_keys", help="Strip API keys from environment (default)")
-    p_new.add_argument("--no-strip-api-keys", action="store_false", dest="strip_api_keys", help="Pass API keys through to the agent")
+    # Tri-state: default None means "no override" so a template's
+    # strip-api-keys value wins. Explicit --strip-api-keys / --no-strip-api-keys
+    # set True/False and beat the template (agents default to strip=true if
+    # neither CLI nor template sets it).
+    p_new.add_argument("--strip-api-keys", action="store_const", const=True, default=None, dest="strip_api_keys", help="Strip API keys from environment (default)")
+    p_new.add_argument("--no-strip-api-keys", action="store_const", const=False, dest="strip_api_keys", help="Pass API keys through to the agent")
     p_new.add_argument("--config", dest="config", action="append", default=[], metavar="KEY=VALUE", help="Config key=value pair (repeat for multiple)")
 
     # -- run --
@@ -339,8 +343,10 @@ def main(argv: Optional[List[str]] = None) -> None:
             config_pairs = list(args.config)
             if args.model is not None:
                 config_pairs.append(f"model={args.model}")
-            if not args.strip_api_keys:
-                config_pairs.append("strip-api-keys=false")
+            if args.strip_api_keys is not None:
+                config_pairs.append(
+                    f"strip-api-keys={'true' if args.strip_api_keys else 'false'}"
+                )
             actor = cmd_new(
                 db, git,
                 name=args.name,
@@ -359,13 +365,16 @@ def main(argv: Optional[List[str]] = None) -> None:
             if prompt is None and not sys.stdin.isatty():
                 prompt = sys.stdin.read().strip()
                 stdin_consumed = True
-            if stdin_consumed and not prompt:
-                print("error: stdin was empty — expected a prompt", file=sys.stderr)
-                sys.exit(1)
-            if prompt is None and args.template is not None:
+            # Template prompt fallback runs before the empty-stdin check so
+            # that `echo "" | actor new foo --template qa` uses the template's
+            # prompt instead of erroring.
+            if not prompt and args.template is not None:
                 tpl = app_config.templates.get(args.template)
                 if tpl is not None and tpl.prompt:
                     prompt = tpl.prompt
+            if stdin_consumed and not prompt:
+                print("error: stdin was empty — expected a prompt", file=sys.stderr)
+                sys.exit(1)
             if prompt:
                 try:
                     agent = agent_for(args.name)

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -77,7 +77,8 @@ Examples:
     p_new.add_argument("--dir", default=None, help="Base directory (defaults to CWD)")
     p_new.add_argument("--no-worktree", action="store_true", help="Skip worktree creation, run in the directory directly")
     p_new.add_argument("--base", default=None, help="Branch to create the worktree from (defaults to current branch)")
-    p_new.add_argument("--agent", default="claude", help="Coding agent to use")
+    p_new.add_argument("--agent", default=None, help="Coding agent to use (defaults to template's agent or 'claude')")
+    p_new.add_argument("--template", default=None, help="Apply a template from settings.kdl")
     p_new.add_argument("--model", default=None, help="Model for the agent to use")
     p_new.add_argument("--strip-api-keys", action="store_true", default=True, dest="strip_api_keys", help="Strip API keys from environment (default)")
     p_new.add_argument("--no-strip-api-keys", action="store_false", dest="strip_api_keys", help="Pass API keys through to the agent")
@@ -332,6 +333,9 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     try:
         if args.command == "new":
+            from .config import load_config
+            app_config = load_config()
+
             config_pairs = list(args.config)
             if args.model is not None:
                 config_pairs.append(f"model={args.model}")
@@ -345,6 +349,8 @@ def main(argv: Optional[List[str]] = None) -> None:
                 base=args.base,
                 agent_name=args.agent,
                 config_pairs=config_pairs,
+                template_name=args.template,
+                app_config=app_config,
             )
             print(f"{actor.name} created ({actor.dir})")
 
@@ -356,6 +362,10 @@ def main(argv: Optional[List[str]] = None) -> None:
             if stdin_consumed and not prompt:
                 print("error: stdin was empty — expected a prompt", file=sys.stderr)
                 sys.exit(1)
+            if prompt is None and args.template is not None:
+                tpl = app_config.templates.get(args.template)
+                if tpl is not None and tpl.prompt:
+                    prompt = tpl.prompt
             if prompt:
                 try:
                     agent = agent_for(args.name)

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -5,14 +5,18 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
 
 from .errors import (
     ActorError,
     AgentNotFoundError,
+    ConfigError,
     IsRunningError,
     NotRunningError,
 )
+
+if TYPE_CHECKING:
+    from .config import AppConfig
 from .interfaces import Agent, GitOps, LogEntry, LogEntryKind, ProcessManager, binary_exists
 from .types import (
     Actor,
@@ -110,17 +114,32 @@ def cmd_new(
     dir: Optional[str],
     no_worktree: bool,
     base: Optional[str],
-    agent_name: str,
+    agent_name: Optional[str],
     config_pairs: List[str],
+    template_name: Optional[str] = None,
+    app_config: Optional["AppConfig"] = None,
 ) -> Actor:
     validate_name(name)
 
+    template = None
+    if template_name is not None:
+        if app_config is None or template_name not in app_config.templates:
+            raise ConfigError(f"unknown template: '{template_name}'")
+        template = app_config.templates[template_name]
+
+    # Agent precedence: explicit CLI flag > template's agent > "claude"
+    if agent_name is None:
+        agent_name = template.agent if (template and template.agent) else "claude"
     agent_kind = AgentKind.from_str(agent_name)
 
     if not binary_exists(agent_kind.binary_name):
         print(f"warning: '{agent_kind.binary_name}' not found on PATH", file=sys.stderr)
 
-    config = parse_config(config_pairs)
+    # Config precedence: template's config is the base; CLI pairs overlay on top.
+    config: Dict[str, str] = dict(template.config) if template else {}
+    for k, v in parse_config(config_pairs).items():
+        config[k] = v
+    config = _sorted_config(config)
 
     if dir is not None:
         try:

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -1,0 +1,139 @@
+"""Config file system for actor.sh.
+
+Loads ~/.actor/settings.kdl (user) and <project>/.actor/settings.kdl
+(project), merges them, and exposes the merged AppConfig with its
+templates map. Project config overrides user config on same-key conflict.
+
+Out of scope (see tickets #30 / #31 / #33): hooks, per-agent default-config
+blocks, aliases. Their nodes are skipped at parse time without error for
+forward compatibility.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+import kdl
+
+from .errors import ConfigError
+
+
+@dataclass
+class Template:
+    name: str
+    agent: Optional[str] = None
+    prompt: Optional[str] = None
+    config: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class AppConfig:
+    templates: Dict[str, Template] = field(default_factory=dict)
+
+
+def _find_project_config(start: Path) -> Optional[Path]:
+    """Walk up from start looking for .actor/settings.kdl."""
+    try:
+        start = start.resolve(strict=False)
+    except OSError:
+        return None
+    for d in [start, *start.parents]:
+        p = d / ".actor" / "settings.kdl"
+        if p.is_file():
+            return p
+    return None
+
+
+def _coerce_value(value: object) -> str:
+    """Coerce a KDL-parsed arg (bool/float/str) into a string for the
+    stringly-typed actor config pipeline."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float):
+        # kdl-py parses all numbers as float; drop the trailing .0 for
+        # integer-valued literals so `effort 5` stays "5" not "5.0".
+        return str(int(value)) if value.is_integer() else str(value)
+    return str(value)
+
+
+def _parse_template(node, source: Path) -> Template:
+    if not node.args or not isinstance(node.args[0], str):
+        raise ConfigError(
+            f"template block in {source} must have a name "
+            f"(e.g. `template \"qa\" {{ ... }}`)"
+        )
+    name = node.args[0]
+    tpl = Template(name=name)
+    for child in node.nodes:
+        key = child.name
+        if not child.args:
+            raise ConfigError(
+                f"template '{name}' in {source}: '{key}' needs a value"
+            )
+        value_str = _coerce_value(child.args[0])
+        if key == "agent":
+            tpl.agent = value_str
+        elif key == "prompt":
+            tpl.prompt = value_str
+        else:
+            tpl.config[key] = value_str
+    return tpl
+
+
+def _parse_kdl_file(path: Path) -> AppConfig:
+    try:
+        text = path.read_text()
+    except OSError as e:
+        raise ConfigError(f"could not read {path}: {e}")
+    try:
+        doc = kdl.parse(text)
+    except Exception as e:
+        raise ConfigError(f"parse error in {path}: {e}")
+    cfg = AppConfig()
+    for node in doc.nodes:
+        if node.name == "template":
+            tpl = _parse_template(node, path)
+            cfg.templates[tpl.name] = tpl
+        # Silently ignore hooks / agent / alias — those belong to follow-up
+        # tickets #30 / #31 / #33 and are not implemented here.
+    return cfg
+
+
+def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
+    merged_templates = dict(base.templates)
+    merged_templates.update(over.templates)
+    return AppConfig(templates=merged_templates)
+
+
+def load_config(
+    cwd: Optional[Path] = None,
+    home: Optional[Path] = None,
+) -> AppConfig:
+    """Load user + project settings.kdl and return the merged AppConfig.
+
+    - cwd defaults to Path.cwd()
+    - home defaults to Path(os.environ['HOME']); if HOME is unset,
+      the user config step is skipped.
+
+    Missing files are skipped silently. Malformed files raise ConfigError.
+    """
+    if cwd is None:
+        cwd = Path.cwd()
+    if home is None:
+        env_home = os.environ.get("HOME")
+        home = Path(env_home) if env_home else None
+
+    merged = AppConfig()
+
+    if home is not None:
+        user_path = home / ".actor" / "settings.kdl"
+        if user_path.is_file():
+            merged = _merge(merged, _parse_kdl_file(user_path))
+
+    project_path = _find_project_config(cwd)
+    if project_path is not None:
+        merged = _merge(merged, _parse_kdl_file(project_path))
+
+    return merged

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -59,10 +59,13 @@ def _find_project_config(
             continue
         if resolved_user is not None:
             try:
-                if p.resolve(strict=False) == resolved_user:
-                    continue
+                resolved_p = p.resolve(strict=False)
             except OSError:
-                pass
+                # Can't tell if this is the user file — skip rather than
+                # risk double-loading it.
+                continue
+            if resolved_p == resolved_user:
+                continue
         return p
     return None
 

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -33,29 +33,57 @@ class AppConfig:
     templates: Dict[str, Template] = field(default_factory=dict)
 
 
-def _find_project_config(start: Path) -> Optional[Path]:
-    """Walk up from start looking for .actor/settings.kdl."""
+def _find_project_config(
+    start: Path, user_path: Optional[Path] = None
+) -> Optional[Path]:
+    """Walk up from start looking for .actor/settings.kdl.
+
+    If user_path is given and the walk-up lands on that exact file, skip it
+    — otherwise `cwd` inside `$HOME` (with no closer project config) would
+    wrongly treat the user's settings as a 'project' config and parse it
+    twice.
+    """
     try:
         start = start.resolve(strict=False)
     except OSError:
         return None
+    resolved_user = None
+    if user_path is not None:
+        try:
+            resolved_user = user_path.resolve(strict=False)
+        except OSError:
+            resolved_user = None
     for d in [start, *start.parents]:
         p = d / ".actor" / "settings.kdl"
-        if p.is_file():
-            return p
+        if not p.is_file():
+            continue
+        if resolved_user is not None:
+            try:
+                if p.resolve(strict=False) == resolved_user:
+                    continue
+            except OSError:
+                pass
+        return p
     return None
 
 
 def _coerce_value(value: object) -> str:
-    """Coerce a KDL-parsed arg (bool/float/str) into a string for the
-    stringly-typed actor config pipeline."""
+    """Coerce a KDL-parsed arg (str/bool/float) into a string for the
+    stringly-typed actor config pipeline. Unknown types raise ConfigError
+    so a future kdl-py change can't silently stringify something
+    nonsensical (e.g. a null → "None")."""
+    # bool must be checked before int/float (bool is a subclass of int).
     if isinstance(value, bool):
         return "true" if value else "false"
+    if isinstance(value, str):
+        return value
     if isinstance(value, float):
         # kdl-py parses all numbers as float; drop the trailing .0 for
         # integer-valued literals so `effort 5` stays "5" not "5.0".
         return str(int(value)) if value.is_integer() else str(value)
-    return str(value)
+    if isinstance(value, int):
+        return str(value)
+    raise ConfigError(f"unsupported KDL value type: {type(value).__name__}")
 
 
 def _parse_template(node, source: Path) -> Template:
@@ -64,15 +92,43 @@ def _parse_template(node, source: Path) -> Template:
             f"template block in {source} must have a name "
             f"(e.g. `template \"qa\" {{ ... }}`)"
         )
+    if len(node.args) > 1:
+        raise ConfigError(
+            f"template '{node.args[0]}' in {source} has extra positional args"
+        )
+    if getattr(node, "props", None):
+        raise ConfigError(
+            f"template '{node.args[0]}' in {source} does not accept properties"
+        )
     name = node.args[0]
     tpl = Template(name=name)
+    seen_keys: set[str] = set()
     for child in node.nodes:
         key = child.name
+        if key in seen_keys:
+            raise ConfigError(
+                f"template '{name}' in {source}: duplicate key '{key}'"
+            )
+        seen_keys.add(key)
         if not child.args:
             raise ConfigError(
                 f"template '{name}' in {source}: '{key}' needs a value"
             )
-        value_str = _coerce_value(child.args[0])
+        if len(child.args) > 1:
+            raise ConfigError(
+                f"template '{name}' in {source}: '{key}' has extra args "
+                f"(only a single value is supported)"
+            )
+        if getattr(child, "props", None):
+            raise ConfigError(
+                f"template '{name}' in {source}: '{key}' does not accept properties"
+            )
+        raw = child.args[0]
+        if key in ("agent", "prompt") and not isinstance(raw, str):
+            raise ConfigError(
+                f"template '{name}' in {source}: '{key}' must be a string"
+            )
+        value_str = _coerce_value(raw)
         if key == "agent":
             tpl.agent = value_str
         elif key == "prompt":
@@ -89,12 +145,16 @@ def _parse_kdl_file(path: Path) -> AppConfig:
         raise ConfigError(f"could not read {path}: {e}")
     try:
         doc = kdl.parse(text)
-    except Exception as e:
+    except kdl.ParseError as e:
         raise ConfigError(f"parse error in {path}: {e}")
     cfg = AppConfig()
     for node in doc.nodes:
         if node.name == "template":
             tpl = _parse_template(node, path)
+            if tpl.name in cfg.templates:
+                raise ConfigError(
+                    f"duplicate template '{tpl.name}' in {path}"
+                )
             cfg.templates[tpl.name] = tpl
         # Silently ignore hooks / agent / alias — those belong to follow-up
         # tickets #30 / #31 / #33 and are not implemented here.
@@ -127,12 +187,13 @@ def load_config(
 
     merged = AppConfig()
 
+    user_path: Optional[Path] = None
     if home is not None:
         user_path = home / ".actor" / "settings.kdl"
         if user_path.is_file():
             merged = _merge(merged, _parse_kdl_file(user_path))
 
-    project_path = _find_project_config(cwd)
+    project_path = _find_project_config(cwd, user_path=user_path)
     if project_path is not None:
         merged = _merge(merged, _parse_kdl_file(project_path))
 

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -95,6 +95,10 @@ def _parse_template(node, source: Path) -> Template:
             f"template block in {source} must have a name "
             f"(e.g. `template \"qa\" {{ ... }}`)"
         )
+    if not node.args[0]:
+        raise ConfigError(
+            f"template block in {source} must have a non-empty name"
+        )
     if len(node.args) > 1:
         raise ConfigError(
             f"template '{node.args[0]}' in {source} has extra positional args"
@@ -145,11 +149,11 @@ def _parse_kdl_file(path: Path) -> AppConfig:
     try:
         text = path.read_text()
     except OSError as e:
-        raise ConfigError(f"could not read {path}: {e}")
+        raise ConfigError(f"could not read {path}: {e}") from e
     try:
         doc = kdl.parse(text)
     except kdl.ParseError as e:
-        raise ConfigError(f"parse error in {path}: {e}")
+        raise ConfigError(f"parse error in {path}: {e}") from e
     cfg = AppConfig()
     for node in doc.nodes:
         if node.name == "template":

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -577,6 +577,124 @@ class TestCmdNew(unittest.TestCase):
 
 
 # ──────────────────────────────────────────────────────────────────────
+#  Test: cmd_new with --template (ticket #29)
+# ──────────────────────────────────────────────────────────────────────
+
+class TestCmdNewTemplate(unittest.TestCase):
+
+    def _db(self) -> Database:
+        return Database.open(":memory:")
+
+    def _cfg_with_qa(self):
+        from actor import AppConfig, Template
+        return AppConfig(templates={
+            "qa": Template(
+                name="qa",
+                agent="codex",
+                prompt="you're qa",
+                config={"model": "opus", "effort": "max"},
+            ),
+        })
+
+    def test_template_applies_agent_and_config(self):
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="fix-auth",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name=None,
+            config_pairs=[],
+            template_name="qa",
+            app_config=self._cfg_with_qa(),
+        )
+        self.assertEqual(actor.agent, AgentKind.CODEX)
+        self.assertEqual(actor.config["model"], "opus")
+        self.assertEqual(actor.config["effort"], "max")
+
+    def test_cli_agent_overrides_template_agent(self):
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="fix-auth",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=[],
+            template_name="qa",
+            app_config=self._cfg_with_qa(),
+        )
+        self.assertEqual(actor.agent, AgentKind.CLAUDE)
+
+    def test_cli_config_pair_overrides_template_config(self):
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="fix-auth",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name=None,
+            config_pairs=["model=haiku"],
+            template_name="qa",
+            app_config=self._cfg_with_qa(),
+        )
+        self.assertEqual(actor.config["model"], "haiku")
+        self.assertEqual(actor.config["effort"], "max")
+
+    def test_unknown_template_raises_config_error(self):
+        from actor.errors import ConfigError
+        db = self._db()
+        git = FakeGit()
+        with self.assertRaises(ConfigError):
+            cmd_new(
+                db, git,
+                name="fix-auth",
+                dir="/tmp",
+                no_worktree=True,
+                base=None,
+                agent_name=None,
+                config_pairs=[],
+                template_name="does-not-exist",
+                app_config=self._cfg_with_qa(),
+            )
+
+    def test_no_template_backward_compatible(self):
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="plain",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=["model=sonnet"],
+        )
+        self.assertEqual(actor.agent, AgentKind.CLAUDE)
+        self.assertEqual(actor.config["model"], "sonnet")
+
+    def test_agent_name_none_without_template_defaults_to_claude(self):
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="x",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name=None,
+            config_pairs=[],
+        )
+        self.assertEqual(actor.agent, AgentKind.CLAUDE)
+
+
+# ──────────────────────────────────────────────────────────────────────
 #  Test: cmd_run  (8 tests from run.rs)
 # ──────────────────────────────────────────────────────────────────────
 

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -183,6 +183,7 @@ class NewCommandTests(unittest.TestCase):
         self.assertEqual(code, 0)
 
     def test_new_with_prompt_run_failure_surfaces_partial_success(self):
+        from actor import AppConfig
         fake_db = MagicMock()
         fake_actor = MagicMock()
         fake_actor.name = "foo"
@@ -193,6 +194,7 @@ class NewCommandTests(unittest.TestCase):
 
         with patch("actor.cli.cmd_new", cmd_new), \
              patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.config.load_config", return_value=AppConfig()), \
              patch("actor.cli.Database") as db_cls, \
              patch("actor.cli._create_agent", return_value=MagicMock()):
             db_cls.open.return_value = fake_db

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -45,6 +45,7 @@ class NewCommandTests(unittest.TestCase):
 
     def _run(self, argv, stdin_text=None, stdin_is_tty=True):
         """Invoke cli.main with argv, patching cmd_new/cmd_run/stdin/Database."""
+        from actor import AppConfig
         fake_db = MagicMock()
         fake_actor = MagicMock()
         fake_actor.name = argv[1] if len(argv) > 1 else "a"
@@ -60,6 +61,7 @@ class NewCommandTests(unittest.TestCase):
 
         with patch("actor.cli.cmd_new", cmd_new), \
              patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.config.load_config", return_value=AppConfig()), \
              patch("actor.cli.Database") as db_cls, \
              patch("sys.stdin", stdin):
             db_cls.open.return_value = fake_db
@@ -110,6 +112,75 @@ class NewCommandTests(unittest.TestCase):
         pairs = cmd_new.call_args.kwargs["config_pairs"]
         self.assertIn("model=sonnet", pairs)
         self.assertIn("strip-api-keys=false", pairs)
+
+    def test_new_passes_template_arg_to_cmd_new_and_uses_template_prompt(self):
+        fake_db = MagicMock()
+        fake_actor = MagicMock()
+        fake_actor.name = "foo"
+        fake_actor.dir = "/tmp/actor"
+        cmd_new = MagicMock(return_value=fake_actor)
+        cmd_run = MagicMock(return_value="done")
+
+        from actor import AppConfig, Template
+        fake_app_cfg = AppConfig(templates={
+            "qa": Template(name="qa", agent="claude", prompt="run tests"),
+        })
+
+        stdin = io.StringIO("")
+        stdin.isatty = lambda: True  # type: ignore[assignment]
+
+        with patch("actor.cli.cmd_new", cmd_new), \
+             patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.config.load_config", return_value=fake_app_cfg), \
+             patch("actor.cli.Database") as db_cls, \
+             patch("actor.cli._create_agent", return_value=MagicMock()), \
+             patch("sys.stdin", stdin):
+            db_cls.open.return_value = fake_db
+            try:
+                main(["new", "foo", "--template", "qa"])
+                code = 0
+            except SystemExit as e:
+                code = e.code if isinstance(e.code, int) else 1
+        cmd_new.assert_called_once()
+        kwargs = cmd_new.call_args.kwargs
+        self.assertEqual(kwargs["template_name"], "qa")
+        self.assertIsNotNone(kwargs["app_config"])
+        self.assertEqual(code, 0)
+        cmd_run.assert_called_once()
+        self.assertEqual(cmd_run.call_args.kwargs["prompt"], "run tests")
+
+    def test_new_cli_prompt_beats_template_prompt(self):
+        fake_db = MagicMock()
+        fake_actor = MagicMock()
+        fake_actor.name = "foo"
+        fake_actor.dir = "/tmp/actor"
+        cmd_new = MagicMock(return_value=fake_actor)
+        cmd_run = MagicMock(return_value="done")
+
+        from actor import AppConfig, Template
+        fake_app_cfg = AppConfig(templates={
+            "qa": Template(name="qa", agent="claude", prompt="template says run tests"),
+        })
+
+        stdin = io.StringIO("")
+        stdin.isatty = lambda: True  # type: ignore[assignment]
+
+        with patch("actor.cli.cmd_new", cmd_new), \
+             patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.config.load_config", return_value=fake_app_cfg), \
+             patch("actor.cli.Database") as db_cls, \
+             patch("actor.cli._create_agent", return_value=MagicMock()), \
+             patch("sys.stdin", stdin):
+            db_cls.open.return_value = fake_db
+            main(["new", "foo", "custom prompt", "--template", "qa"])
+        self.assertEqual(cmd_run.call_args.kwargs["prompt"], "custom prompt")
+
+    def test_new_without_template_does_not_pass_template_kwargs(self):
+        """Regression check: normal `actor new foo` must still work end-to-end."""
+        cmd_new, cmd_run, code = self._run(["new", "foo"])
+        kwargs = cmd_new.call_args.kwargs
+        self.assertIsNone(kwargs["template_name"])
+        self.assertEqual(code, 0)
 
     def test_new_with_prompt_run_failure_surfaces_partial_success(self):
         fake_db = MagicMock()

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -113,6 +113,23 @@ class NewCommandTests(unittest.TestCase):
         self.assertIn("model=sonnet", pairs)
         self.assertIn("strip-api-keys=false", pairs)
 
+    def test_new_without_strip_api_keys_flag_does_not_emit_override(self):
+        """Tri-state check: omitting both --strip-api-keys and --no-strip-api-keys
+        must NOT push a strip-api-keys pair, so a template's value wins."""
+        cmd_new, _cmd_run, _code = self._run(["new", "foo"])
+        pairs = cmd_new.call_args.kwargs["config_pairs"]
+        self.assertFalse(
+            any(p.startswith("strip-api-keys=") for p in pairs),
+            f"expected no strip-api-keys override, got {pairs}",
+        )
+
+    def test_new_explicit_strip_api_keys_flag_emits_true_override(self):
+        """Explicit --strip-api-keys must push strip-api-keys=true so it
+        can override a template's strip-api-keys "false"."""
+        cmd_new, _cmd_run, _code = self._run(["new", "foo", "--strip-api-keys"])
+        pairs = cmd_new.call_args.kwargs["config_pairs"]
+        self.assertIn("strip-api-keys=true", pairs)
+
     def test_new_passes_template_arg_to_cmd_new_and_uses_template_prompt(self):
         fake_db = MagicMock()
         fake_actor = MagicMock()
@@ -181,6 +198,59 @@ class NewCommandTests(unittest.TestCase):
         kwargs = cmd_new.call_args.kwargs
         self.assertIsNone(kwargs["template_name"])
         self.assertEqual(code, 0)
+
+    def test_new_empty_stdin_with_template_prompt_falls_back(self):
+        """`echo "" | actor new foo --template qa` must use the template's
+        prompt instead of erroring on empty stdin."""
+        fake_db = MagicMock()
+        fake_actor = MagicMock()
+        fake_actor.name = "foo"
+        fake_actor.dir = "/tmp/actor"
+        cmd_new = MagicMock(return_value=fake_actor)
+        cmd_run = MagicMock(return_value="done")
+
+        from actor import AppConfig, Template
+        fake_app_cfg = AppConfig(templates={
+            "qa": Template(name="qa", agent="claude", prompt="run tests"),
+        })
+
+        stdin = io.StringIO("")
+        stdin.isatty = lambda: False  # type: ignore[assignment]
+
+        with patch("actor.cli.cmd_new", cmd_new), \
+             patch("actor.cli.cmd_run", cmd_run), \
+             patch("actor.config.load_config", return_value=fake_app_cfg), \
+             patch("actor.cli.Database") as db_cls, \
+             patch("actor.cli._create_agent", return_value=MagicMock()), \
+             patch("sys.stdin", stdin):
+            db_cls.open.return_value = fake_db
+            try:
+                main(["new", "foo", "--template", "qa"])
+                code = 0
+            except SystemExit as e:
+                code = e.code if isinstance(e.code, int) else 1
+        self.assertEqual(code, 0)
+        cmd_run.assert_called_once()
+        self.assertEqual(cmd_run.call_args.kwargs["prompt"], "run tests")
+
+    def test_new_surfaces_config_error_from_load_config(self):
+        """A malformed settings.kdl must exit non-zero with the error text
+        on stderr, not crash with an uncaught ConfigError."""
+        from actor.errors import ConfigError
+        fake_db = MagicMock()
+        with patch("actor.config.load_config",
+                   side_effect=ConfigError("parse error in /x/settings.kdl: boom")), \
+             patch("actor.cli.Database") as db_cls:
+            db_cls.open.return_value = fake_db
+            stderr = io.StringIO()
+            with patch("sys.stderr", stderr):
+                try:
+                    main(["new", "foo", "do x"])
+                    code = 0
+                except SystemExit as e:
+                    code = e.code if isinstance(e.code, int) else 1
+        self.assertEqual(code, 1)
+        self.assertIn("parse error", stderr.getvalue())
 
     def test_new_with_prompt_run_failure_surfaces_partial_success(self):
         from actor import AppConfig

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,6 +215,42 @@ class TestLoadConfigParseStrict(unittest.TestCase):
             "prompt",
         )
 
+    def test_props_on_template_node_raises(self):
+        self._expect_error(
+            'template "qa" flag="x" {\n    agent "claude"\n}\n',
+            "qa",
+        )
+
+    def test_empty_template_name_raises(self):
+        self._expect_error(
+            'template "" {\n    agent "claude"\n}\n',
+            "non-empty",
+        )
+
+
+class TestLoadConfigCoercion(unittest.TestCase):
+
+    def test_non_integer_float_keeps_decimal(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text('template "x" {\n    temperature 0.5\n}\n')
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.templates["x"].config["temperature"], "0.5")
+
+
+class TestLoadConfigHomeUnset(unittest.TestCase):
+
+    def test_home_none_skips_user_config_and_loads_project(self):
+        with tempfile.TemporaryDirectory() as cwd:
+            proj = Path(cwd) / ".actor"
+            proj.mkdir()
+            (proj / "settings.kdl").write_text(
+                'template "qa" {\n    agent "claude"\n}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=None)
+            self.assertIn("qa", cfg.templates)
+
 
 class TestLoadConfigCwdUnderHome(unittest.TestCase):
     """Walk-up must stop before re-parsing the user config as a 'project'."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,5 +30,135 @@ class TestLoadConfigEmpty(unittest.TestCase):
             self.assertEqual(cfg.templates["qa"].agent, "claude")
 
 
+class TestLoadConfigPrecedence(unittest.TestCase):
+
+    def _write(self, path: Path, body: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    def test_project_overrides_user_same_template_name(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'template "qa" {\n    agent "claude"\n    model "sonnet"\n}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'template "qa" {\n    agent "codex"\n    model "opus"\n}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.templates["qa"].agent, "codex")
+            self.assertEqual(cfg.templates["qa"].config["model"], "opus")
+
+    def test_user_and_project_both_contribute_distinct_templates(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'template "qa" {\n    agent "claude"\n}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'template "reviewer" {\n    agent "claude"\n}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("qa", cfg.templates)
+            self.assertIn("reviewer", cfg.templates)
+
+
+class TestLoadConfigWalkUp(unittest.TestCase):
+
+    def test_project_config_found_by_walking_up_from_cwd(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as root:
+            proj = Path(root) / ".actor"
+            proj.mkdir()
+            (proj / "settings.kdl").write_text(
+                'template "qa" {\n    agent "claude"\n}\n'
+            )
+            deep = Path(root) / "src" / "nested" / "deeper"
+            deep.mkdir(parents=True)
+            cfg = load_config(cwd=deep, home=Path(home))
+            self.assertIn("qa", cfg.templates)
+
+
+class TestLoadConfigErrors(unittest.TestCase):
+
+    def test_malformed_kdl_raises_config_error_with_path(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            bad = Path(cwd) / ".actor" / "settings.kdl"
+            bad.parent.mkdir()
+            bad.write_text('template "qa" {\n    unclosed\n')
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn(str(bad), str(ctx.exception))
+
+    def test_template_without_name_raises(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            bad = Path(cwd) / ".actor" / "settings.kdl"
+            bad.parent.mkdir()
+            bad.write_text('template {\n    agent "claude"\n}\n')
+            with self.assertRaises(ConfigError):
+                load_config(cwd=Path(cwd), home=Path(home))
+
+    def test_template_child_without_value_raises(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            bad = Path(cwd) / ".actor" / "settings.kdl"
+            bad.parent.mkdir()
+            bad.write_text('template "qa" {\n    agent\n}\n')
+            with self.assertRaises(ConfigError):
+                load_config(cwd=Path(cwd), home=Path(home))
+
+
+class TestLoadConfigParseShapes(unittest.TestCase):
+
+    def test_template_with_all_fields(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'template "qa" {\n'
+                '    agent "claude"\n'
+                '    model "opus"\n'
+                '    effort "max"\n'
+                '    prompt "You\'re a QA engineer."\n'
+                '}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            tpl = cfg.templates["qa"]
+            self.assertEqual(tpl.agent, "claude")
+            self.assertEqual(tpl.prompt, "You're a QA engineer.")
+            self.assertEqual(tpl.config, {"model": "opus", "effort": "max"})
+
+    def test_bool_value_coerced_to_string(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text('template "x" {\n    strip-api-keys true\n}\n')
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.templates["x"].config["strip-api-keys"], "true")
+
+    def test_int_value_coerced_without_trailing_zero(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text('template "x" {\n    max-budget-usd 5\n}\n')
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.templates["x"].config["max-budget-usd"], "5")
+
+    def test_unknown_top_level_nodes_are_ignored(self):
+        # Forward-compat: hooks/agent/alias exist in follow-up tickets but
+        # should parse as no-ops today rather than erroring.
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'hooks {\n    on-start "echo hi"\n}\n'
+                'alias "max" template="qa"\n'
+                'template "qa" {\n    agent "claude"\n}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("qa", cfg.templates)
+            self.assertEqual(len(cfg.templates), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,5 +160,100 @@ class TestLoadConfigParseShapes(unittest.TestCase):
             self.assertEqual(len(cfg.templates), 1)
 
 
+class TestLoadConfigParseStrict(unittest.TestCase):
+    """Parser should reject silently-dropped input (ambiguous user intent)."""
+
+    def _expect_error(self, kdl_text: str, needle: str) -> None:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(kdl_text)
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn(needle, str(ctx.exception))
+
+    def test_extra_args_on_template_node_raises(self):
+        self._expect_error(
+            'template "qa" "extra" {\n    agent "claude"\n}\n',
+            "extra",
+        )
+
+    def test_extra_args_on_child_node_raises(self):
+        self._expect_error(
+            'template "qa" {\n    model "opus" "sonnet"\n}\n',
+            "model",
+        )
+
+    def test_props_on_child_node_raises(self):
+        self._expect_error(
+            'template "qa" {\n    model name="opus"\n}\n',
+            "model",
+        )
+
+    def test_duplicate_key_in_template_raises(self):
+        self._expect_error(
+            'template "qa" {\n    model "opus"\n    model "sonnet"\n}\n',
+            "model",
+        )
+
+    def test_duplicate_template_name_in_file_raises(self):
+        self._expect_error(
+            'template "qa" {\n    agent "claude"\n}\n'
+            'template "qa" {\n    agent "codex"\n}\n',
+            "qa",
+        )
+
+    def test_non_string_agent_value_raises(self):
+        self._expect_error(
+            'template "qa" {\n    agent 42\n}\n',
+            "agent",
+        )
+
+    def test_non_string_prompt_value_raises(self):
+        self._expect_error(
+            'template "qa" {\n    prompt 42\n}\n',
+            "prompt",
+        )
+
+
+class TestLoadConfigCwdUnderHome(unittest.TestCase):
+    """Walk-up must stop before re-parsing the user config as a 'project'."""
+
+    def test_cwd_inside_home_does_not_double_load_user_config(self):
+        # cwd sits inside home, and only the user config exists.
+        # Without the fix, walk-up finds the user config as the "project"
+        # path too, and duplicate template names would merge over
+        # themselves — and worse, a strict duplicate-template check would
+        # wrongly fire on the second parse.
+        with tempfile.TemporaryDirectory() as home:
+            home_p = Path(home)
+            (home_p / ".actor").mkdir()
+            (home_p / ".actor" / "settings.kdl").write_text(
+                'template "qa" {\n    agent "claude"\n}\n'
+            )
+            sub = home_p / "work" / "repo"
+            sub.mkdir(parents=True)
+            cfg = load_config(cwd=sub, home=home_p)
+            self.assertIn("qa", cfg.templates)
+            self.assertEqual(cfg.templates["qa"].agent, "claude")
+
+    def test_project_config_found_even_when_cwd_is_inside_home(self):
+        # Project config at <home>/work/repo/.actor/settings.kdl is still
+        # picked up when cwd is there (and wins on override).
+        with tempfile.TemporaryDirectory() as home:
+            home_p = Path(home)
+            (home_p / ".actor").mkdir()
+            (home_p / ".actor" / "settings.kdl").write_text(
+                'template "qa" {\n    agent "claude"\n}\n'
+            )
+            proj = home_p / "work" / "repo"
+            (proj / ".actor").mkdir(parents=True)
+            (proj / ".actor" / "settings.kdl").write_text(
+                'template "qa" {\n    agent "codex"\n}\n'
+            )
+            cfg = load_config(cwd=proj, home=home_p)
+            self.assertEqual(cfg.templates["qa"].agent, "codex")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Tests for src/actor/config.py — KDL loader + templates."""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from actor.config import AppConfig, Template, load_config
+from actor.errors import ConfigError
+
+
+class TestLoadConfigEmpty(unittest.TestCase):
+
+    def test_no_files_returns_empty_config(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIsInstance(cfg, AppConfig)
+            self.assertEqual(cfg.templates, {})
+
+    def test_missing_user_file_but_project_file_loads_project(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            proj = Path(cwd) / ".actor"
+            proj.mkdir()
+            (proj / "settings.kdl").write_text(
+                'template "qa" {\n    agent "claude"\n}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("qa", cfg.templates)
+            self.assertEqual(cfg.templates["qa"].agent, "claude")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,12 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
 name = "actor-sh"
 source = { editable = "." }
 dependencies = [
+    { name = "kdl-py" },
     { name = "mcp" },
     { name = "pyte" },
     { name = "textual" },
@@ -14,6 +15,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "kdl-py", specifier = ">=1.2.0" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pyte", specifier = ">=0.8.1" },
     { name = "textual", specifier = ">=1.0" },
@@ -613,6 +615,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "kdl-py"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/35/caa43d276dd46efe73926e25024429fab25effca24ba0af3875ea5cdc362/kdl-py-1.2.0.tar.gz", hash = "sha256:63f3f46c6277dedadce44dcfc94672bf6e6bf3330b90122e0134c22857e29973", size = 29224, upload-time = "2024-01-18T23:50:16.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/04/766286ba77621edf37225c66ce0ef2bceead987c69439b572e85ad27980c/kdl_py-1.2.0-py3-none-any.whl", hash = "sha256:d11e556dbb226cccf666bb4ffe17c73e9d5bb08d29976649fa9292bac973d3e2", size = 23665, upload-time = "2024-01-18T23:50:14.785Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `~/.actor/settings.kdl` (user) and `<project>/.actor/settings.kdl` (project) KDL loader with merge semantics (project wins on overlap, walk-up from cwd, user-file dedup when cwd is inside `$HOME`)
- `Template { name, agent, prompt, config }` parser with strict validation (duplicate keys, extra args, props, non-string agent/prompt, empty name all raise `ConfigError`); unknown top-level nodes (hooks / agent / alias) parse as no-ops for forward compat with #30 / #31 / #33
- Wire `actor new --template <name>` into the CLI; explicit CLI flags (`--agent`, `--model`, `--config`, positional prompt / stdin) win over the template. `--strip-api-keys` becomes tri-state (`None` / `True` / `False`) so a template value can be overridden back to true from the CLI

## Test plan
- [x] `uv run python -m unittest discover tests` — 333 tests, all passing (38 new)
- [x] Malformed KDL raises `ConfigError` with file path in message
- [x] Duplicate template names across files merge (project wins); within a file raise
- [x] Walk-up from a deeply nested cwd finds `<root>/.actor/settings.kdl`
- [x] cwd inside `$HOME` doesn't re-parse the user config as a "project" config
- [x] `HOME` unset skips user-config lookup without error
- [x] `actor new --template qa` applies template fields; CLI flags override
- [x] Empty stdin with a template that has a `prompt` falls back to the template prompt
- [x] `actor new` surfaces `ConfigError` from a malformed settings file

Closes #29.

Scope: strictly #29. Hooks (#30), per-agent default-config blocks (#31), aliases (#33) are explicitly out of scope — their nodes are recognized and ignored at parse time for forward compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)