### PR TITLE
Add --configure flow: guided setup before spawning an actor (#38)

### DIFF
--- a/src/actor/__init__.py
+++ b/src/actor/__init__.py
@@ -35,7 +35,15 @@ from .types import (
 )
 
 # Config
-from .config import AppConfig, Template, load_config
+from .config import (
+    AgentSettings,
+    AppConfig,
+    ConfigureBlock,
+    Question,
+    QuestionOption,
+    Template,
+    load_config,
+)
 
 # Interfaces
 from .interfaces import (
@@ -107,6 +115,10 @@ __all__ = [
     # Config
     "AppConfig",
     "Template",
+    "Question",
+    "QuestionOption",
+    "ConfigureBlock",
+    "AgentSettings",
     "load_config",
     # Interfaces
     "LogEntryKind",

--- a/src/actor/__init__.py
+++ b/src/actor/__init__.py
@@ -45,6 +45,14 @@ from .config import (
     load_config,
 )
 
+# Configure flow
+from .configure import (
+    BUILTIN_QUESTIONS,
+    ConfigureDisabledError,
+    questions_to_payload,
+    resolve_questions,
+)
+
 # Interfaces
 from .interfaces import (
     LogEntryKind,
@@ -120,6 +128,11 @@ __all__ = [
     "ConfigureBlock",
     "AgentSettings",
     "load_config",
+    # Configure flow
+    "BUILTIN_QUESTIONS",
+    "ConfigureDisabledError",
+    "questions_to_payload",
+    "resolve_questions",
     # Interfaces
     "LogEntryKind",
     "LogEntry",

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: actor
 description: Manage coding agents running tasks in parallel. Use when the user wants to start, monitor, or finish background coding tasks — e.g. "spin up an actor to fix the auth module", "start three actors", "what are my actors doing", "make a PR for that actor".
-allowed-tools: mcp__actor__list_actors mcp__actor__show_actor mcp__actor__logs_actor mcp__actor__stop_actor mcp__actor__discard_actor mcp__actor__config_actor mcp__actor__new_actor mcp__actor__run_actor Bash(actor *)
+allowed-tools: mcp__actor__list_actors mcp__actor__show_actor mcp__actor__logs_actor mcp__actor__stop_actor mcp__actor__discard_actor mcp__actor__config_actor mcp__actor__new_actor mcp__actor__run_actor mcp__actor__get_configure_questions AskUserQuestion Bash(actor *)
 ---
 
 # Actor — Parallel Coding Agent Orchestrator
@@ -71,6 +71,79 @@ new_actor(name="fix-nav", prompt="...", dir="/path/to/repo")                # wo
 new_actor(name="fix-nav", prompt="...", no_worktree=True)                   # no worktree
 new_actor(name="fix-nav", prompt="...", config=["model=opus"])              # saved defaults
 ```
+
+### Guided setup (configure flow)
+
+When the user explicitly asks to be walked through actor setup — phrases
+like "create an actor with setup", "configure a new actor", "help me pick
+options", or running `actor new foo --configure` — use this flow instead
+of calling `new_actor` directly with ad-hoc values.
+
+**Steps:**
+
+1. Call `mcp__actor__get_configure_questions(agent="claude", model=<hint>)`
+   passing the agent type the actor will use and any model hint the user
+   mentioned. The tool returns `{"questions": [...]}`. Each entry has
+   `{key, kind, optional, question, header, options, multiSelect}`.
+
+2. For each entry, **strip the non-AskUserQuestion fields** (`key`,
+   `kind`, `optional`) and pass the remaining `{question, header, options,
+   multiSelect}` to `AskUserQuestion`. AskUserQuestion accepts up to 4
+   questions per call; split across multiple calls if there are more.
+
+3. AskUserQuestion returns `{answer_text: answer_value}` (keyed by the
+   question text). Map answers back using each question's original `key`
+   field:
+   - If `kind == "text"` AND `answer_value` is the literal string `"Skip"`
+     or `"Enter below"` — the user didn't provide a real answer, **skip it**.
+     (The user is expected to pick "Other" in the AskUserQuestion widget
+     and type the real value; that typed text is what arrives as
+     `answer_value`.)
+   - If `key == "prompt"` → use `answer_value` as the `prompt` parameter
+     on `new_actor`.
+   - Otherwise → append `"{key}={answer_value}"` to the `config` list on
+     `new_actor`.
+
+4. Call `new_actor(name=..., prompt=..., config=[...], agent=...)` with
+   the merged data.
+
+If `get_configure_questions` raises an error saying configure is disabled,
+skip the guided flow and call `new_actor` directly with whatever the user
+already supplied.
+
+**Customizing the question set via settings.kdl:**
+
+```kdl
+agent "claude" {
+    configure "opus" {
+        question "effort" {
+            prompt "How hard should it think?"
+            options "max" "medium" "low"
+        }
+        question "prompt" {
+            prompt "What's the goal?"
+            kind "text"
+        }
+    }
+}
+```
+
+- The block `configure "<model>" { ... }` only applies when that model is
+  the one being picked (model-scoped).
+- An un-argumented `configure { ... }` applies to the agent regardless of
+  model (agent-level).
+- Model-scoped wins over agent-level, which wins over the built-in
+  defaults.
+
+**Disabling the flow globally:**
+
+```kdl
+configure-default "off"
+```
+
+**CLI fallback:** `actor new foo --configure` triggers a stdin-based
+fallback (numbered option picks + raw text input) — no AskUserQuestion
+widget, but the same question set.
 
 ### Templates
 

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -351,19 +351,25 @@ def main(argv: Optional[List[str]] = None) -> None:
 
             configure_prompt: Optional[str] = None
             if args.configure is True:
-                # Resolve the agent hint the same way cmd_new does: explicit
-                # --agent wins; otherwise fall back to the template's agent if
-                # a template was named; otherwise default to claude.
+                # Resolve the agent + model the same way cmd_new does:
+                # explicit CLI args win; otherwise fall back to the template's
+                # values if a template was named; otherwise default to claude.
                 resolved_agent = args.agent or "claude"
-                if args.agent is None and args.template is not None:
+                resolved_model: Optional[str] = args.model
+                if args.template is not None:
                     tpl = app_config.templates.get(args.template)
-                    if tpl is not None and tpl.agent:
-                        resolved_agent = tpl.agent
+                    if tpl is not None:
+                        if args.agent is None and tpl.agent:
+                            resolved_agent = tpl.agent
+                        if resolved_model is None:
+                            tpl_model = tpl.config.get("model")
+                            if tpl_model:
+                                resolved_model = tpl_model
                 try:
                     questions = resolve_questions(
                         app_config,
                         agent=resolved_agent,
-                        model=args.model,
+                        model=resolved_model,
                     )
                 except ConfigureDisabledError as e:
                     print(f"error: {e}", file=sys.stderr)

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -6,6 +6,11 @@ import sys
 from typing import List, Optional
 
 from . import __version__
+from .configure import (
+    ConfigureDisabledError,
+    prompt_interactively,
+    resolve_questions,
+)
 from .errors import ActorError
 from .interfaces import Agent
 from .types import AgentKind, Status
@@ -88,6 +93,9 @@ Examples:
     p_new.add_argument("--strip-api-keys", action="store_const", const=True, default=None, dest="strip_api_keys", help="Strip API keys from environment (default)")
     p_new.add_argument("--no-strip-api-keys", action="store_const", const=False, dest="strip_api_keys", help="Pass API keys through to the agent")
     p_new.add_argument("--config", dest="config", action="append", default=[], metavar="KEY=VALUE", help="Config key=value pair (repeat for multiple)")
+    # Tri-state: None = no override (don't run the configure flow).
+    p_new.add_argument("--configure", action="store_const", const=True, default=None, dest="configure", help="Ask a configurable set of questions before creating (stdin fallback)")
+    p_new.add_argument("--no-configure", action="store_const", const=False, dest="configure", help="Skip the configure flow")
 
     # -- run --
     p_run = sub.add_parser(
@@ -341,6 +349,36 @@ def main(argv: Optional[List[str]] = None) -> None:
             from .config import load_config
             app_config = load_config()
 
+            configure_prompt: Optional[str] = None
+            if args.configure is True:
+                # Resolve the agent hint the same way cmd_new does: explicit
+                # --agent wins; otherwise fall back to the template's agent if
+                # a template was named; otherwise default to claude.
+                resolved_agent = args.agent or "claude"
+                if args.agent is None and args.template is not None:
+                    tpl = app_config.templates.get(args.template)
+                    if tpl is not None and tpl.agent:
+                        resolved_agent = tpl.agent
+                try:
+                    questions = resolve_questions(
+                        app_config,
+                        agent=resolved_agent,
+                        model=args.model,
+                    )
+                except ConfigureDisabledError as e:
+                    print(f"error: {e}", file=sys.stderr)
+                    sys.exit(1)
+
+                answers = prompt_interactively(questions)
+                for key, value in answers.items():
+                    if key == "prompt":
+                        # Only use the answered prompt if the user didn't
+                        # already pass one on the CLI.
+                        if args.prompt is None:
+                            configure_prompt = value
+                    else:
+                        args.config.append(f"{key}={value}")
+
             config_pairs = list(args.config)
             if args.model is not None:
                 config_pairs.append(f"model={args.model}")
@@ -366,6 +404,10 @@ def main(argv: Optional[List[str]] = None) -> None:
             if prompt is None and not sys.stdin.isatty():
                 prompt = sys.stdin.read().strip()
                 stdin_consumed = True
+            # Configure-flow prompt answer fills in only when neither the CLI
+            # arg nor piped stdin supplied a prompt.
+            if not prompt and configure_prompt is not None:
+                prompt = configure_prompt
             # Template prompt fallback runs before the empty-stdin check so
             # that `echo "" | actor new foo --template qa` uses the template's
             # prompt instead of erroring.

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -194,6 +194,27 @@ def _parse_kdl_file(path: Path) -> AppConfig:
                     f"duplicate template '{tpl.name}' in {path}"
                 )
             cfg.templates[tpl.name] = tpl
+        elif node.name == "configure-default":
+            if not node.args or not isinstance(node.args[0], str):
+                raise ConfigError(
+                    f"configure-default in {path} must be a string: "
+                    f'configure-default "on" | "off"'
+                )
+            if len(node.args) > 1:
+                raise ConfigError(
+                    f"configure-default in {path} accepts exactly one argument"
+                )
+            if getattr(node, "props", None):
+                raise ConfigError(
+                    f"configure-default in {path} does not accept properties"
+                )
+            value = node.args[0]
+            if value not in ("on", "off"):
+                raise ConfigError(
+                    f"configure-default in {path} must be \"on\" or \"off\", "
+                    f"got {value!r}"
+                )
+            cfg.configure_default = value
         # Silently ignore hooks / agent / alias — those belong to follow-up
         # tickets #30 / #31 / #33 and are not implemented here.
     return cfg

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -62,6 +62,11 @@ class AppConfig:
     templates: Dict[str, Template] = field(default_factory=dict)
     agents: Dict[str, AgentSettings] = field(default_factory=dict)
     configure_default: str = "on"
+    # Did a config file explicitly set `configure_default`? Needed during
+    # merge so a project file can override a user file's value in both
+    # directions (e.g. user "off" → project "on"), independent of which
+    # value happens to equal the hardcoded default.
+    configure_default_set: bool = False
 
 
 def _find_project_config(
@@ -325,6 +330,11 @@ def _parse_configure_block(node, agent_name: str, source: Path) -> ConfigureBloc
             )
         seen_keys.add(q.key)
         questions.append(q)
+    if not questions:
+        raise ConfigError(
+            f"{block_desc} in {source}: block is empty — declare at least "
+            f"one question, or remove the block to fall back to built-ins"
+        )
     return ConfigureBlock(model=model, questions=questions)
 
 
@@ -393,6 +403,7 @@ def _parse_kdl_file(path: Path) -> AppConfig:
                     f"got {value!r}"
                 )
             cfg.configure_default = value
+            cfg.configure_default_set = True
         elif node.name == "agent":
             agent = _parse_agent(node, path)
             if agent.name in cfg.agents:
@@ -418,18 +429,19 @@ def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
             )
         else:
             merged_agents[name] = over_agent
-    # configure_default: a non-default value in `over` overrides. If `over`
-    # didn't set it, it's still "on" (the field default), so this preserves
-    # whatever `base` had.
-    merged_default = (
-        over.configure_default
-        if over.configure_default != "on"
-        else base.configure_default
-    )
+    # configure_default: if `over` explicitly set it, that wins (either
+    # value). Otherwise inherit from `base` including its "set" flag.
+    if over.configure_default_set:
+        merged_default = over.configure_default
+        merged_default_set = True
+    else:
+        merged_default = base.configure_default
+        merged_default_set = base.configure_default_set
     return AppConfig(
         templates=merged_templates,
         agents=merged_agents,
         configure_default=merged_default,
+        configure_default_set=merged_default_set,
     )
 
 

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import kdl
 
@@ -29,8 +29,39 @@ class Template:
 
 
 @dataclass
+class QuestionOption:
+    label: str
+    description: str = ""
+
+
+@dataclass
+class Question:
+    key: str
+    prompt: str
+    header: str
+    options: List[QuestionOption]
+    kind: str = "options"
+    optional: bool = False
+    multi_select: bool = False
+
+
+@dataclass
+class ConfigureBlock:
+    model: Optional[str]
+    questions: List[Question]
+
+
+@dataclass
+class AgentSettings:
+    name: str
+    configure_blocks: Dict[Optional[str], ConfigureBlock] = field(default_factory=dict)
+
+
+@dataclass
 class AppConfig:
     templates: Dict[str, Template] = field(default_factory=dict)
+    agents: Dict[str, AgentSettings] = field(default_factory=dict)
+    configure_default: str = "on"
 
 
 def _find_project_config(
@@ -171,7 +202,29 @@ def _parse_kdl_file(path: Path) -> AppConfig:
 def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
     merged_templates = dict(base.templates)
     merged_templates.update(over.templates)
-    return AppConfig(templates=merged_templates)
+    merged_agents: Dict[str, AgentSettings] = dict(base.agents)
+    for name, over_agent in over.agents.items():
+        if name in merged_agents:
+            merged_blocks = dict(merged_agents[name].configure_blocks)
+            merged_blocks.update(over_agent.configure_blocks)
+            merged_agents[name] = AgentSettings(
+                name=name, configure_blocks=merged_blocks
+            )
+        else:
+            merged_agents[name] = over_agent
+    # configure_default: a non-default value in `over` overrides. If `over`
+    # didn't set it, it's still "on" (the field default), so this preserves
+    # whatever `base` had.
+    merged_default = (
+        over.configure_default
+        if over.configure_default != "on"
+        else base.configure_default
+    )
+    return AppConfig(
+        templates=merged_templates,
+        agents=merged_agents,
+        configure_default=merged_default,
+    )
 
 
 def load_config(

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -176,6 +176,184 @@ def _parse_template(node, source: Path) -> Template:
     return tpl
 
 
+def _parse_question(node, block_desc: str, source: Path) -> Question:
+    if not node.args or not isinstance(node.args[0], str) or not node.args[0]:
+        raise ConfigError(
+            f"question in {block_desc} of {source} must have a string key "
+            f'(e.g. `question "model" {{ ... }}`)'
+        )
+    if len(node.args) > 1:
+        raise ConfigError(
+            f"question '{node.args[0]}' in {block_desc} of {source} has extra args"
+        )
+    if getattr(node, "props", None):
+        raise ConfigError(
+            f"question '{node.args[0]}' in {block_desc} of {source} "
+            f"does not accept properties"
+        )
+    key = node.args[0]
+    prompt: Optional[str] = None
+    header: Optional[str] = None
+    kind = "options"
+    optional = False
+    multi_select = False
+    options: List[QuestionOption] = []
+    seen_keys: set[str] = set()
+    for child in node.nodes:
+        cname = child.name
+        if cname in seen_keys:
+            raise ConfigError(
+                f"question '{key}' in {block_desc} of {source}: "
+                f"duplicate child '{cname}'"
+            )
+        seen_keys.add(cname)
+        if cname == "prompt":
+            if not child.args or not isinstance(child.args[0], str):
+                raise ConfigError(
+                    f"question '{key}' in {block_desc} of {source}: "
+                    f"prompt must be a string"
+                )
+            prompt = child.args[0]
+        elif cname == "header":
+            if not child.args or not isinstance(child.args[0], str):
+                raise ConfigError(
+                    f"question '{key}' in {block_desc} of {source}: "
+                    f"header must be a string"
+                )
+            header = child.args[0]
+        elif cname == "kind":
+            if not child.args or child.args[0] not in ("options", "text"):
+                raise ConfigError(
+                    f"question '{key}' in {block_desc} of {source}: "
+                    f'kind must be "options" or "text"'
+                )
+            kind = child.args[0]
+        elif cname == "optional":
+            if not child.args or not isinstance(child.args[0], bool):
+                raise ConfigError(
+                    f"question '{key}' in {block_desc} of {source}: "
+                    f"optional must be a boolean"
+                )
+            optional = child.args[0]
+        elif cname == "multi-select":
+            if not child.args or not isinstance(child.args[0], bool):
+                raise ConfigError(
+                    f"question '{key}' in {block_desc} of {source}: "
+                    f"multi-select must be a boolean"
+                )
+            multi_select = child.args[0]
+        elif cname == "options":
+            if not child.args:
+                raise ConfigError(
+                    f"question '{key}' in {block_desc} of {source}: "
+                    f"options needs at least one value"
+                )
+            for arg in child.args:
+                if not isinstance(arg, str):
+                    raise ConfigError(
+                        f"question '{key}' in {block_desc} of {source}: "
+                        f"option values must be strings"
+                    )
+                options.append(QuestionOption(label=arg))
+        else:
+            raise ConfigError(
+                f"question '{key}' in {block_desc} of {source}: "
+                f"unknown child '{cname}'"
+            )
+
+    if prompt is None:
+        raise ConfigError(
+            f"question '{key}' in {block_desc} of {source}: prompt is required"
+        )
+    if kind == "text" and options:
+        raise ConfigError(
+            f"question '{key}' in {block_desc} of {source}: "
+            f"text-kind questions cannot declare options"
+        )
+    if kind == "options" and not options:
+        raise ConfigError(
+            f"question '{key}' in {block_desc} of {source}: "
+            f"options-kind questions need an options list"
+        )
+
+    if header is None:
+        # Default: key, hyphens → spaces, title-cased, trimmed to 12 chars for
+        # AskUserQuestion compatibility.
+        header = key.replace("-", " ").title()[:12]
+
+    return Question(
+        key=key,
+        prompt=prompt,
+        header=header,
+        options=options,
+        kind=kind,
+        optional=optional,
+        multi_select=multi_select,
+    )
+
+
+def _parse_configure_block(node, agent_name: str, source: Path) -> ConfigureBlock:
+    model: Optional[str] = None
+    if node.args:
+        if len(node.args) > 1:
+            raise ConfigError(
+                f"configure block in agent '{agent_name}' in {source} "
+                f"takes at most one model arg"
+            )
+        if not isinstance(node.args[0], str) or not node.args[0]:
+            raise ConfigError(
+                f"configure block in agent '{agent_name}' in {source}: "
+                f"model must be a non-empty string"
+            )
+        model = node.args[0]
+    block_desc = (
+        f'agent "{agent_name}" configure "{model}"'
+        if model is not None
+        else f'agent "{agent_name}" configure'
+    )
+    questions: List[Question] = []
+    seen_keys: set[str] = set()
+    for child in node.nodes:
+        if child.name != "question":
+            raise ConfigError(
+                f"{block_desc} in {source}: unknown child '{child.name}'"
+            )
+        q = _parse_question(child, block_desc, source)
+        if q.key in seen_keys:
+            raise ConfigError(
+                f"{block_desc} in {source}: duplicate question '{q.key}'"
+            )
+        seen_keys.add(q.key)
+        questions.append(q)
+    return ConfigureBlock(model=model, questions=questions)
+
+
+def _parse_agent(node, source: Path) -> AgentSettings:
+    if not node.args or not isinstance(node.args[0], str) or not node.args[0]:
+        raise ConfigError(
+            f"agent block in {source} needs a non-empty name "
+            f'(e.g. `agent "claude" {{ ... }}`)'
+        )
+    if len(node.args) > 1:
+        raise ConfigError(
+            f"agent '{node.args[0]}' in {source} has extra positional args"
+        )
+    name = node.args[0]
+    s = AgentSettings(name=name)
+    for child in node.nodes:
+        if child.name == "configure":
+            block = _parse_configure_block(child, name, source)
+            if block.model in s.configure_blocks:
+                label = f'"{block.model}"' if block.model else "(default)"
+                raise ConfigError(
+                    f"agent '{name}' in {source}: duplicate configure block {label}"
+                )
+            s.configure_blocks[block.model] = block
+        # Other children (default-config, hooks, alias) — silently ignored
+        # for forward-compat with tickets #30 / #31 / #33.
+    return s
+
+
 def _parse_kdl_file(path: Path) -> AppConfig:
     try:
         text = path.read_text()
@@ -215,8 +393,15 @@ def _parse_kdl_file(path: Path) -> AppConfig:
                     f"got {value!r}"
                 )
             cfg.configure_default = value
-        # Silently ignore hooks / agent / alias — those belong to follow-up
-        # tickets #30 / #31 / #33 and are not implemented here.
+        elif node.name == "agent":
+            agent = _parse_agent(node, path)
+            if agent.name in cfg.agents:
+                raise ConfigError(
+                    f"duplicate agent block for '{agent.name}' in {path}"
+                )
+            cfg.agents[agent.name] = agent
+        # Silently ignore hooks / alias — those belong to follow-up tickets
+        # #30 / #33 and are not implemented here.
     return cfg
 
 

--- a/src/actor/configure.py
+++ b/src/actor/configure.py
@@ -18,7 +18,7 @@ enables, "off" disables. When "off", `resolve_questions` raises
 """
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 from .config import AppConfig, Question, QuestionOption
 from .errors import ActorError
@@ -178,3 +178,60 @@ def questions_to_payload(questions: List[Question]) -> Dict:
             }
         )
     return {"questions": out_questions}
+
+
+def prompt_interactively(
+    questions: List[Question],
+    input_fn: Callable[..., str] = input,
+    output_fn: Callable[[str], None] = print,
+) -> Dict[str, str]:
+    """Walk the user through questions on stdin. Returns {key: value}.
+
+    Options-kind: user types the option number (1-based) or a label; invalid
+    input reprompts. Text-kind: raw input; empty string skips if `optional`,
+    else reprompts.
+
+    The input/output callables are injectable so tests can drive the flow
+    without touching a real terminal. Tests typically pass a zero-arg
+    `iter([...]).__next__`; we wrap the call so both zero-arg and
+    one-arg (real `input`) signatures work.
+    """
+    answers: Dict[str, str] = {}
+
+    def _ask(prompt_text: str) -> str:
+        try:
+            return input_fn(prompt_text)
+        except TypeError:
+            return input_fn()
+
+    for q in questions:
+        output_fn(f"\n{q.prompt}")
+        if q.kind == "text":
+            suffix = " (optional, enter to skip)" if q.optional else ""
+            while True:
+                raw = _ask(f"{q.header}{suffix}: ").strip()
+                if raw:
+                    answers[q.key] = raw
+                    break
+                if q.optional:
+                    break
+                output_fn("  (answer required)")
+        else:
+            for i, opt in enumerate(q.options, 1):
+                tail = f" — {opt.description}" if opt.description else ""
+                output_fn(f"  {i}. {opt.label}{tail}")
+            while True:
+                raw = _ask(f"{q.header}: ").strip()
+                if raw.isdigit():
+                    idx = int(raw)
+                    if 1 <= idx <= len(q.options):
+                        answers[q.key] = q.options[idx - 1].label
+                        break
+                    output_fn(f"  (enter 1-{len(q.options)} or a label)")
+                    continue
+                labels = [o.label for o in q.options]
+                if raw in labels:
+                    answers[q.key] = raw
+                    break
+                output_fn(f"  (unknown — enter 1-{len(q.options)} or a label)")
+    return answers

--- a/src/actor/configure.py
+++ b/src/actor/configure.py
@@ -1,0 +1,180 @@
+"""Configure flow: built-in question defaults, resolver, AskUserQuestion payload shaping.
+
+The outer Claude Code session calls `get_configure_questions(agent, model)` via
+MCP, which returns a payload shaped for AskUserQuestion plus extra per-question
+metadata (`key`, `kind`, `optional`) so the LLM can map answers back to
+`new_actor` config pairs.
+
+Resolution order (model-scoped wins over agent-level, which wins over builtins):
+  1. Built-in default for the agent (BUILTIN_QUESTIONS).
+  2. `agent "<name>" { configure { ... } }` (agent-level override).
+  3. `agent "<name>" { configure "<model>" { ... } }` (model-scoped override).
+
+User + project layering is already handled at load time in `_merge`.
+
+The `configure-default` top-level KDL key toggles the feature: "on" (default)
+enables, "off" disables. When "off", `resolve_questions` raises
+`ConfigureDisabledError`.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from .config import AppConfig, Question, QuestionOption
+from .errors import ActorError
+
+
+class ConfigureDisabledError(ActorError):
+    """Raised when configure-default is 'off' and resolution is attempted."""
+
+    def __init__(self, message: Optional[str] = None) -> None:
+        super().__init__(
+            message
+            or 'configure flow is disabled globally (configure-default "off")'
+        )
+
+
+# Built-in defaults. Labels are the actual config values (what `actor config`
+# accepts) so the answer strings can be used verbatim.
+BUILTIN_QUESTIONS: Dict[str, List[Question]] = {
+    "claude": [
+        Question(
+            key="model",
+            prompt="Which Claude model?",
+            header="Model",
+            options=[
+                QuestionOption("opus", "Most capable, highest cost"),
+                QuestionOption("sonnet", "Balanced"),
+                QuestionOption("haiku", "Fastest, lowest cost"),
+            ],
+        ),
+        Question(
+            key="effort",
+            prompt="How hard should it think?",
+            header="Effort",
+            options=[
+                QuestionOption("max", "Maximum thinking"),
+                QuestionOption("high"),
+                QuestionOption("medium"),
+                QuestionOption("low"),
+            ],
+        ),
+        Question(
+            key="permission-mode",
+            prompt="Permission mode?",
+            header="Perms",
+            options=[
+                QuestionOption(
+                    "bypassPermissions", "Skip all permission checks (default)"
+                ),
+                QuestionOption(
+                    "acceptEdits", "Auto-approve file edits, ask for other actions"
+                ),
+                QuestionOption("plan", "Plan mode — no edits"),
+            ],
+        ),
+        Question(
+            key="prompt",
+            prompt="Initial prompt (optional)?",
+            header="Prompt",
+            options=[],
+            kind="text",
+            optional=True,
+        ),
+    ],
+    "codex": [
+        Question(
+            key="sandbox",
+            prompt="Sandbox policy?",
+            header="Sandbox",
+            options=[
+                QuestionOption("danger-full-access", "No sandboxing (default)"),
+                QuestionOption(
+                    "workspace-write", "Writes only inside the workspace"
+                ),
+                QuestionOption("read-only", "No writes allowed"),
+            ],
+        ),
+        Question(
+            key="prompt",
+            prompt="Initial prompt (optional)?",
+            header="Prompt",
+            options=[],
+            kind="text",
+            optional=True,
+        ),
+    ],
+}
+
+
+def resolve_questions(
+    config: AppConfig,
+    agent: str,
+    model: Optional[str],
+) -> List[Question]:
+    """Resolve the effective question list for (agent, model).
+
+    Raises ConfigureDisabledError if the feature is off globally, and
+    ActorError if the agent name is unknown.
+    """
+    if config.configure_default == "off":
+        raise ConfigureDisabledError()
+
+    if agent not in BUILTIN_QUESTIONS:
+        raise ActorError(
+            f"unknown agent '{agent}' — supported: {sorted(BUILTIN_QUESTIONS)}"
+        )
+
+    settings = config.agents.get(agent)
+    if settings is not None:
+        if model is not None and model in settings.configure_blocks:
+            return list(settings.configure_blocks[model].questions)
+        if None in settings.configure_blocks:
+            return list(settings.configure_blocks[None].questions)
+
+    return list(BUILTIN_QUESTIONS[agent])
+
+
+# Sentinel labels for synthesized text-question options.
+TEXT_ENTER_LABEL = "Enter below"
+TEXT_SKIP_LABEL = "Skip"
+
+
+def questions_to_payload(questions: List[Question]) -> Dict:
+    """Convert Question objects into an AskUserQuestion-shaped payload.
+
+    Each payload entry keeps per-question metadata (`key`, `kind`, `optional`)
+    so the LLM can map answers back to config keys. The skill in
+    `src/actor/_skill/SKILL.md` documents the mapping contract.
+    """
+    out_questions = []
+    for q in questions:
+        header = q.header[:12]
+        if q.kind == "text":
+            options = [
+                {
+                    "label": TEXT_ENTER_LABEL,
+                    "description": "Select 'Other' below to type your answer",
+                },
+                {
+                    "label": TEXT_SKIP_LABEL,
+                    "description": "Leave this unset",
+                },
+            ]
+        else:
+            options = [
+                {"label": opt.label, "description": opt.description}
+                for opt in q.options
+            ]
+        out_questions.append(
+            {
+                "key": q.key,
+                "kind": q.kind,
+                "optional": q.optional,
+                "question": q.prompt,
+                "header": header,
+                "options": options,
+                "multiSelect": q.multi_select,
+            }
+        )
+    return {"questions": out_questions}

--- a/src/actor/server.py
+++ b/src/actor/server.py
@@ -15,6 +15,8 @@ from mcp.server.stdio import stdio_server
 from mcp.shared.message import SessionMessage
 from mcp.types import JSONRPCMessage, JSONRPCNotification
 
+from .config import AppConfig, load_config
+from .configure import questions_to_payload, resolve_questions
 from .db import Database
 from .errors import ActorError
 from .git import RealGit
@@ -71,6 +73,12 @@ mcp = ActorMCP("actor.sh", instructions=_build_instructions())
 
 def _db() -> Database:
     return Database.open(_db_path())
+
+
+def _load_app_config() -> AppConfig:
+    """Indirection so tests can patch the config load without touching the
+    real filesystem."""
+    return load_config()
 
 
 async def _send_channel_notification(
@@ -149,6 +157,32 @@ def discard_actor(name: str) -> str:
         name: Actor name.
     """
     return cmd_discard(_db(), RealProcessManager(), name=name)
+
+
+@mcp.tool()
+def get_configure_questions(agent: str, model: str | None = None) -> dict:
+    """Return the configure question set for (agent, model) as an AskUserQuestion-shaped payload.
+
+    Use this when the user explicitly asks to be walked through actor setup
+    (e.g. "create an actor with setup", "help me configure this",
+    "--configure"). Pipe the returned `questions` array into AskUserQuestion
+    after dropping each entry's `key`, `kind`, `optional` fields — those
+    are only for mapping answers back to `new_actor` parameters.
+
+    When AskUserQuestion returns `{question_text: answer_value}`:
+      - If kind=="text" and answer_value is "Skip" / "Enter below",
+        the user didn't provide an answer — skip it.
+      - If key == "prompt", use answer_value as the `prompt` param on new_actor.
+      - Otherwise append "key=answer_value" to the `config` list on new_actor.
+
+    Args:
+        agent: Coding agent — "claude" or "codex".
+        model: Optional model hint. Selects a model-scoped configure block if
+               one exists in settings.kdl, otherwise the agent-level default.
+    """
+    cfg = _load_app_config()
+    questions = resolve_questions(cfg, agent=agent, model=model)
+    return questions_to_payload(questions)
 
 
 @mcp.tool()

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -574,6 +574,55 @@ class ConfigureFlagTests(unittest.TestCase):
         cmd_run.assert_called_once()
         self.assertEqual(cmd_run.call_args.kwargs["prompt"], "cli prompt")
 
+    def test_configure_flag_uses_template_model_for_resolution(self):
+        """When --configure + --template is used (no explicit --model), the
+        resolver should see the template's model so model-scoped `configure`
+        blocks apply."""
+        from actor import AppConfig
+        from actor.config import (
+            AgentSettings,
+            ConfigureBlock,
+            Question,
+            QuestionOption,
+            Template,
+        )
+
+        opus_block = ConfigureBlock(
+            model="opus",
+            questions=[
+                Question(
+                    key="opus-only",
+                    prompt="?",
+                    header="Opus",
+                    options=[QuestionOption("a"), QuestionOption("b")],
+                )
+            ],
+        )
+        app_config = AppConfig(
+            templates={
+                "qa": Template(name="qa", agent="claude", config={"model": "opus"})
+            },
+            agents={
+                "claude": AgentSettings(
+                    name="claude", configure_blocks={"opus": opus_block}
+                )
+            },
+        )
+
+        captured = {}
+
+        def fake_prompt(questions, **_):
+            captured["keys"] = [q.key for q in questions]
+            return {}
+
+        prompt_fn = MagicMock(side_effect=fake_prompt)
+        self._run(
+            ["new", "foo", "--configure", "--template", "qa"],
+            prompt_fn=prompt_fn,
+            app_config=app_config,
+        )
+        self.assertEqual(captured["keys"], ["opus-only"])
+
 
 class GetConfigureQuestionsTests(unittest.TestCase):
     """MCP `get_configure_questions(agent, model)` tool."""

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -476,5 +476,73 @@ class McpToolTests(unittest.TestCase):
         self.assertEqual(kwargs["config_pairs"], ["model=opus"])
 
 
+class GetConfigureQuestionsTests(unittest.TestCase):
+    """MCP `get_configure_questions(agent, model)` tool."""
+
+    def _call(self, agent="claude", model=None, app_config=None):
+        from actor import AppConfig, server
+        if app_config is None:
+            app_config = AppConfig()
+        with patch("actor.server._load_app_config", return_value=app_config):
+            return server.get_configure_questions(agent=agent, model=model)
+
+    def test_returns_builtin_claude_questions(self):
+        from actor.configure import BUILTIN_QUESTIONS
+        result = self._call(agent="claude")
+        keys = [q["key"] for q in result["questions"]]
+        self.assertEqual(keys, [q.key for q in BUILTIN_QUESTIONS["claude"]])
+
+    def test_returns_builtin_codex_questions(self):
+        result = self._call(agent="codex")
+        keys = {q["key"] for q in result["questions"]}
+        self.assertIn("sandbox", keys)
+
+    def test_unknown_agent_raises(self):
+        with self.assertRaises(ActorError):
+            self._call(agent="bogus")
+
+    def test_disabled_raises(self):
+        from actor import AppConfig
+        from actor.configure import ConfigureDisabledError
+        cfg = AppConfig(configure_default="off")
+        with self.assertRaises(ConfigureDisabledError):
+            self._call(agent="claude", app_config=cfg)
+
+    def test_model_scoped_override_is_honored(self):
+        from actor import (
+            AgentSettings,
+            AppConfig,
+            ConfigureBlock,
+            Question,
+            QuestionOption,
+        )
+        agent = AgentSettings(
+            name="claude",
+            configure_blocks={
+                "opus": ConfigureBlock(
+                    model="opus",
+                    questions=[
+                        Question(
+                            key="custom",
+                            prompt="Custom?",
+                            header="Custom",
+                            options=[QuestionOption("x"), QuestionOption("y")],
+                        )
+                    ],
+                )
+            },
+        )
+        cfg = AppConfig(agents={"claude": agent})
+        result = self._call(agent="claude", model="opus", app_config=cfg)
+        self.assertEqual([q["key"] for q in result["questions"]], ["custom"])
+
+    def test_text_question_gets_two_sentinel_options(self):
+        result = self._call(agent="claude")
+        prompt_q = next(q for q in result["questions"] if q["key"] == "prompt")
+        labels = {o["label"] for o in prompt_q["options"]}
+        self.assertIn("Skip", labels)
+        self.assertIn("Enter below", labels)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -476,6 +476,105 @@ class McpToolTests(unittest.TestCase):
         self.assertEqual(kwargs["config_pairs"], ["model=opus"])
 
 
+class ConfigureFlagTests(unittest.TestCase):
+    """`actor new --configure` triggers the stdin interactive fallback."""
+
+    def _run(self, argv, prompt_fn=None, app_config=None):
+        from contextlib import ExitStack
+        from actor import AppConfig
+        if app_config is None:
+            app_config = AppConfig()
+        fake_db = MagicMock()
+        fake_actor = MagicMock()
+        fake_actor.name = argv[1] if len(argv) > 1 else "a"
+        fake_actor.dir = "/tmp/actor"
+        cmd_new = MagicMock(return_value=fake_actor)
+        cmd_run = MagicMock(return_value="done")
+
+        stdin = io.StringIO("")
+        stdin.isatty = lambda: True  # type: ignore[assignment]
+
+        err = io.StringIO()
+        with ExitStack() as stack:
+            stack.enter_context(patch("actor.cli.cmd_new", cmd_new))
+            stack.enter_context(patch("actor.cli.cmd_run", cmd_run))
+            stack.enter_context(
+                patch("actor.config.load_config", return_value=app_config)
+            )
+            db_cls = stack.enter_context(patch("actor.cli.Database"))
+            db_cls.open.return_value = fake_db
+            stack.enter_context(
+                patch("actor.cli._create_agent", return_value=MagicMock())
+            )
+            stack.enter_context(patch("sys.stdin", stdin))
+            stack.enter_context(patch("sys.stderr", err))
+            if prompt_fn is not None:
+                stack.enter_context(
+                    patch("actor.cli.prompt_interactively", prompt_fn)
+                )
+            try:
+                main(argv)
+                code = 0
+            except SystemExit as e:
+                code = e.code if isinstance(e.code, int) else 1
+        return cmd_new, cmd_run, code, err.getvalue()
+
+    def test_configure_flag_calls_prompt_interactively_and_maps_to_config(self):
+        prompt_fn = MagicMock(return_value={"model": "opus", "effort": "max"})
+        cmd_new, cmd_run, code, _ = self._run(["new", "foo", "--configure"], prompt_fn=prompt_fn)
+        prompt_fn.assert_called_once()
+        pairs = cmd_new.call_args.kwargs["config_pairs"]
+        self.assertIn("model=opus", pairs)
+        self.assertIn("effort=max", pairs)
+
+    def test_configure_flag_uses_prompt_answer_as_prompt_param(self):
+        prompt_fn = MagicMock(return_value={"prompt": "fix nav"})
+        cmd_new, cmd_run, code, _ = self._run(["new", "foo", "--configure"], prompt_fn=prompt_fn)
+        cmd_run.assert_called_once()
+        self.assertEqual(cmd_run.call_args.kwargs["prompt"], "fix nav")
+
+    def test_configure_flag_errors_when_disabled(self):
+        from actor import AppConfig
+        app_config = AppConfig(configure_default="off")
+        _, _, code, err = self._run(["new", "foo", "--configure"], app_config=app_config)
+        self.assertEqual(code, 1)
+        self.assertIn("disabled", err)
+
+    def test_no_configure_does_not_prompt(self):
+        prompt_fn = MagicMock()
+        self._run(["new", "foo", "--no-configure"], prompt_fn=prompt_fn)
+        prompt_fn.assert_not_called()
+
+    def test_bare_new_does_not_prompt(self):
+        # Without --configure, the flow should not run (the plan treats
+        # configure as opt-in on the CLI).
+        prompt_fn = MagicMock()
+        self._run(["new", "foo"], prompt_fn=prompt_fn)
+        prompt_fn.assert_not_called()
+
+    def test_configure_flag_resolves_with_agent_from_flag(self):
+        captured = {}
+
+        def fake_prompt(questions, **_):
+            captured["keys"] = [q.key for q in questions]
+            return {}
+
+        prompt_fn = MagicMock(side_effect=fake_prompt)
+        self._run(["new", "foo", "--configure", "--agent", "codex"], prompt_fn=prompt_fn)
+        self.assertIn("sandbox", captured["keys"])
+        self.assertNotIn("model", captured["keys"])
+
+    def test_configure_flag_explicit_prompt_beats_answer(self):
+        """If the user already passed a prompt on the CLI, the 'prompt'
+        answer from the configure flow should not override it."""
+        prompt_fn = MagicMock(return_value={"prompt": "from flow"})
+        cmd_new, cmd_run, _, _ = self._run(
+            ["new", "foo", "cli prompt", "--configure"], prompt_fn=prompt_fn
+        )
+        cmd_run.assert_called_once()
+        self.assertEqual(cmd_run.call_args.kwargs["prompt"], "cli prompt")
+
+
 class GetConfigureQuestionsTests(unittest.TestCase):
     """MCP `get_configure_questions(agent, model)` tool."""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -342,6 +342,34 @@ class TestConfigureDefaultParsing(unittest.TestCase):
             cfg = load_config(cwd=Path(cwd), home=Path(home))
             self.assertEqual(cfg.configure_default, "off")
 
+    def test_project_on_overrides_user_off(self):
+        # A user who disabled configure globally should be able to re-enable
+        # it per-project — explicit overrides should win regardless of value.
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            (Path(home) / ".actor").mkdir()
+            (Path(home) / ".actor" / "settings.kdl").write_text(
+                'configure-default "off"\n'
+            )
+            (Path(cwd) / ".actor").mkdir()
+            (Path(cwd) / ".actor" / "settings.kdl").write_text(
+                'configure-default "on"\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.configure_default, "on")
+
+    def test_user_off_preserved_when_project_does_not_set(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            (Path(home) / ".actor").mkdir()
+            (Path(home) / ".actor" / "settings.kdl").write_text(
+                'configure-default "off"\n'
+            )
+            (Path(cwd) / ".actor").mkdir()
+            (Path(cwd) / ".actor" / "settings.kdl").write_text(
+                'template "qa" {\n    agent "claude"\n}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.configure_default, "off")
+
 
 class TestAgentConfigureParsing(unittest.TestCase):
 
@@ -497,6 +525,19 @@ class TestAgentConfigureParsing(unittest.TestCase):
         )
         with self.assertRaises(ConfigError):
             self._load(body)
+
+    def test_empty_configure_block_raises(self):
+        # An empty `configure { }` block used to silently erase the agent's
+        # built-in question set. Force the user to be explicit.
+        body = (
+            'agent "claude" {\n'
+            "    configure {\n"
+            "    }\n"
+            "}\n"
+        )
+        with self.assertRaises(ConfigError) as ctx:
+            self._load(body)
+        self.assertIn("empty", str(ctx.exception))
 
     def test_project_configure_replaces_user_configure_for_same_agent_and_model(self):
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -343,6 +343,207 @@ class TestConfigureDefaultParsing(unittest.TestCase):
             self.assertEqual(cfg.configure_default, "off")
 
 
+class TestAgentConfigureParsing(unittest.TestCase):
+
+    def _load(self, body: str) -> AppConfig:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(body)
+            return load_config(cwd=Path(cwd), home=Path(home))
+
+    def test_agent_level_configure_with_options_question(self):
+        body = (
+            'agent "claude" {\n'
+            "    configure {\n"
+            '        question "effort" {\n'
+            '            prompt "How hard?"\n'
+            '            options "max" "medium" "low"\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        cfg = self._load(body)
+        self.assertIn("claude", cfg.agents)
+        block = cfg.agents["claude"].configure_blocks[None]
+        self.assertEqual(len(block.questions), 1)
+        q = block.questions[0]
+        self.assertEqual(q.key, "effort")
+        self.assertEqual(q.prompt, "How hard?")
+        self.assertEqual([o.label for o in q.options], ["max", "medium", "low"])
+        self.assertEqual(q.kind, "options")
+
+    def test_model_scoped_configure(self):
+        body = (
+            'agent "claude" {\n'
+            '    configure "opus" {\n'
+            '        question "effort" {\n'
+            '            prompt "How hard?"\n'
+            '            options "max" "low"\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        cfg = self._load(body)
+        self.assertIn("opus", cfg.agents["claude"].configure_blocks)
+        self.assertNotIn(None, cfg.agents["claude"].configure_blocks)
+
+    def test_text_kind_question(self):
+        body = (
+            'agent "claude" {\n'
+            "    configure {\n"
+            '        question "focus" {\n'
+            '            prompt "Focus dir?"\n'
+            '            kind "text"\n'
+            "            optional true\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        cfg = self._load(body)
+        q = cfg.agents["claude"].configure_blocks[None].questions[0]
+        self.assertEqual(q.kind, "text")
+        self.assertTrue(q.optional)
+        self.assertEqual(q.options, [])
+
+    def test_question_header_override(self):
+        body = (
+            'agent "claude" {\n'
+            "    configure {\n"
+            '        question "effort" {\n'
+            '            prompt "How hard?"\n'
+            '            header "Effort"\n'
+            '            options "max" "low"\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        cfg = self._load(body)
+        q = cfg.agents["claude"].configure_blocks[None].questions[0]
+        self.assertEqual(q.header, "Effort")
+
+    def test_unknown_agent_child_silently_ignored(self):
+        # 'default-config' belongs to #31; ignore it here for forward-compat.
+        body = (
+            'agent "claude" {\n'
+            "    default-config {\n"
+            '        model "opus"\n'
+            "    }\n"
+            "    configure {\n"
+            '        question "effort" {\n'
+            '            prompt "How hard?"\n'
+            '            options "max" "low"\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        cfg = self._load(body)
+        self.assertIn("claude", cfg.agents)
+        self.assertEqual(
+            len(cfg.agents["claude"].configure_blocks[None].questions), 1
+        )
+
+    def test_question_without_prompt_raises(self):
+        body = (
+            'agent "claude" {\n'
+            "    configure {\n"
+            '        question "effort" {\n'
+            '            options "max" "low"\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        with self.assertRaises(ConfigError) as ctx:
+            self._load(body)
+        self.assertIn("prompt", str(ctx.exception))
+
+    def test_options_question_with_zero_options_raises(self):
+        body = (
+            'agent "claude" {\n'
+            "    configure {\n"
+            '        question "effort" {\n'
+            '            prompt "How hard?"\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        with self.assertRaises(ConfigError):
+            self._load(body)
+
+    def test_text_question_with_options_raises(self):
+        body = (
+            'agent "claude" {\n'
+            "    configure {\n"
+            '        question "focus" {\n'
+            '            prompt "Focus dir?"\n'
+            '            kind "text"\n'
+            '            options "a" "b"\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        with self.assertRaises(ConfigError) as ctx:
+            self._load(body)
+        self.assertIn("text", str(ctx.exception))
+
+    def test_duplicate_question_key_in_block_raises(self):
+        body = (
+            'agent "claude" {\n'
+            "    configure {\n"
+            '        question "effort" { prompt "a"; options "x" "y" }\n'
+            '        question "effort" { prompt "b"; options "x" "y" }\n'
+            "    }\n"
+            "}\n"
+        )
+        with self.assertRaises(ConfigError):
+            self._load(body)
+
+    def test_project_configure_replaces_user_configure_for_same_agent_and_model(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            (Path(home) / ".actor").mkdir()
+            (Path(home) / ".actor" / "settings.kdl").write_text(
+                'agent "claude" {\n'
+                "    configure {\n"
+                '        question "effort" {\n'
+                '            prompt "user prompt"\n'
+                '            options "low" "high"\n'
+                "        }\n"
+                "    }\n"
+                "}\n"
+            )
+            (Path(cwd) / ".actor").mkdir()
+            (Path(cwd) / ".actor" / "settings.kdl").write_text(
+                'agent "claude" {\n'
+                "    configure {\n"
+                '        question "effort" {\n'
+                '            prompt "project prompt"\n'
+                '            options "med" "top"\n'
+                "        }\n"
+                "    }\n"
+                "}\n"
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            q = cfg.agents["claude"].configure_blocks[None].questions[0]
+            self.assertEqual(q.prompt, "project prompt")
+            self.assertEqual([o.label for o in q.options], ["med", "top"])
+
+    def test_duplicate_agent_block_in_single_file_raises(self):
+        body = (
+            'agent "claude" {\n'
+            "    configure {\n"
+            '        question "a" { prompt "?"; options "x" "y" }\n'
+            "    }\n"
+            "}\n"
+            'agent "claude" {\n'
+            "    configure {\n"
+            '        question "b" { prompt "?"; options "x" "y" }\n'
+            "    }\n"
+            "}\n"
+        )
+        with self.assertRaises(ConfigError):
+            self._load(body)
+
+
 class TestAppConfigDefaults(unittest.TestCase):
 
     def test_empty_app_config_has_no_agents_and_on_default(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,15 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from actor.config import AppConfig, Template, load_config
+from actor.config import (
+    AgentSettings,
+    AppConfig,
+    ConfigureBlock,
+    Question,
+    QuestionOption,
+    Template,
+    load_config,
+)
 from actor.errors import ConfigError
 
 
@@ -289,6 +297,29 @@ class TestLoadConfigCwdUnderHome(unittest.TestCase):
             )
             cfg = load_config(cwd=proj, home=home_p)
             self.assertEqual(cfg.templates["qa"].agent, "codex")
+
+
+class TestAppConfigDefaults(unittest.TestCase):
+
+    def test_empty_app_config_has_no_agents_and_on_default(self):
+        cfg = AppConfig()
+        self.assertEqual(cfg.agents, {})
+        self.assertEqual(cfg.configure_default, "on")
+
+    def test_agent_settings_roundtrip(self):
+        block = ConfigureBlock(
+            model="opus",
+            questions=[
+                Question(
+                    key="effort",
+                    prompt="How hard?",
+                    header="Effort",
+                    options=[QuestionOption(label="max"), QuestionOption(label="low")],
+                )
+            ],
+        )
+        s = AgentSettings(name="claude", configure_blocks={"opus": block})
+        self.assertEqual(s.configure_blocks["opus"].questions[0].key, "effort")
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -299,6 +299,50 @@ class TestLoadConfigCwdUnderHome(unittest.TestCase):
             self.assertEqual(cfg.templates["qa"].agent, "codex")
 
 
+class TestConfigureDefaultParsing(unittest.TestCase):
+
+    def _load(self, body: str) -> AppConfig:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(body)
+            return load_config(cwd=Path(cwd), home=Path(home))
+
+    def test_default_when_absent_is_on(self):
+        cfg = self._load('template "qa" {\n    agent "claude"\n}\n')
+        self.assertEqual(cfg.configure_default, "on")
+
+    def test_explicit_off(self):
+        cfg = self._load('configure-default "off"\n')
+        self.assertEqual(cfg.configure_default, "off")
+
+    def test_explicit_on(self):
+        cfg = self._load('configure-default "on"\n')
+        self.assertEqual(cfg.configure_default, "on")
+
+    def test_invalid_value_raises(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text('configure-default "maybe"\n')
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("configure-default", str(ctx.exception))
+
+    def test_project_off_overrides_user_on(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            (Path(home) / ".actor").mkdir()
+            (Path(home) / ".actor" / "settings.kdl").write_text(
+                'configure-default "on"\n'
+            )
+            (Path(cwd) / ".actor").mkdir()
+            (Path(cwd) / ".actor" / "settings.kdl").write_text(
+                'configure-default "off"\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.configure_default, "off")
+
+
 class TestAppConfigDefaults(unittest.TestCase):
 
     def test_empty_app_config_has_no_agents_and_on_default(self):

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -213,5 +213,126 @@ class TestPayloadShape(unittest.TestCase):
         self.assertTrue(payload["questions"][0]["optional"])
 
 
+class TestPromptInteractively(unittest.TestCase):
+
+    def test_options_question_picks_option_by_number(self):
+        from actor.configure import prompt_interactively
+        q = Question(
+            key="model",
+            prompt="Model?",
+            header="Model",
+            options=[QuestionOption("opus"), QuestionOption("sonnet")],
+        )
+        answers = prompt_interactively(
+            [q],
+            input_fn=iter(["1"]).__next__,
+            output_fn=lambda _: None,
+        )
+        self.assertEqual(answers, {"model": "opus"})
+
+    def test_options_question_accepts_label_directly(self):
+        from actor.configure import prompt_interactively
+        q = Question(
+            key="model",
+            prompt="Model?",
+            header="Model",
+            options=[QuestionOption("opus"), QuestionOption("sonnet")],
+        )
+        answers = prompt_interactively(
+            [q],
+            input_fn=iter(["sonnet"]).__next__,
+            output_fn=lambda _: None,
+        )
+        self.assertEqual(answers, {"model": "sonnet"})
+
+    def test_text_question_uses_raw_input(self):
+        from actor.configure import prompt_interactively
+        q = Question(
+            key="prompt",
+            prompt="Goal?",
+            header="Goal",
+            options=[],
+            kind="text",
+        )
+        answers = prompt_interactively(
+            [q],
+            input_fn=iter(["fix the nav"]).__next__,
+            output_fn=lambda _: None,
+        )
+        self.assertEqual(answers, {"prompt": "fix the nav"})
+
+    def test_text_question_optional_skipped_on_empty(self):
+        from actor.configure import prompt_interactively
+        q = Question(
+            key="prompt",
+            prompt="Goal?",
+            header="Goal",
+            options=[],
+            kind="text",
+            optional=True,
+        )
+        answers = prompt_interactively(
+            [q],
+            input_fn=iter([""]).__next__,
+            output_fn=lambda _: None,
+        )
+        self.assertNotIn("prompt", answers)
+
+    def test_invalid_options_input_retries(self):
+        from actor.configure import prompt_interactively
+        q = Question(
+            key="model",
+            prompt="Model?",
+            header="Model",
+            options=[QuestionOption("opus"), QuestionOption("sonnet")],
+        )
+        answers = prompt_interactively(
+            [q],
+            input_fn=iter(["xyz", "5", "1"]).__next__,  # bad, bad, valid
+            output_fn=lambda _: None,
+        )
+        self.assertEqual(answers, {"model": "opus"})
+
+    def test_multiple_questions_each_answered(self):
+        from actor.configure import prompt_interactively
+        qs = [
+            Question(
+                key="a",
+                prompt="A?",
+                header="A",
+                options=[QuestionOption("x"), QuestionOption("y")],
+            ),
+            Question(
+                key="b",
+                prompt="B?",
+                header="B",
+                options=[QuestionOption("1"), QuestionOption("2")],
+            ),
+        ]
+        answers = prompt_interactively(
+            qs,
+            input_fn=iter(["1", "2"]).__next__,
+            output_fn=lambda _: None,
+        )
+        self.assertEqual(answers, {"a": "x", "b": "2"})
+
+    def test_required_text_reprompts_on_empty(self):
+        from actor.configure import prompt_interactively
+        q = Question(
+            key="goal",
+            prompt="Goal?",
+            header="Goal",
+            options=[],
+            kind="text",
+            optional=False,
+        )
+        answers = prompt_interactively(
+            [q],
+            input_fn=iter(["", "", "finish it"]).__next__,
+            output_fn=lambda _: None,
+        )
+        self.assertEqual(answers, {"goal": "finish it"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Tests for src/actor/configure.py — built-in question defaults, resolver,
+AskUserQuestion payload shape."""
+from __future__ import annotations
+
+import unittest
+
+from actor.config import (
+    AgentSettings,
+    AppConfig,
+    ConfigureBlock,
+    Question,
+    QuestionOption,
+)
+from actor.configure import (
+    BUILTIN_QUESTIONS,
+    ConfigureDisabledError,
+    questions_to_payload,
+    resolve_questions,
+)
+from actor.errors import ActorError
+
+
+class TestBuiltInDefaults(unittest.TestCase):
+
+    def test_claude_builtins_cover_expected_keys(self):
+        keys = {q.key for q in BUILTIN_QUESTIONS["claude"]}
+        self.assertIn("model", keys)
+        self.assertIn("effort", keys)
+        self.assertIn("permission-mode", keys)
+        self.assertIn("prompt", keys)
+
+    def test_codex_builtins_cover_expected_keys(self):
+        keys = {q.key for q in BUILTIN_QUESTIONS["codex"]}
+        self.assertIn("sandbox", keys)
+        self.assertIn("prompt", keys)
+
+    def test_all_builtin_options_have_two_or_more_labels(self):
+        # AskUserQuestion requires >= 2 options per question.
+        for agent, qs in BUILTIN_QUESTIONS.items():
+            for q in qs:
+                if q.kind == "options":
+                    self.assertGreaterEqual(
+                        len(q.options), 2,
+                        f"{agent} {q.key}: only {len(q.options)} options",
+                    )
+
+
+class TestResolveQuestions(unittest.TestCase):
+
+    def test_unknown_agent_raises(self):
+        cfg = AppConfig()
+        with self.assertRaises(ActorError):
+            resolve_questions(cfg, agent="bogus", model=None)
+
+    def test_no_overrides_returns_builtins(self):
+        cfg = AppConfig()
+        qs = resolve_questions(cfg, agent="claude", model=None)
+        self.assertEqual(
+            [q.key for q in qs], [q.key for q in BUILTIN_QUESTIONS["claude"]]
+        )
+
+    def test_agent_level_configure_replaces_builtins(self):
+        agent = AgentSettings(
+            name="claude",
+            configure_blocks={
+                None: ConfigureBlock(
+                    model=None,
+                    questions=[
+                        Question(
+                            key="focus",
+                            prompt="Focus?",
+                            header="Focus",
+                            options=[QuestionOption("ui"), QuestionOption("api")],
+                        )
+                    ],
+                )
+            },
+        )
+        cfg = AppConfig(agents={"claude": agent})
+        qs = resolve_questions(cfg, agent="claude", model=None)
+        self.assertEqual([q.key for q in qs], ["focus"])
+
+    def test_model_scoped_wins_over_agent_level(self):
+        agent = AgentSettings(
+            name="claude",
+            configure_blocks={
+                None: ConfigureBlock(
+                    model=None,
+                    questions=[
+                        Question(
+                            key="a",
+                            prompt="?",
+                            header="A",
+                            options=[QuestionOption("x"), QuestionOption("y")],
+                        )
+                    ],
+                ),
+                "opus": ConfigureBlock(
+                    model="opus",
+                    questions=[
+                        Question(
+                            key="b",
+                            prompt="?",
+                            header="B",
+                            options=[QuestionOption("x"), QuestionOption("y")],
+                        )
+                    ],
+                ),
+            },
+        )
+        cfg = AppConfig(agents={"claude": agent})
+        qs_agent = resolve_questions(cfg, agent="claude", model=None)
+        self.assertEqual([q.key for q in qs_agent], ["a"])
+        qs_model = resolve_questions(cfg, agent="claude", model="opus")
+        self.assertEqual([q.key for q in qs_model], ["b"])
+
+    def test_model_scoped_falls_back_to_agent_level_when_no_model_block(self):
+        agent = AgentSettings(
+            name="claude",
+            configure_blocks={
+                None: ConfigureBlock(
+                    model=None,
+                    questions=[
+                        Question(
+                            key="a",
+                            prompt="?",
+                            header="A",
+                            options=[QuestionOption("x"), QuestionOption("y")],
+                        )
+                    ],
+                ),
+            },
+        )
+        cfg = AppConfig(agents={"claude": agent})
+        qs = resolve_questions(cfg, agent="claude", model="sonnet")
+        self.assertEqual([q.key for q in qs], ["a"])
+
+    def test_model_scoped_falls_back_to_builtins_when_no_agent_block(self):
+        cfg = AppConfig(
+            agents={
+                "claude": AgentSettings(name="claude", configure_blocks={})
+            }
+        )
+        qs = resolve_questions(cfg, agent="claude", model="opus")
+        self.assertEqual(
+            [q.key for q in qs], [q.key for q in BUILTIN_QUESTIONS["claude"]]
+        )
+
+    def test_disabled_raises(self):
+        cfg = AppConfig(configure_default="off")
+        with self.assertRaises(ConfigureDisabledError):
+            resolve_questions(cfg, agent="claude", model=None)
+
+
+class TestPayloadShape(unittest.TestCase):
+
+    def test_options_question_renders_straight_through(self):
+        q = Question(
+            key="model",
+            prompt="Which model?",
+            header="Model",
+            options=[QuestionOption("opus"), QuestionOption("sonnet")],
+        )
+        payload = questions_to_payload([q])
+        self.assertEqual(len(payload["questions"]), 1)
+        entry = payload["questions"][0]
+        self.assertEqual(entry["key"], "model")
+        self.assertEqual(entry["kind"], "options")
+        self.assertEqual(entry["question"], "Which model?")
+        self.assertEqual(entry["header"], "Model")
+        self.assertEqual(entry["multiSelect"], False)
+        self.assertEqual(
+            [o["label"] for o in entry["options"]], ["opus", "sonnet"]
+        )
+
+    def test_text_question_synthesizes_skip_and_enter_options(self):
+        q = Question(
+            key="prompt",
+            prompt="What's the goal?",
+            header="Goal",
+            options=[],
+            kind="text",
+            optional=True,
+        )
+        payload = questions_to_payload([q])
+        entry = payload["questions"][0]
+        self.assertEqual(entry["kind"], "text")
+        labels = [o["label"] for o in entry["options"]]
+        self.assertIn("Skip", labels)
+        self.assertIn("Enter below", labels)
+
+    def test_payload_header_is_trimmed_to_12_chars(self):
+        q = Question(
+            key="x",
+            prompt="?",
+            header="This header is too long",
+            options=[QuestionOption("a"), QuestionOption("b")],
+        )
+        payload = questions_to_payload([q])
+        self.assertLessEqual(len(payload["questions"][0]["header"]), 12)
+
+    def test_optional_flag_surfaces_in_payload(self):
+        q = Question(
+            key="prompt",
+            prompt="?",
+            header="Prompt",
+            options=[],
+            kind="text",
+            optional=True,
+        )
+        payload = questions_to_payload([q])
+        self.assertTrue(payload["questions"][0]["optional"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the `--configure` flow from issue #38: before spawning a new actor, the outer Claude Code session (or the CLI, via stdin) presents an AskUserQuestion-shaped set of choices so the user can pick agent parameters explicitly rather than hunting for flag names.

- **New MCP tool `get_configure_questions(agent, model)`** returns an AskUserQuestion payload plus per-question metadata (`key`, `kind`, `optional`) so the LLM can map answers back to `new_actor` args. Built-in defaults cover claude (model / effort / permission-mode / prompt) and codex (sandbox / prompt); text-kind questions synthesize `Enter below` / `Skip` options to satisfy the 2-option minimum.
- **KDL config syntax** for overrides: `configure-default "on" | "off"` at the top level, and `agent "<name>" { configure [<model>] { question ... } }` per agent / per model. Model-scoped wins over agent-level, which wins over built-ins.
- **CLI flags `--configure` / `--no-configure`** on `actor new`. When enabled, `prompt_interactively` walks the user through the questions on stdin and maps answers to `--config key=value` pairs (plus `prompt` if not already supplied).
- **Skill docs** (`_skill/SKILL.md`) explain the flow and how to translate answers back into `new_actor` args.

Closes #38

## Test plan

- [x] `uv run python -m unittest discover tests` — 389 tests, all passing
- [x] New suites: `tests/test_configure.py` (resolver, payload, stdin fallback), and expansion of `tests/test_config.py` (KDL parsing) + `tests/test_cli_and_mcp.py` (CLI flag behavior + MCP tool)
- [x] Code review loop: fixed the three important findings (merge bug where project "on" couldn't override user "off"; empty `configure { }` blocks silently erasing built-ins; CLI not using template's model for resolution)

## Scope

Strictly within #38 — no rollover from #30 / #31 / #33. No new runtime dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)