### PR TITLE
Per-agent default config in settings.kdl (#31)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,10 @@ the base and per-run `--config` arguments layer on top for that run
 only.
 
 Unknown top-level nodes (e.g. `hooks`, `alias`) are silently ignored
-for forward-compat with follow-up tickets #30 / #33.
+for forward-compat with follow-up tickets #30 / #33. A top-level
+`default-config` block is rejected with a helpful error instead of
+being silently ignored, because the keys inside would otherwise vanish
+— nest it under `agent "claude" { … }` / `agent "codex" { … }`.
 
 Load programmatically via `actor.config.load_config(cwd=..., home=...)` —
 both args default to `Path.cwd()` / `$HOME` so tests can inject temp dirs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,10 +149,15 @@ coerced to strings).
 
 Per-agent default config lives in `agent "claude" { default-config { … } }`
 (and the same shape for `codex`). Any actor of that kind picks up those
-keys as the lowest config layer — below templates and below CLI
-`--config`. User-wide keys merge per-key with project-level ones
-(project wins on same-key conflicts). See `spec/PLAN-AGENT-DEFAULTS.md`
-for the full precedence ladder.
+keys at creation time. User-wide and project-level blocks merge per key;
+project wins on same-key conflicts.
+
+Precedence for the final per-actor config (lowest → highest): built-in
+agent defaults → per-agent `default-config` (merged user+project) →
+template config (`--template`) → CLI `--config key=value`. The resolved
+merge is snapshotted into the DB at `actor new`; later edits to
+`settings.kdl` don't retroactively change existing actors — use
+`actor config <name> key=value` to mutate an actor's stored config.
 
 Unknown top-level nodes (e.g. `hooks`, `alias`) are silently ignored
 for forward-compat with follow-up tickets #30 / #33.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Manages multiple Claude/Codex agents running in isolated git worktrees.
 src/actor/               # Python package
   cli.py                 # argparse CLI, command dispatch
   commands.py            # Command implementations (cmd_new, cmd_run, cmd_list, etc.)
-  config.py              # KDL loader for ~/.actor/settings.kdl + <repo>/.actor/settings.kdl — templates
+  config.py              # KDL loader for ~/.actor/settings.kdl + <repo>/.actor/settings.kdl — templates & per-agent defaults
   setup.py               # 'actor setup' / 'actor update' — deploy bundled skill + register MCP
   server.py              # MCP server entry point
   db.py                  # SQLite database layer (~/.actor/actor.db)
@@ -152,12 +152,14 @@ Per-agent default config lives in `agent "claude" { default-config { … } }`
 keys at creation time. User-wide and project-level blocks merge per key;
 project wins on same-key conflicts.
 
-Precedence for the final per-actor config (lowest → highest): built-in
-agent defaults → per-agent `default-config` (merged user+project) →
-template config (`--template`) → CLI `--config key=value`. The resolved
-merge is snapshotted into the DB at `actor new`; later edits to
-`settings.kdl` don't retroactively change existing actors — use
-`actor config <name> key=value` to mutate an actor's stored config.
+Precedence at actor creation (`actor new`), lowest → highest: per-agent
+`default-config` (merged user+project) → template config (`--template`)
+→ CLI `--config key=value`. The resolved merge is snapshotted into the
+DB at creation; later edits to `settings.kdl` don't retroactively change
+existing actors — use `actor config <name> key=value` to mutate an
+actor's stored config. At run time (`actor run`), the stored config is
+the base and per-run `--config` arguments layer on top for that run
+only.
 
 Unknown top-level nodes (e.g. `hooks`, `alias`) are silently ignored
 for forward-compat with follow-up tickets #30 / #33.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,15 @@ prompt / stdin) override the template. `agent` and `prompt` are promoted to
 top-level fields; every other child is stored as a config key (values
 coerced to strings).
 
-Unknown top-level nodes (e.g. `hooks`, `agent`, `alias`) are silently
-ignored for forward-compat with follow-up tickets.
+Per-agent default config lives in `agent "claude" { default-config { … } }`
+(and the same shape for `codex`). Any actor of that kind picks up those
+keys as the lowest config layer — below templates and below CLI
+`--config`. User-wide keys merge per-key with project-level ones
+(project wins on same-key conflicts). See `spec/PLAN-AGENT-DEFAULTS.md`
+for the full precedence ladder.
+
+Unknown top-level nodes (e.g. `hooks`, `alias`) are silently ignored
+for forward-compat with follow-up tickets #30 / #33.
 
 Load programmatically via `actor.config.load_config(cwd=..., home=...)` —
 both args default to `Path.cwd()` / `$HOME` so tests can inject temp dirs.

--- a/spec/PLAN-AGENT-DEFAULTS.md
+++ b/spec/PLAN-AGENT-DEFAULTS.md
@@ -173,12 +173,14 @@ Add a new helper above `_parse_kdl_file` (after `_parse_template`):
 
 ```python
 def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]:
-    """Parse a `default-config { … }` block inside an agent block.
+    """Parse a `default-config { … }` block inside an `agent` block.
 
     Same shape rules as template children: each child is `key "value"`
-    with exactly one scalar arg, no props, no duplicates. Unknown keys
-    pass through (no fixed schema — they're consumed by the agent at
-    spawn time).
+    with exactly one scalar arg, no props, no duplicates. Keys other
+    than the template-level reserved names (`prompt`, `agent`) pass
+    through — no fixed schema, they're consumed by the agent at spawn
+    time. Using `prompt` or `agent` here raises; they belong on the
+    template, not inside a block whose scope is already one agent.
     """
     if node.args:
         raise ConfigError(
@@ -191,12 +193,32 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
             f"accept properties"
         )
     out: Dict[str, str] = {}
+    seen_keys: set[str] = set()
     for child in node.nodes:
         key = child.name
-        if key in out:
+        # Reject reserved keys BEFORE the duplicate check so a malformed
+        # `prompt "a" / prompt "b"` reports the reserved-key error
+        # (which tells the user to move `prompt` up to the template)
+        # instead of a misleading "duplicate prompt".
+        if key in ("prompt", "agent"):
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: '{key}' is not a "
+                f"valid default-config key (it's a template-level field, "
+                f"not an agent config key)"
+            )
+        if key in seen_keys:
             raise ConfigError(
                 f"agent '{agent_name}' in {source}: duplicate key '{key}' "
                 f"in default-config"
+            )
+        seen_keys.add(key)
+        # Props check runs before the args check so `model name="opus"`
+        # reports "does not accept properties" rather than a misleading
+        # "needs a value".
+        if getattr(child, "props", None):
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: '{key}' does not accept "
+                f"properties"
             )
         if not child.args:
             raise ConfigError(
@@ -206,11 +228,6 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
             raise ConfigError(
                 f"agent '{agent_name}' in {source}: '{key}' has extra args "
                 f"(only a single value is supported)"
-            )
-        if getattr(child, "props", None):
-            raise ConfigError(
-                f"agent '{agent_name}' in {source}: '{key}' does not accept "
-                f"properties"
             )
         out[key] = _coerce_value(child.args[0])
     return out

--- a/spec/PLAN-AGENT-DEFAULTS.md
+++ b/spec/PLAN-AGENT-DEFAULTS.md
@@ -85,14 +85,16 @@ class TestLoadConfigAgentDefaults(unittest.TestCase):
         self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
         self.assertEqual(cfg.agent_defaults["codex"], {"sandbox": "danger-full-access"})
 
-    def test_empty_default_config_block_yields_empty_dict(self):
+    def test_empty_default_config_block_omits_agent_from_defaults(self):
         cfg = self._load(
             'agent "claude" {\n'
             '    default-config {\n'
             '    }\n'
             '}\n'
         )
-        self.assertEqual(cfg.agent_defaults["claude"], {})
+        # Empty default-config contributes no keys; presence in
+        # agent_defaults implies at least one declared key.
+        self.assertNotIn("claude", cfg.agent_defaults)
 
     def test_agent_block_without_default_config_is_ignored(self):
         # Forward-compat: hooks etc. may live under `agent` in future
@@ -147,11 +149,16 @@ Replace the import line `from typing import Dict, Optional` with:
 from typing import Dict, Optional, Tuple
 ```
 
-Add right after the existing `from .errors import ConfigError` line:
+Widen the errors import and add an AgentKind import:
 
 ```python
+from .errors import ActorError, ConfigError
 from .types import AgentKind
 ```
+
+(`ActorError` is the base class `AgentKind.from_str` raises; we catch
+it when re-raising as `ConfigError` so downstream typo messages stay
+uniform across the codebase.)
 
 Replace the `AppConfig` dataclass (currently around lines 31-33):
 
@@ -213,14 +220,21 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
     """Parse an `agent "name" { … }` block. Returns (agent_name, defaults).
 
     Validates the agent name against AgentKind so typos (`agent "cluade"`)
-    fail fast. Children other than `default-config` are silently ignored
-    so future tickets (hooks etc.) can share the block without breaking
-    today's parser.
+    fail fast. Block-style children other than `default-config` (no args)
+    are silently accepted as forward-compat no-ops for follow-up tickets
+    (hooks #30 etc.). Key-with-value children directly under `agent` —
+    e.g. `model "opus"` instead of `default-config { model "opus" }` —
+    raise so the user's keys aren't silently dropped.
     """
-    if not node.args or not isinstance(node.args[0], str):
+    if not node.args:
         raise ConfigError(
             f"agent block in {source} must have a name "
             f"(e.g. `agent \"claude\" {{ … }}`)"
+        )
+    if not isinstance(node.args[0], str):
+        raise ConfigError(
+            f"agent block in {source}: name must be a string, "
+            f"got {type(node.args[0]).__name__}"
         )
     if not node.args[0]:
         raise ConfigError(
@@ -237,25 +251,31 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
     name = node.args[0]
     try:
         AgentKind.from_str(name)
-    except Exception as e:
+    except ActorError as e:
+        valid = ", ".join(k.value for k in AgentKind)
         raise ConfigError(
             f"agent block in {source}: unknown agent '{name}' "
-            f"(valid: {', '.join(k.value for k in AgentKind)})"
+            f"(valid: {valid})"
         ) from e
 
     defaults: Dict[str, str] = {}
     seen_default_config = False
     for child in node.nodes:
-        if child.name != "default-config":
-            # Forward-compat: e.g. hooks (#30). Silently skipped today.
+        if child.name == "default-config":
+            if seen_default_config:
+                raise ConfigError(
+                    f"agent '{name}' in {source}: multiple `default-config` "
+                    f"blocks (only one is allowed)"
+                )
+            seen_default_config = True
+            defaults = _parse_default_config(child, name, source)
             continue
-        if seen_default_config:
+        if child.args:
             raise ConfigError(
-                f"agent '{name}' in {source}: multiple `default-config` "
-                f"blocks (only one is allowed)"
+                f"agent '{name}' in {source}: `{child.name}` cannot sit "
+                f"directly under an `agent` block — nest config keys "
+                f"inside `default-config {{ … }}`"
             )
-        seen_default_config = True
-        defaults = _parse_default_config(child, name, source)
     return name, defaults
 ```
 
@@ -272,6 +292,11 @@ def _parse_kdl_file(path: Path) -> AppConfig:
     except kdl.ParseError as e:
         raise ConfigError(f"parse error in {path}: {e}") from e
     cfg = AppConfig()
+    # Track seen agent names separately from `cfg.agent_defaults`, which
+    # only records agents that contributed at least one key. Without the
+    # separate set, a first empty `agent "claude" { … }` block would not
+    # be detected as a duplicate when a later block declared real keys.
+    seen_agents: set[str] = set()
     for node in doc.nodes:
         if node.name == "template":
             tpl = _parse_template(node, path)
@@ -282,15 +307,25 @@ def _parse_kdl_file(path: Path) -> AppConfig:
             cfg.templates[tpl.name] = tpl
         elif node.name == "agent":
             name, defaults = _parse_agent_block(node, path)
-            if name in cfg.agent_defaults:
+            if name in seen_agents:
                 raise ConfigError(
                     f"duplicate agent block '{name}' in {path}"
                 )
-            # An agent block with no `default-config` child contributes no
-            # defaults — don't create an empty entry, keep the invariant
-            # "presence in agent_defaults implies defaults were declared".
+            seen_agents.add(name)
+            # An agent block with no `default-config` child contributes
+            # nothing — preserve the invariant "presence in
+            # agent_defaults implies at least one declared key".
             if defaults:
                 cfg.agent_defaults[name] = defaults
+        elif node.name == "default-config":
+            # A top-level `default-config` block is a common misread of
+            # the schema; without this branch the user's keys would
+            # silently vanish.
+            raise ConfigError(
+                f"top-level `default-config` block in {path} is not "
+                f"supported — nest it inside `agent \"claude\" {{ … }}` "
+                f"or `agent \"codex\" {{ … }}`"
+            )
         # Silently ignore hooks / alias — those belong to follow-up
         # tickets #30 / #33 and are not implemented here.
     return cfg
@@ -853,23 +888,26 @@ that:
 2. Points to `claude-config.md` / `codex-config.md` for valid keys.
 3. Spells out the precedence ladder and merge rule. Treat user and
    project `settings.kdl` as a single merged layer — NOT as separate
-   ordered steps — to match how `_merge` folds them per key. Recommended
-   phrasing:
+   ordered steps — to match how `_merge` folds them per key. The ladder
+   covers only the inputs `cmd_new` actually consumes at creation time;
+   don't invent phantom layers (e.g. "built-in defaults") that don't
+   exist in the code. Recommended phrasing:
 
    ```
-   Precedence (lowest → highest):
+   Precedence at actor creation (lowest → highest):
 
-   1. Built-in defaults
-   2. Per-agent defaults from `settings.kdl` (user + project merged per
+   1. Per-agent defaults from `settings.kdl` (user + project merged per
       key; project wins on conflicts)
-   3. Template config (`--template X`)
-   4. CLI `--config key=value`
-   5. Per-actor DB config
+   2. Template config (`--template X`)
+   3. CLI `--config key=value`
 
    `settings.kdl` is read at actor CREATION time. Editing the file later
    does not retroactively change existing actors — use
    `config_actor(name="…", pairs=[…])` / `actor config <name> key=value`
    to update an actor's stored config.
+
+   At run time (`actor run`), the stored config is the base and per-run
+   `--config` arguments layer on top for that run only.
    ```
 
 - [ ] **Step 2: Update CLAUDE.md — extend the "Config files & templates" section**
@@ -879,10 +917,9 @@ In `CLAUDE.md`, replace the forward-compat paragraph that mentions
 
 1. A per-agent-defaults paragraph that describes the block shape,
    mentions user+project per-key merge, and inlines the precedence
-   ladder (lowest → highest: built-in → per-agent defaults → template →
-   CLI `--config`). Include a sentence about snapshot-at-creation —
-   editing `settings.kdl` later does not retroactively change existing
-   actors.
+   ladder (lowest → highest: per-agent defaults → template → CLI
+   `--config`). Include a sentence about snapshot-at-creation — editing
+   `settings.kdl` later does not retroactively change existing actors.
 2. A short forward-compat paragraph that still mentions `hooks` / `alias`
    (no longer `agent`) as silently ignored for tickets #30 / #33.
 

--- a/spec/PLAN-AGENT-DEFAULTS.md
+++ b/spec/PLAN-AGENT-DEFAULTS.md
@@ -1,0 +1,919 @@
+# Per-Agent Default Config — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement ticket #31. Add `agent "claude" { default-config { … } }` blocks to `settings.kdl` so per-agent defaults slot into the 6-layer precedence chain between project config and templates. Launching a Claude actor auto-applies the claude block; launching a Codex actor auto-applies the codex block.
+
+**Architecture:** Extend `AppConfig` with `agent_defaults: Dict[str, Dict[str, str]]` keyed by agent name. Parser learns the new block shape, validates the agent name via `AgentKind.from_str` (catches typos early), and merges across user + project files (project wins per-key). `cmd_new` applies the chosen agent's defaults as the lowest config layer, below the template and below CLI `--config` pairs. Existing templates / CLI behavior untouched.
+
+**Tech Stack:** Python 3.10+, unittest, `kdl-py` (already a dep). No new runtime dependencies.
+
+---
+
+### Precedence recap (from #31)
+
+Merge order in `cmd_new` (lowest → highest):
+
+1. Empty dict
+2. **`app_config.agent_defaults[chosen_agent]`** ← new
+3. `template.config` (if `--template X`)
+4. `parse_config(config_pairs)` (CLI `--config` / `--model` / `--strip-api-keys`)
+
+Later layers overwrite earlier on same key. User vs. project settings.kdl merging happens once in `load_config` before any of this runs (project wins per-key).
+
+The chosen agent is resolved **before** the merge, using today's rule: CLI `--agent` > template's `agent` > `"claude"`. So the defaults follow the agent kind that actually wins — not the template's agent when CLI overrides it.
+
+---
+
+### Task 1: Add `agent_defaults` field + parse minimal agent block
+
+**Files:**
+- Modify: `src/actor/config.py`
+- Modify: `tests/test_config.py`
+
+- [ ] **Step 1: Write failing tests for minimal + multi-key + multi-agent parsing**
+
+Append to `tests/test_config.py` after `TestLoadConfigCwdUnderHome`:
+
+```python
+class TestLoadConfigAgentDefaults(unittest.TestCase):
+
+    def _load(self, body: str) -> AppConfig:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(body)
+            return load_config(cwd=Path(cwd), home=Path(home))
+
+    def test_single_key_default_config(self):
+        cfg = self._load(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n'
+        )
+        self.assertEqual(cfg.agent_defaults, {"claude": {"model": "opus"}})
+
+    def test_multiple_keys_in_default_config(self):
+        cfg = self._load(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '        effort "max"\n'
+            '        strip-api-keys true\n'
+            '    }\n'
+            '}\n'
+        )
+        self.assertEqual(cfg.agent_defaults["claude"], {
+            "model": "opus", "effort": "max", "strip-api-keys": "true",
+        })
+
+    def test_blocks_for_multiple_agents(self):
+        cfg = self._load(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n'
+            'agent "codex" {\n'
+            '    default-config {\n'
+            '        sandbox "danger-full-access"\n'
+            '    }\n'
+            '}\n'
+        )
+        self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+        self.assertEqual(cfg.agent_defaults["codex"], {"sandbox": "danger-full-access"})
+
+    def test_empty_default_config_block_yields_empty_dict(self):
+        cfg = self._load(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '    }\n'
+            '}\n'
+        )
+        self.assertEqual(cfg.agent_defaults["claude"], {})
+
+    def test_agent_block_without_default_config_is_ignored(self):
+        # Forward-compat: hooks etc. may live under `agent` in future
+        # tickets; for now an agent block with no `default-config` child
+        # parses without error and contributes no defaults.
+        cfg = self._load('agent "claude" {\n}\n')
+        self.assertNotIn("claude", cfg.agent_defaults)
+
+    def test_non_default_config_children_of_agent_are_ignored(self):
+        # Forward-compat: #30 will add `hooks {}` under `agent`. Unknown
+        # children parse as no-ops today.
+        cfg = self._load(
+            'agent "claude" {\n'
+            '    hooks {\n'
+            '        on-start "echo hi"\n'
+            '    }\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n'
+        )
+        self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+```
+
+- [ ] **Step 2: Run the new tests — expect failure**
+
+Run: `uv run python -m unittest tests.test_config.TestLoadConfigAgentDefaults -v`
+Expected: every test FAILs with `AttributeError: 'AppConfig' object has no attribute 'agent_defaults'`.
+
+- [ ] **Step 3: Extend AppConfig and add minimal parser for agent blocks**
+
+In `src/actor/config.py`:
+
+Update the top-level docstring (lines 7-9): change the "Out of scope" comment to reflect that per-agent defaults are now implemented:
+
+```python
+"""Config file system for actor.sh.
+
+Loads ~/.actor/settings.kdl (user) and <project>/.actor/settings.kdl
+(project), merges them, and exposes the merged AppConfig with its
+templates map and per-agent default-config overrides. Project config
+overrides user config on same-key conflict.
+
+Out of scope (see tickets #30 / #33): hooks, aliases. Their nodes are
+skipped at parse time without error for forward compatibility.
+"""
+```
+
+Replace the import line `from typing import Dict, Optional` with:
+
+```python
+from typing import Dict, Optional, Tuple
+```
+
+Add right after the existing `from .errors import ConfigError` line:
+
+```python
+from .types import AgentKind
+```
+
+Replace the `AppConfig` dataclass (currently around lines 31-33):
+
+```python
+@dataclass
+class AppConfig:
+    templates: Dict[str, Template] = field(default_factory=dict)
+    agent_defaults: Dict[str, Dict[str, str]] = field(default_factory=dict)
+```
+
+Add a new helper above `_parse_kdl_file` (after `_parse_template`):
+
+```python
+def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]:
+    """Parse a `default-config { … }` block inside an agent block.
+
+    Same shape rules as template children: each child is `key "value"`
+    with exactly one scalar arg, no props, no duplicates. Unknown keys
+    pass through (no fixed schema — they're consumed by the agent at
+    spawn time).
+    """
+    if node.args:
+        raise ConfigError(
+            f"agent '{agent_name}' in {source}: `default-config` does not "
+            f"accept positional arguments"
+        )
+    if getattr(node, "props", None):
+        raise ConfigError(
+            f"agent '{agent_name}' in {source}: `default-config` does not "
+            f"accept properties"
+        )
+    out: Dict[str, str] = {}
+    for child in node.nodes:
+        key = child.name
+        if key in out:
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: duplicate key '{key}' "
+                f"in default-config"
+            )
+        if not child.args:
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: '{key}' needs a value"
+            )
+        if len(child.args) > 1:
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: '{key}' has extra args "
+                f"(only a single value is supported)"
+            )
+        if getattr(child, "props", None):
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: '{key}' does not accept "
+                f"properties"
+            )
+        out[key] = _coerce_value(child.args[0])
+    return out
+
+
+def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
+    """Parse an `agent "name" { … }` block. Returns (agent_name, defaults).
+
+    Validates the agent name against AgentKind so typos (`agent "cluade"`)
+    fail fast. Children other than `default-config` are silently ignored
+    so future tickets (hooks etc.) can share the block without breaking
+    today's parser.
+    """
+    if not node.args or not isinstance(node.args[0], str):
+        raise ConfigError(
+            f"agent block in {source} must have a name "
+            f"(e.g. `agent \"claude\" {{ … }}`)"
+        )
+    if not node.args[0]:
+        raise ConfigError(
+            f"agent block in {source} must have a non-empty name"
+        )
+    if len(node.args) > 1:
+        raise ConfigError(
+            f"agent '{node.args[0]}' in {source} has extra positional args"
+        )
+    if getattr(node, "props", None):
+        raise ConfigError(
+            f"agent '{node.args[0]}' in {source} does not accept properties"
+        )
+    name = node.args[0]
+    try:
+        AgentKind.from_str(name)
+    except Exception as e:
+        raise ConfigError(
+            f"agent block in {source}: unknown agent '{name}' "
+            f"(valid: {', '.join(k.value for k in AgentKind)})"
+        ) from e
+
+    defaults: Dict[str, str] = {}
+    seen_default_config = False
+    for child in node.nodes:
+        if child.name != "default-config":
+            # Forward-compat: e.g. hooks (#30). Silently skipped today.
+            continue
+        if seen_default_config:
+            raise ConfigError(
+                f"agent '{name}' in {source}: multiple `default-config` "
+                f"blocks (only one is allowed)"
+            )
+        seen_default_config = True
+        defaults = _parse_default_config(child, name, source)
+    return name, defaults
+```
+
+Change `_parse_kdl_file` to dispatch `agent` nodes to the new parser (currently its loop silently skips them):
+
+```python
+def _parse_kdl_file(path: Path) -> AppConfig:
+    try:
+        text = path.read_text()
+    except OSError as e:
+        raise ConfigError(f"could not read {path}: {e}") from e
+    try:
+        doc = kdl.parse(text)
+    except kdl.ParseError as e:
+        raise ConfigError(f"parse error in {path}: {e}") from e
+    cfg = AppConfig()
+    for node in doc.nodes:
+        if node.name == "template":
+            tpl = _parse_template(node, path)
+            if tpl.name in cfg.templates:
+                raise ConfigError(
+                    f"duplicate template '{tpl.name}' in {path}"
+                )
+            cfg.templates[tpl.name] = tpl
+        elif node.name == "agent":
+            name, defaults = _parse_agent_block(node, path)
+            if name in cfg.agent_defaults:
+                raise ConfigError(
+                    f"duplicate agent block '{name}' in {path}"
+                )
+            # An agent block with no `default-config` child contributes no
+            # defaults — don't create an empty entry, keep the invariant
+            # "presence in agent_defaults implies defaults were declared".
+            if defaults:
+                cfg.agent_defaults[name] = defaults
+        # Silently ignore hooks / alias — those belong to follow-up
+        # tickets #30 / #33 and are not implemented here.
+    return cfg
+```
+
+- [ ] **Step 4: Run the new tests — expect pass**
+
+Run: `uv run python -m unittest tests.test_config.TestLoadConfigAgentDefaults -v`
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Run the full config test module — expect pass**
+
+Run: `uv run python -m unittest tests.test_config -v`
+Expected: every existing test still PASSes (the `agent` no-op forward-compat test still works because `agent "claude"` without a `default-config` child continues to contribute nothing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/actor/config.py tests/test_config.py
+git commit -m "Parse agent \"X\" { default-config } blocks in settings.kdl (#31)"
+```
+
+---
+
+### Task 2: Validation errors for malformed agent blocks
+
+**Files:**
+- Modify: `tests/test_config.py`
+
+Parser work already done in Task 1; this task adds the explicit error-case coverage.
+
+- [ ] **Step 1: Write failing (really: passing) tests for each validation path**
+
+Append to `tests/test_config.py`:
+
+```python
+class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
+    """Parser should reject silently-dropped / ambiguous agent-block input."""
+
+    def _expect_error(self, kdl_text: str, needle: str) -> None:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(kdl_text)
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn(needle, str(ctx.exception))
+
+    def test_unknown_agent_name_raises(self):
+        self._expect_error(
+            'agent "gpt4" {\n    default-config {\n        model "x"\n    }\n}\n',
+            "gpt4",
+        )
+
+    def test_agent_block_without_name_raises(self):
+        self._expect_error(
+            'agent {\n    default-config {\n        model "x"\n    }\n}\n',
+            "name",
+        )
+
+    def test_empty_agent_name_raises(self):
+        self._expect_error(
+            'agent "" {\n    default-config {\n    }\n}\n',
+            "non-empty",
+        )
+
+    def test_non_string_agent_name_raises(self):
+        self._expect_error(
+            'agent 42 {\n    default-config {\n    }\n}\n',
+            "name",
+        )
+
+    def test_extra_positional_on_agent_raises(self):
+        self._expect_error(
+            'agent "claude" "extra" {\n    default-config {\n    }\n}\n',
+            "extra",
+        )
+
+    def test_props_on_agent_node_raises(self):
+        self._expect_error(
+            'agent "claude" flag="x" {\n    default-config {\n    }\n}\n',
+            "claude",
+        )
+
+    def test_duplicate_agent_block_in_file_raises(self):
+        self._expect_error(
+            'agent "claude" {\n    default-config {\n        model "opus"\n    }\n}\n'
+            'agent "claude" {\n    default-config {\n        model "sonnet"\n    }\n}\n',
+            "claude",
+        )
+
+    def test_multiple_default_config_blocks_in_one_agent_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n        model "opus"\n    }\n'
+            '    default-config {\n        model "sonnet"\n    }\n'
+            '}\n',
+            "default-config",
+        )
+
+    def test_duplicate_key_in_default_config_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '        model "sonnet"\n'
+            '    }\n'
+            '}\n',
+            "model",
+        )
+
+    def test_child_without_value_in_default_config_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model\n'
+            '    }\n'
+            '}\n',
+            "model",
+        )
+
+    def test_extra_args_on_default_config_child_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus" "sonnet"\n'
+            '    }\n'
+            '}\n',
+            "model",
+        )
+
+    def test_props_on_default_config_child_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model name="opus"\n'
+            '    }\n'
+            '}\n',
+            "model",
+        )
+
+    def test_positional_args_on_default_config_block_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config "oops" {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n',
+            "default-config",
+        )
+```
+
+- [ ] **Step 2: Run the strict tests — expect all to pass**
+
+Run: `uv run python -m unittest tests.test_config.TestLoadConfigAgentDefaultsStrict -v`
+Expected: all PASS (Task 1's parser already raises in each of these cases).
+
+If any test fails, adjust the parser in `src/actor/config.py` — the needle/case the test expects dictates which `raise ConfigError(...)` call is missing or mis-worded. Don't loosen tests; fix the parser.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_config.py
+git commit -m "Add strict tests for agent block parser errors (#31)"
+```
+
+---
+
+### Task 3: Merge `agent_defaults` across user + project configs
+
+**Files:**
+- Modify: `src/actor/config.py`
+- Modify: `tests/test_config.py`
+
+- [ ] **Step 1: Write failing tests for user+project merge semantics**
+
+Append to `tests/test_config.py`:
+
+```python
+class TestLoadConfigAgentDefaultsMerge(unittest.TestCase):
+
+    def _write(self, path: Path, body: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    def test_project_wins_on_same_key(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "sonnet"\n'
+                '    }\n'
+                '}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+
+    def test_distinct_keys_merge(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        effort "max"\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.agent_defaults["claude"], {
+                "model": "opus", "effort": "max",
+            })
+
+    def test_distinct_agents_in_user_and_project_both_survive(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "codex" {\n'
+                '    default-config {\n'
+                '        sandbox "danger-full-access"\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+            self.assertEqual(cfg.agent_defaults["codex"], {"sandbox": "danger-full-access"})
+
+    def test_templates_and_agent_defaults_coexist_in_same_file(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'template "qa" {\n'
+                '    agent "claude"\n'
+                '    prompt "you are qa"\n'
+                '}\n'
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.templates["qa"].agent, "claude")
+            self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+```
+
+- [ ] **Step 2: Run the merge tests — expect failure on `test_distinct_keys_merge`**
+
+Run: `uv run python -m unittest tests.test_config.TestLoadConfigAgentDefaultsMerge -v`
+Expected: `test_project_wins_on_same_key` PASSes today (`dict.update` already overwrites), but `test_distinct_keys_merge` FAILs because the current `_merge` does `merged.update(over)` which replaces the claude dict wholesale (user's `model` is lost when project has only `effort`).
+
+- [ ] **Step 3: Update `_merge` to do per-agent deep-merge on `agent_defaults`**
+
+Replace `_merge` in `src/actor/config.py`:
+
+```python
+def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
+    merged_templates = dict(base.templates)
+    merged_templates.update(over.templates)
+
+    merged_agent_defaults: Dict[str, Dict[str, str]] = {
+        agent: dict(keys) for agent, keys in base.agent_defaults.items()
+    }
+    for agent, keys in over.agent_defaults.items():
+        existing = merged_agent_defaults.setdefault(agent, {})
+        existing.update(keys)
+
+    return AppConfig(
+        templates=merged_templates,
+        agent_defaults=merged_agent_defaults,
+    )
+```
+
+Templates stay shallow-merged (project replaces user for the same template name — matches existing behavior). Agent defaults merge per-key so a user-wide `model` plus a project-scoped `effort` both survive.
+
+- [ ] **Step 4: Run the merge tests — expect pass**
+
+Run: `uv run python -m unittest tests.test_config.TestLoadConfigAgentDefaultsMerge -v`
+Expected: all 4 PASS.
+
+- [ ] **Step 5: Run the full config test module**
+
+Run: `uv run python -m unittest tests.test_config -v`
+Expected: every test PASSes (templates still merge as before).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/actor/config.py tests/test_config.py
+git commit -m "Per-key merge of agent_defaults across user + project configs (#31)"
+```
+
+---
+
+### Task 4: Apply `agent_defaults` in `cmd_new` precedence chain
+
+**Files:**
+- Modify: `src/actor/commands.py`
+- Modify: `tests/test_actor.py`
+
+- [ ] **Step 1: Write failing tests for cmd_new integration**
+
+Append to `tests/test_actor.py` after `TestCmdNewTemplate` (right before `TestCmdRun`):
+
+```python
+# ──────────────────────────────────────────────────────────────────────
+#  Test: cmd_new with per-agent default-config (ticket #31)
+# ──────────────────────────────────────────────────────────────────────
+
+class TestCmdNewAgentDefaults(unittest.TestCase):
+
+    def _db(self) -> Database:
+        return Database.open(":memory:")
+
+    def _cfg(self, **kwargs):
+        from actor import AppConfig
+        return AppConfig(**kwargs)
+
+    def test_agent_defaults_applied_for_claude(self):
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={"claude": {"model": "opus"}})
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="claude", config_pairs=[],
+            app_config=cfg,
+        )
+        self.assertEqual(actor.config["model"], "opus")
+
+    def test_only_chosen_agent_defaults_apply(self):
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={
+            "claude": {"model": "opus"},
+            "codex": {"sandbox": "danger-full-access"},
+        })
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="codex", config_pairs=[],
+            app_config=cfg,
+        )
+        self.assertEqual(actor.config, {"sandbox": "danger-full-access"})
+        self.assertNotIn("model", actor.config)
+
+    def test_cli_config_pair_overrides_agent_default(self):
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={"claude": {"model": "opus"}})
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="claude", config_pairs=["model=haiku"],
+            app_config=cfg,
+        )
+        self.assertEqual(actor.config["model"], "haiku")
+
+    def test_template_config_overrides_agent_default(self):
+        # Agent defaults sit BELOW templates in the ladder.
+        from actor import AppConfig, Template
+        db = self._db()
+        git = FakeGit()
+        cfg = AppConfig(
+            templates={"qa": Template(
+                name="qa", agent="claude", config={"model": "sonnet"},
+            )},
+            agent_defaults={"claude": {"model": "opus", "effort": "max"}},
+        )
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name=None, config_pairs=[],
+            template_name="qa", app_config=cfg,
+        )
+        # Template wins on `model`; agent default supplies `effort`.
+        self.assertEqual(actor.config["model"], "sonnet")
+        self.assertEqual(actor.config["effort"], "max")
+
+    def test_cli_overrides_both_template_and_agent_default(self):
+        from actor import AppConfig, Template
+        db = self._db()
+        git = FakeGit()
+        cfg = AppConfig(
+            templates={"qa": Template(
+                name="qa", agent="claude", config={"model": "sonnet"},
+            )},
+            agent_defaults={"claude": {"model": "opus"}},
+        )
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name=None, config_pairs=["model=haiku"],
+            template_name="qa", app_config=cfg,
+        )
+        self.assertEqual(actor.config["model"], "haiku")
+
+    def test_defaults_follow_cli_agent_not_template_agent(self):
+        # Template says claude, but CLI --agent=codex wins → codex defaults
+        # apply, claude defaults do NOT.
+        from actor import AppConfig, Template
+        db = self._db()
+        git = FakeGit()
+        cfg = AppConfig(
+            templates={"qa": Template(name="qa", agent="claude")},
+            agent_defaults={
+                "claude": {"model": "opus"},
+                "codex": {"sandbox": "danger-full-access"},
+            },
+        )
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="codex", config_pairs=[],
+            template_name="qa", app_config=cfg,
+        )
+        self.assertEqual(actor.agent, AgentKind.CODEX)
+        self.assertEqual(actor.config, {"sandbox": "danger-full-access"})
+
+    def test_no_defaults_for_agent_is_noop(self):
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={"codex": {"sandbox": "x"}})
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="claude", config_pairs=[],
+            app_config=cfg,
+        )
+        self.assertEqual(actor.config, {})
+
+    def test_none_app_config_is_noop(self):
+        # Backward-compat: callers that don't pass app_config see the old
+        # behavior (no defaults applied).
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="claude", config_pairs=["model=sonnet"],
+        )
+        self.assertEqual(actor.config, {"model": "sonnet"})
+
+    def test_defaults_applied_when_agent_name_defaults_to_claude(self):
+        # agent_name=None + no template → chosen agent is claude. Claude
+        # defaults should still apply.
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={"claude": {"model": "opus"}})
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name=None, config_pairs=[],
+            app_config=cfg,
+        )
+        self.assertEqual(actor.agent, AgentKind.CLAUDE)
+        self.assertEqual(actor.config["model"], "opus")
+```
+
+- [ ] **Step 2: Run the new tests — expect failure**
+
+Run: `uv run python -m unittest tests.test_actor.TestCmdNewAgentDefaults -v`
+Expected: most tests FAIL — `actor.config` is missing the agent-default keys.
+
+- [ ] **Step 3: Wire agent_defaults into cmd_new**
+
+In `src/actor/commands.py`, replace the config-building section of `cmd_new` (currently around lines 138-142):
+
+Before:
+```python
+    # Config precedence: template's config is the base; CLI pairs overlay on top.
+    config: Dict[str, str] = dict(template.config) if template else {}
+    for k, v in parse_config(config_pairs).items():
+        config[k] = v
+    config = _sorted_config(config)
+```
+
+After:
+```python
+    # Config precedence (lowest → highest): per-agent defaults from
+    # settings.kdl → template.config → CLI --config pairs. Per-agent
+    # defaults key off the ALREADY-chosen agent_kind, so CLI --agent
+    # overriding a template's agent correctly picks up the new agent's
+    # defaults rather than the template's.
+    config: Dict[str, str] = {}
+    if app_config is not None:
+        agent_defaults = app_config.agent_defaults.get(agent_kind.as_str())
+        if agent_defaults:
+            config.update(agent_defaults)
+    if template is not None:
+        config.update(template.config)
+    for k, v in parse_config(config_pairs).items():
+        config[k] = v
+    config = _sorted_config(config)
+```
+
+- [ ] **Step 4: Run the new tests — expect pass**
+
+Run: `uv run python -m unittest tests.test_actor.TestCmdNewAgentDefaults -v`
+Expected: all 9 PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run python -m unittest discover tests`
+Expected: every test PASSes. Existing `TestCmdNewTemplate` tests still work because without an `app_config.agent_defaults` entry, the new branch is a no-op.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/actor/commands.py tests/test_actor.py
+git commit -m "Apply per-agent default-config as lowest layer in cmd_new (#31)"
+```
+
+---
+
+### Task 5: Docs — SKILL.md + CLAUDE.md
+
+**Files:**
+- Modify: `src/actor/_skill/SKILL.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update SKILL.md — add a "Per-agent defaults" subsection under Templates**
+
+In `src/actor/_skill/SKILL.md`, locate the paragraph near the top of the Templates section that ends with "Unknown top-level nodes (`hooks`, `agent`, `alias`) parse as no-ops today —" (around line 122) and change it to reflect that `agent` is now implemented. Replace that paragraph with:
+
+```
+Unknown top-level nodes (`hooks`, `alias`) parse as no-ops today —
+they're reserved for follow-up tickets. Malformed KDL raises an error
+with the file path.
+```
+
+Then, immediately before the "**Applying a template** (CLI only — see note below):" line, insert a new subsection:
+
+```markdown
+**Per-agent defaults:**
+
+Alongside templates you can declare default config scoped to a specific
+coding agent. Any Claude actor picks up the `agent "claude"` block; any
+Codex actor picks up the `agent "codex"` block.
+
+```kdl
+agent "claude" {
+    default-config {
+        model "opus"
+        effort "max"
+        strip-api-keys true
+    }
+}
+
+agent "codex" {
+    default-config {
+        sandbox "danger-full-access"
+    }
+}
+```
+
+Valid keys are anything the agent itself accepts — same catalogue as
+[claude-config.md](claude-config.md) and [codex-config.md](codex-config.md).
+
+Precedence (lowest → highest): built-in defaults → user `settings.kdl`
+→ project `settings.kdl` → **per-agent defaults for the chosen agent**
+→ template (`--template X`) → CLI `--config key=value` → per-actor DB
+config. Same-key conflicts between user and project blocks are resolved
+per key, with project winning.
+
+```
+
+- [ ] **Step 2: Update CLAUDE.md — extend the "Config files & templates" section**
+
+In `CLAUDE.md`, locate the paragraph that begins "Unknown top-level nodes (e.g. `hooks`, `agent`, `alias`) are silently ignored for forward-compat with follow-up tickets." and replace it with:
+
+```
+Per-agent default config lives in `agent "claude" { default-config { … } }`
+(and the same shape for `codex`). Any actor of that kind picks up those
+keys as the lowest config layer, under templates and under CLI `--config`.
+See ticket #31 for precedence details.
+
+Unknown top-level nodes (e.g. `hooks`, `alias`) are silently ignored for
+forward-compat with follow-up tickets #30 / #33.
+```
+
+- [ ] **Step 3: Run the full test suite one more time (docs-only changes, but sanity)**
+
+Run: `uv run python -m unittest discover tests`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/actor/_skill/SKILL.md CLAUDE.md
+git commit -m "Document per-agent default-config in SKILL.md and CLAUDE.md (#31)"
+```
+
+---
+
+## Self-review checklist
+
+- [x] **Spec coverage:** Ticket #31 asks for `agent "X" { default-config { … } }` blocks, precedence layer 4, API-key subsumption. Task 1 parses the block; Task 3 merges across files; Task 4 wires precedence; `strip-api-keys` is covered as an ordinary key (Task 1's multi-key test + Task 4's `--config` override test). Docs in Task 5. No `--api-key` CLI flag work needed — ticket keeps existing `--strip-api-keys` / `--no-strip-api-keys` CLI tri-state.
+- [x] **Placeholders:** No "TBD" / "similar to". All code blocks concrete.
+- [x] **Type consistency:** `agent_defaults: Dict[str, Dict[str, str]]` used identically in parser, merge, and cmd_new.
+- [x] **Out-of-scope fences:** No hooks (#30), no aliases (#33), no MCP `template=` parameter — those are explicitly deferred in the SKILL.md text.

--- a/spec/PLAN-AGENT-DEFAULTS.md
+++ b/spec/PLAN-AGENT-DEFAULTS.md
@@ -839,63 +839,56 @@ git commit -m "Apply per-agent default-config as lowest layer in cmd_new (#31)"
 
 - [ ] **Step 1: Update SKILL.md — add a "Per-agent defaults" subsection under Templates**
 
-In `src/actor/_skill/SKILL.md`, locate the paragraph near the top of the Templates section that ends with "Unknown top-level nodes (`hooks`, `agent`, `alias`) parse as no-ops today —" (around line 122) and change it to reflect that `agent` is now implemented. Replace that paragraph with:
+In `src/actor/_skill/SKILL.md`, update the forward-compat paragraph in
+the Templates section so it no longer advertises `agent` as a no-op
+(`agent` is now implemented). Leave the remaining forward-compat nodes
+(`hooks`, `alias`) listed.
 
-```
-Unknown top-level nodes (`hooks`, `alias`) parse as no-ops today —
-they're reserved for follow-up tickets. Malformed KDL raises an error
-with the file path.
-```
+Then, immediately before the "**Applying a template** (CLI only — see
+note below):" line, insert a new "**Per-agent defaults:**" subsection
+that:
 
-Then, immediately before the "**Applying a template** (CLI only — see note below):" line, insert a new subsection:
+1. Shows the `agent "claude" { default-config { … } }` / `agent "codex"
+   { default-config { … } }` block syntax.
+2. Points to `claude-config.md` / `codex-config.md` for valid keys.
+3. Spells out the precedence ladder and merge rule. Treat user and
+   project `settings.kdl` as a single merged layer — NOT as separate
+   ordered steps — to match how `_merge` folds them per key. Recommended
+   phrasing:
 
-```markdown
-**Per-agent defaults:**
+   ```
+   Precedence (lowest → highest):
 
-Alongside templates you can declare default config scoped to a specific
-coding agent. Any Claude actor picks up the `agent "claude"` block; any
-Codex actor picks up the `agent "codex"` block.
+   1. Built-in defaults
+   2. Per-agent defaults from `settings.kdl` (user + project merged per
+      key; project wins on conflicts)
+   3. Template config (`--template X`)
+   4. CLI `--config key=value`
+   5. Per-actor DB config
 
-```kdl
-agent "claude" {
-    default-config {
-        model "opus"
-        effort "max"
-        strip-api-keys true
-    }
-}
-
-agent "codex" {
-    default-config {
-        sandbox "danger-full-access"
-    }
-}
-```
-
-Valid keys are anything the agent itself accepts — same catalogue as
-[claude-config.md](claude-config.md) and [codex-config.md](codex-config.md).
-
-Precedence (lowest → highest): built-in defaults → user `settings.kdl`
-→ project `settings.kdl` → **per-agent defaults for the chosen agent**
-→ template (`--template X`) → CLI `--config key=value` → per-actor DB
-config. Same-key conflicts between user and project blocks are resolved
-per key, with project winning.
-
-```
+   `settings.kdl` is read at actor CREATION time. Editing the file later
+   does not retroactively change existing actors — use
+   `config_actor(name="…", pairs=[…])` / `actor config <name> key=value`
+   to update an actor's stored config.
+   ```
 
 - [ ] **Step 2: Update CLAUDE.md — extend the "Config files & templates" section**
 
-In `CLAUDE.md`, locate the paragraph that begins "Unknown top-level nodes (e.g. `hooks`, `agent`, `alias`) are silently ignored for forward-compat with follow-up tickets." and replace it with:
+In `CLAUDE.md`, replace the forward-compat paragraph that mentions
+`hooks`/`agent`/`alias` with two paragraphs:
 
-```
-Per-agent default config lives in `agent "claude" { default-config { … } }`
-(and the same shape for `codex`). Any actor of that kind picks up those
-keys as the lowest config layer, under templates and under CLI `--config`.
-See ticket #31 for precedence details.
+1. A per-agent-defaults paragraph that describes the block shape,
+   mentions user+project per-key merge, and inlines the precedence
+   ladder (lowest → highest: built-in → per-agent defaults → template →
+   CLI `--config`). Include a sentence about snapshot-at-creation —
+   editing `settings.kdl` later does not retroactively change existing
+   actors.
+2. A short forward-compat paragraph that still mentions `hooks` / `alias`
+   (no longer `agent`) as silently ignored for tickets #30 / #33.
 
-Unknown top-level nodes (e.g. `hooks`, `alias`) are silently ignored for
-forward-compat with follow-up tickets #30 / #33.
-```
+Do NOT reference this plan document (`spec/PLAN-AGENT-DEFAULTS.md`) from
+`CLAUDE.md` — the plan is transient and will be archived after the PR
+merges.
 
 - [ ] **Step 3: Run the full test suite one more time (docs-only changes, but sanity)**
 

--- a/spec/PLAN-AGENT-DEFAULTS.md
+++ b/spec/PLAN-AGENT-DEFAULTS.md
@@ -163,10 +163,24 @@ uniform across the codebase.)
 Replace the `AppConfig` dataclass (currently around lines 31-33):
 
 ```python
+# Template-level field names — rejected inside `default-config` and
+# when dropped bare under an `agent` block. Centralised so the two
+# parser checks can't drift apart.
+_RESERVED_TEMPLATE_KEYS = ("prompt", "agent")
+
+
 @dataclass
 class AppConfig:
     templates: Dict[str, Template] = field(default_factory=dict)
+    # Parser invariant: every key present in `agent_defaults` maps to
+    # a non-empty dict. `__post_init__` enforces it on programmatic
+    # construction; `_merge` maintains it across merges.
     agent_defaults: Dict[str, Dict[str, str]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.agent_defaults = {
+            agent: keys for agent, keys in self.agent_defaults.items() if keys
+        }
 ```
 
 Add a new helper above `_parse_kdl_file` (after `_parse_template`):
@@ -181,6 +195,8 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
     through — no fixed schema, they're consumed by the agent at spawn
     time. Using `prompt` or `agent` here raises; they belong on the
     template, not inside a block whose scope is already one agent.
+    Nested `default-config { default-config { … } }` raises with a
+    dedicated message instead of the misleading "needs a value".
     """
     if node.args:
         raise ConfigError(
@@ -200,11 +216,17 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
         # `prompt "a" / prompt "b"` reports the reserved-key error
         # (which tells the user to move `prompt` up to the template)
         # instead of a misleading "duplicate prompt".
-        if key in ("prompt", "agent"):
+        if key in _RESERVED_TEMPLATE_KEYS:
             raise ConfigError(
                 f"agent '{agent_name}' in {source}: '{key}' is not a "
                 f"valid default-config key (it's a template-level field, "
                 f"not an agent config key)"
+            )
+        if key == "default-config":
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: `default-config` "
+                f"cannot be nested inside another `default-config` — "
+                f"list config keys directly"
             )
         if key in seen_keys:
             raise ConfigError(
@@ -221,6 +243,15 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
                 f"properties"
             )
         if not child.args:
+            # `model { nested "x" }` trips this branch with args == []
+            # but nodes != []; distinguish that case so the user isn't
+            # told their key "needs a value" when they did supply one.
+            if getattr(child, "nodes", None):
+                raise ConfigError(
+                    f"agent '{agent_name}' in {source}: '{key}' must be a "
+                    f"scalar `{key} \"value\"` entry — nested blocks are "
+                    f"not supported inside `default-config`"
+                )
             raise ConfigError(
                 f"agent '{agent_name}' in {source}: '{key}' needs a value"
             )
@@ -237,11 +268,13 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
     """Parse an `agent "name" { … }` block. Returns (agent_name, defaults).
 
     Validates the agent name against AgentKind so typos (`agent "cluade"`)
-    fail fast. Block-style children other than `default-config` (no args)
-    are silently accepted as forward-compat no-ops for follow-up tickets
-    (hooks #30 etc.). Key-with-value children directly under `agent` —
-    e.g. `model "opus"` instead of `default-config { model "opus" }` —
-    raise so the user's keys aren't silently dropped.
+    fail fast. Children with no positional args (`hooks { … }`, bare
+    `alias`) are silently accepted as forward-compat no-ops for
+    follow-up tickets (#30 / #33). Key-with-value children directly
+    under `agent` — e.g. `model "opus"` instead of
+    `default-config { model "opus" }` — raise so the user's keys
+    aren't silently dropped. Reserved template names (`prompt`, `agent`)
+    raise regardless of shape and point the user at `template` blocks.
     """
     if not node.args:
         raise ConfigError(
@@ -287,6 +320,15 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
             seen_default_config = True
             defaults = _parse_default_config(child, name, source)
             continue
+        # Catch reserved template names regardless of shape — pointing
+        # the user at `default-config` is actively wrong because those
+        # names are rejected there too.
+        if child.name in _RESERVED_TEMPLATE_KEYS:
+            raise ConfigError(
+                f"agent '{name}' in {source}: `{child.name}` is a "
+                f"template-level field, not an agent config key — "
+                f"put it on a `template` block instead"
+            )
         if child.args:
             raise ConfigError(
                 f"agent '{name}' in {source}: `{child.name}` cannot sit "
@@ -347,6 +389,8 @@ def _parse_kdl_file(path: Path) -> AppConfig:
         # tickets #30 / #33 and are not implemented here.
     return cfg
 ```
+
+Also add a targeted `default-config` rejection inside `_parse_template` (existing function) so `template "qa" { default-config { … } }` raises a helpful "belongs under an `agent` block" error instead of the misleading "'default-config' needs a value" from the generic args check.
 
 - [ ] **Step 4: Run the new tests — expect pass**
 
@@ -628,10 +672,19 @@ def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
     merged_templates = dict(base.templates)
     merged_templates.update(over.templates)
 
+    # Filter empty dicts on both sides to preserve the
+    # `AppConfig.agent_defaults` invariant ("presence implies at least
+    # one key") even when callers pass in programmatically constructed
+    # configs. `__post_init__` does the same at construction time, but
+    # filtering here keeps `_merge` correct in isolation.
     merged_agent_defaults: Dict[str, Dict[str, str]] = {
-        agent: dict(keys) for agent, keys in base.agent_defaults.items()
+        agent: dict(keys)
+        for agent, keys in base.agent_defaults.items()
+        if keys
     }
     for agent, keys in over.agent_defaults.items():
+        if not keys:
+            continue
         existing = merged_agent_defaults.setdefault(agent, {})
         existing.update(keys)
 

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -149,12 +149,24 @@ agent "codex" {
 Valid keys are anything the agent itself accepts — same catalogue as
 [claude-config.md](claude-config.md) and [codex-config.md](codex-config.md).
 
-Precedence (lowest → highest): built-in defaults → user `settings.kdl`
-→ project `settings.kdl` → **per-agent defaults for the chosen agent**
-→ template (`--template X`) → CLI `--config key=value` → per-actor DB
-config. Same-key conflicts between the user and project `agent` blocks
-resolve per key, with project winning; keys the project doesn't
-restate are kept from the user block.
+Precedence (lowest → highest):
+
+1. Built-in defaults (hard-coded per agent)
+2. **Per-agent defaults from `settings.kdl`** (user + project merged per
+   key; project wins on same-key conflicts)
+3. Template config (`--template X`)
+4. CLI `--config key=value`
+5. Per-actor DB config (persisted by `config_actor` / `actor config`)
+
+User and project `settings.kdl` are not separate layers in the precedence
+chain — they merge per key into a single per-agent map before precedence
+is applied, so a user-wide `model "opus"` plus a project-scoped
+`effort "max"` both survive.
+
+`settings.kdl` is read when the actor is **created**. Editing the file
+later does not retroactively change existing actors — use
+`config_actor(name="…", pairs=[…])` (MCP) or `actor config <name> key=value`
+(CLI) to update an actor's stored config.
 
 **Applying a template** (CLI only — see note below):
 

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -148,6 +148,10 @@ agent "codex" {
 
 Valid keys are anything the agent itself accepts — same catalogue as
 [claude-config.md](claude-config.md) and [codex-config.md](codex-config.md).
+Values may be strings, booleans, or numbers; they're all coerced to
+strings to match the actor config pipeline (same rules as templates).
+`prompt` and `agent` are template-level fields and cannot appear inside
+`default-config` — using them there raises a `ConfigError`.
 
 Precedence at actor **creation** (`new_actor` / `actor new`),
 lowest → highest:

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -121,7 +121,10 @@ template "reviewer" {
 
 Unknown top-level nodes (`hooks`, `alias`) parse as no-ops today —
 they're reserved for follow-up tickets. Malformed KDL raises an error
-with the file path.
+with the file path. A top-level `default-config` block is explicitly
+rejected (not silently ignored) because it is almost always a
+misread of the schema — nest it under `agent "claude" { … }` or
+`agent "codex" { … }` instead.
 
 **Per-agent defaults:**
 

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -149,24 +149,27 @@ agent "codex" {
 Valid keys are anything the agent itself accepts — same catalogue as
 [claude-config.md](claude-config.md) and [codex-config.md](codex-config.md).
 
-Precedence (lowest → highest):
+Precedence at actor **creation** (`new_actor` / `actor new`),
+lowest → highest:
 
-1. Built-in defaults (hard-coded per agent)
-2. **Per-agent defaults from `settings.kdl`** (user + project merged per
-   key; project wins on same-key conflicts)
-3. Template config (`--template X`)
-4. CLI `--config key=value`
-5. Per-actor DB config (persisted by `config_actor` / `actor config`)
+1. **Per-agent defaults from `settings.kdl`** (user + project merged
+   per key; project wins on same-key conflicts)
+2. Template config (`--template X`)
+3. CLI `config` / `--config key=value`
 
-User and project `settings.kdl` are not separate layers in the precedence
-chain — they merge per key into a single per-agent map before precedence
-is applied, so a user-wide `model "opus"` plus a project-scoped
+User and project `settings.kdl` are not separate layers in this chain —
+they merge per key into a single per-agent map before precedence is
+applied, so a user-wide `model "opus"` plus a project-scoped
 `effort "max"` both survive.
 
-`settings.kdl` is read when the actor is **created**. Editing the file
-later does not retroactively change existing actors — use
-`config_actor(name="…", pairs=[…])` (MCP) or `actor config <name> key=value`
-(CLI) to update an actor's stored config.
+The merge result is snapshotted into the actor's stored config. Editing
+`settings.kdl` later does not retroactively change existing actors —
+use `config_actor(name="…", pairs=[…])` (MCP) or
+`actor config <name> key=value` (CLI) to update the stored config.
+
+Precedence at **run** (`run_actor` / `actor run`): the actor's stored
+config is the base; per-run `config` / `--config` arguments layer on
+top for that run only and are not saved.
 
 **Applying a template** (CLI only — see note below):
 

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -119,9 +119,42 @@ template "reviewer" {
   numbers; they're all coerced to strings to match the actor config
   pipeline.
 
-Unknown top-level nodes (`hooks`, `agent`, `alias`) parse as no-ops today —
+Unknown top-level nodes (`hooks`, `alias`) parse as no-ops today —
 they're reserved for follow-up tickets. Malformed KDL raises an error
 with the file path.
+
+**Per-agent defaults:**
+
+Alongside templates you can declare default config scoped to a specific
+coding agent. Any Claude actor picks up the `agent "claude"` block; any
+Codex actor picks up the `agent "codex"` block. Neither competes with
+the other.
+
+```kdl
+agent "claude" {
+    default-config {
+        model "opus"
+        effort "max"
+        strip-api-keys true
+    }
+}
+
+agent "codex" {
+    default-config {
+        sandbox "danger-full-access"
+    }
+}
+```
+
+Valid keys are anything the agent itself accepts — same catalogue as
+[claude-config.md](claude-config.md) and [codex-config.md](codex-config.md).
+
+Precedence (lowest → highest): built-in defaults → user `settings.kdl`
+→ project `settings.kdl` → **per-agent defaults for the chosen agent**
+→ template (`--template X`) → CLI `--config key=value` → per-actor DB
+config. Same-key conflicts between the user and project `agent` blocks
+resolve per key, with project winning; keys the project doesn't
+restate are kept from the user block.
 
 **Applying a template** (CLI only — see note below):
 

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -135,8 +135,20 @@ def cmd_new(
     if not binary_exists(agent_kind.binary_name):
         print(f"warning: '{agent_kind.binary_name}' not found on PATH", file=sys.stderr)
 
-    # Config precedence: template's config is the base; CLI pairs overlay on top.
-    config: Dict[str, str] = dict(template.config) if template else {}
+    # Config precedence (lowest → highest):
+    #   per-agent default-config for the chosen agent
+    #     → template.config
+    #       → CLI --config pairs.
+    # Defaults key off the already-chosen agent_kind, so CLI --agent
+    # overriding a template's agent correctly picks up the new agent's
+    # defaults rather than the template's.
+    config: Dict[str, str] = {}
+    if app_config is not None:
+        agent_defaults = app_config.agent_defaults.get(agent_kind.as_str())
+        if agent_defaults:
+            config.update(agent_defaults)
+    if template is not None:
+        config.update(template.config)
     for k, v in parse_config(config_pairs).items():
         config[k] = v
     config = _sorted_config(config)

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -17,7 +17,7 @@ from typing import Dict, Optional, Tuple
 
 import kdl
 
-from .errors import ConfigError
+from .errors import ActorError, ConfigError
 from .types import AgentKind
 
 
@@ -119,6 +119,16 @@ def _parse_template(node, source: Path) -> Template:
                 f"template '{name}' in {source}: duplicate key '{key}'"
             )
         seen_keys.add(key)
+        # Catch a common mix-up: `default-config {}` belongs under an
+        # `agent "..."` block, not under a template. Without this check
+        # the user gets "'default-config' needs a value" because the
+        # node has only children, no args — which hides the real fix.
+        if key == "default-config":
+            raise ConfigError(
+                f"template '{name}' in {source}: `default-config` blocks "
+                f"belong under `agent \"claude\" {{ … }}` / "
+                f"`agent \"codex\" {{ … }}`, not inside a template"
+            )
         if not child.args:
             raise ConfigError(
                 f"template '{name}' in {source}: '{key}' needs a value"
@@ -194,15 +204,21 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
 def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
     """Parse an `agent "name" { … }` block. Returns (agent_name, defaults).
 
-    Validates the agent name against AgentKind so typos (`agent "cluade"`)
-    fail fast. Children other than `default-config` are silently ignored
-    so future tickets (hooks etc.) can share the block without breaking
-    today's parser.
+    Validates the agent name via `AgentKind.from_str` so typos
+    (`agent "cluade"`) fail fast with the same canonical allowlist the
+    rest of the codebase uses. Children other than `default-config` are
+    silently ignored so future tickets (hooks etc.) can share the block
+    without breaking today's parser.
     """
-    if not node.args or not isinstance(node.args[0], str):
+    if not node.args:
         raise ConfigError(
             f"agent block in {source} must have a name "
             f"(e.g. `agent \"claude\" {{ … }}`)"
+        )
+    if not isinstance(node.args[0], str):
+        raise ConfigError(
+            f"agent block in {source}: name must be a string, "
+            f"got {type(node.args[0]).__name__}"
         )
     if not node.args[0]:
         raise ConfigError(
@@ -217,12 +233,14 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
             f"agent '{node.args[0]}' in {source} does not accept properties"
         )
     name = node.args[0]
-    valid = [k.value for k in AgentKind]
-    if name not in valid:
+    try:
+        AgentKind.from_str(name)
+    except ActorError as e:
+        valid = ", ".join(k.value for k in AgentKind)
         raise ConfigError(
             f"agent block in {source}: unknown agent '{name}' "
-            f"(valid: {', '.join(valid)})"
-        )
+            f"(valid: {valid})"
+        ) from e
 
     defaults: Dict[str, str] = {}
     seen_default_config = False

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -2,22 +2,23 @@
 
 Loads ~/.actor/settings.kdl (user) and <project>/.actor/settings.kdl
 (project), merges them, and exposes the merged AppConfig with its
-templates map. Project config overrides user config on same-key conflict.
+templates map and per-agent default-config overrides. Project config
+overrides user config on same-key conflict.
 
-Out of scope (see tickets #30 / #31 / #33): hooks, per-agent default-config
-blocks, aliases. Their nodes are skipped at parse time without error for
-forward compatibility.
+Out of scope (see tickets #30 / #33): hooks, aliases. Their nodes are
+skipped at parse time without error for forward compatibility.
 """
 from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import kdl
 
 from .errors import ConfigError
+from .types import AgentKind
 
 
 @dataclass
@@ -31,6 +32,7 @@ class Template:
 @dataclass
 class AppConfig:
     templates: Dict[str, Template] = field(default_factory=dict)
+    agent_defaults: Dict[str, Dict[str, str]] = field(default_factory=dict)
 
 
 def _find_project_config(
@@ -145,6 +147,99 @@ def _parse_template(node, source: Path) -> Template:
     return tpl
 
 
+def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]:
+    """Parse a `default-config { … }` block inside an `agent` block.
+
+    Same shape rules as template children: each child is `key "value"`
+    with exactly one scalar arg, no props, no duplicates. Unknown keys
+    pass through (no fixed schema — they're consumed by the agent at
+    spawn time).
+    """
+    if node.args:
+        raise ConfigError(
+            f"agent '{agent_name}' in {source}: `default-config` does not "
+            f"accept positional arguments"
+        )
+    if getattr(node, "props", None):
+        raise ConfigError(
+            f"agent '{agent_name}' in {source}: `default-config` does not "
+            f"accept properties"
+        )
+    out: Dict[str, str] = {}
+    for child in node.nodes:
+        key = child.name
+        if key in out:
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: duplicate key '{key}' "
+                f"in default-config"
+            )
+        if not child.args:
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: '{key}' needs a value"
+            )
+        if len(child.args) > 1:
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: '{key}' has extra args "
+                f"(only a single value is supported)"
+            )
+        if getattr(child, "props", None):
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: '{key}' does not accept "
+                f"properties"
+            )
+        out[key] = _coerce_value(child.args[0])
+    return out
+
+
+def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
+    """Parse an `agent "name" { … }` block. Returns (agent_name, defaults).
+
+    Validates the agent name against AgentKind so typos (`agent "cluade"`)
+    fail fast. Children other than `default-config` are silently ignored
+    so future tickets (hooks etc.) can share the block without breaking
+    today's parser.
+    """
+    if not node.args or not isinstance(node.args[0], str):
+        raise ConfigError(
+            f"agent block in {source} must have a name "
+            f"(e.g. `agent \"claude\" {{ … }}`)"
+        )
+    if not node.args[0]:
+        raise ConfigError(
+            f"agent block in {source} must have a non-empty name"
+        )
+    if len(node.args) > 1:
+        raise ConfigError(
+            f"agent '{node.args[0]}' in {source} has extra positional args"
+        )
+    if getattr(node, "props", None):
+        raise ConfigError(
+            f"agent '{node.args[0]}' in {source} does not accept properties"
+        )
+    name = node.args[0]
+    valid = [k.value for k in AgentKind]
+    if name not in valid:
+        raise ConfigError(
+            f"agent block in {source}: unknown agent '{name}' "
+            f"(valid: {', '.join(valid)})"
+        )
+
+    defaults: Dict[str, str] = {}
+    seen_default_config = False
+    for child in node.nodes:
+        if child.name != "default-config":
+            # Forward-compat: e.g. hooks (#30). Silently skipped today.
+            continue
+        if seen_default_config:
+            raise ConfigError(
+                f"agent '{name}' in {source}: multiple `default-config` "
+                f"blocks (only one is allowed)"
+            )
+        seen_default_config = True
+        defaults = _parse_default_config(child, name, source)
+    return name, defaults
+
+
 def _parse_kdl_file(path: Path) -> AppConfig:
     try:
         text = path.read_text()
@@ -163,15 +258,31 @@ def _parse_kdl_file(path: Path) -> AppConfig:
                     f"duplicate template '{tpl.name}' in {path}"
                 )
             cfg.templates[tpl.name] = tpl
-        # Silently ignore hooks / agent / alias — those belong to follow-up
-        # tickets #30 / #31 / #33 and are not implemented here.
+        elif node.name == "agent":
+            name, defaults = _parse_agent_block(node, path)
+            if name in cfg.agent_defaults:
+                raise ConfigError(
+                    f"duplicate agent block '{name}' in {path}"
+                )
+            # An agent block with no `default-config` child contributes
+            # nothing — preserve the invariant "presence in
+            # agent_defaults implies at least one declared key".
+            if defaults:
+                cfg.agent_defaults[name] = defaults
+        # Silently ignore hooks / alias — those belong to follow-up
+        # tickets #30 / #33 and are not implemented here.
     return cfg
 
 
 def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
     merged_templates = dict(base.templates)
     merged_templates.update(over.templates)
-    return AppConfig(templates=merged_templates)
+    merged_agent_defaults = dict(base.agent_defaults)
+    merged_agent_defaults.update(over.agent_defaults)
+    return AppConfig(
+        templates=merged_templates,
+        agent_defaults=merged_agent_defaults,
+    )
 
 
 def load_config(

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -42,10 +42,15 @@ class AppConfig:
     templates: Dict[str, Template] = field(default_factory=dict)
     # Parser invariant: every key present in `agent_defaults` maps to a
     # non-empty dict — an `agent "claude" { default-config {} }` block
-    # contributes nothing, so the key is omitted entirely. `_merge`
-    # filters empty dicts on both sides so this invariant survives
-    # programmatic construction too.
+    # contributes nothing, so the key is omitted entirely. `__post_init__`
+    # enforces this on programmatic construction; `_merge` maintains it
+    # across merges.
     agent_defaults: Dict[str, Dict[str, str]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.agent_defaults = {
+            agent: keys for agent, keys in self.agent_defaults.items() if keys
+        }
 
 
 def _find_project_config(
@@ -241,6 +246,16 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
                 f"properties"
             )
         if not child.args:
+            # Block-shaped children (`model { nested "x" }`) trip this
+            # branch with `args == []`. Distinguish that case so the
+            # user isn't told their key "needs a value" when they did
+            # supply one — just in an unsupported shape.
+            if getattr(child, "nodes", None):
+                raise ConfigError(
+                    f"agent '{agent_name}' in {source}: '{key}' must be a "
+                    f"scalar `{key} \"value\"` entry — nested blocks are "
+                    f"not supported inside `default-config`"
+                )
             raise ConfigError(
                 f"agent '{agent_name}' in {source}: '{key}' needs a value"
             )
@@ -258,12 +273,13 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
 
     Validates the agent name via `AgentKind.from_str` so typos
     (`agent "cluade"`) fail fast with the same canonical allowlist the
-    rest of the codebase uses. Block-style children other than
-    `default-config` (those with no args, e.g. `hooks { … }`) are
-    silently accepted as forward-compat no-ops for follow-up tickets.
-    Key-with-value children directly under `agent` (e.g. `model "opus"`
-    instead of `default-config { model "opus" }`) raise so the user's
-    keys aren't silently dropped.
+    rest of the codebase uses. Children with no positional args
+    (`hooks { … }`, bare `alias`) are silently accepted as forward-compat
+    no-ops for follow-up tickets. Key-with-value children directly under
+    `agent` (e.g. `model "opus"` instead of
+    `default-config { model "opus" }`) raise so the user's keys aren't
+    silently dropped. Reserved template names (`prompt`, `agent`) raise
+    regardless of shape and point the user at `template` blocks.
     """
     if not node.args:
         raise ConfigError(
@@ -309,22 +325,23 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
             seen_default_config = True
             defaults = _parse_default_config(child, name, source)
             continue
+        # `prompt` / `agent` are template-level fields, not config keys.
+        # Catch them regardless of shape (`prompt "x"`, `prompt { ... }`,
+        # or bare `prompt`) — pointing the user at `default-config` is
+        # actively wrong because those names are rejected there too.
+        if child.name in _RESERVED_TEMPLATE_KEYS:
+            raise ConfigError(
+                f"agent '{name}' in {source}: `{child.name}` is a "
+                f"template-level field, not an agent config key — "
+                f"put it on a `template` block instead"
+            )
         # Mirror of the template-side guard: a user who writes
         # `model "opus"` directly under `agent "claude" { … }` (forgetting
         # the `default-config { … }` wrapper) would otherwise see their
-        # key silently dropped. Block-style children with no args stay
-        # silently accepted as forward-compat no-ops for follow-up
-        # tickets (e.g. `hooks {}` from #30).
+        # key silently dropped. Children with no args (bare `hooks` or
+        # `hooks { … }` blocks) stay silently accepted as forward-compat
+        # no-ops for follow-up tickets (e.g. #30).
         if child.args:
-            # `prompt` / `agent` are template-level fields, not config
-            # keys — pointing the user at `default-config` would be
-            # actively wrong because those names are rejected there too.
-            if child.name in _RESERVED_TEMPLATE_KEYS:
-                raise ConfigError(
-                    f"agent '{name}' in {source}: `{child.name}` is a "
-                    f"template-level field, not an agent config key — "
-                    f"put it on a `template` block instead"
-                )
             raise ConfigError(
                 f"agent '{name}' in {source}: `{child.name}` cannot sit "
                 f"directly under an `agent` block — nest config keys "
@@ -424,6 +441,11 @@ def load_config(
       the user config step is skipped.
 
     Missing files are skipped silently. Malformed files raise ConfigError.
+
+    Merge semantics (see `_merge`): templates merge by name, with
+    project overriding user on collision. Per-agent `default-config`
+    merges per-key — user + project contribute distinct keys for the
+    same agent, and project wins on same-key conflict.
     """
     if cwd is None:
         cwd = Path.cwd()

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -6,7 +6,9 @@ templates map and per-agent default-config overrides. Project config
 overrides user config on same-key conflict.
 
 Out of scope (see tickets #30 / #33): hooks, aliases. Their nodes are
-skipped at parse time without error for forward compatibility.
+skipped at parse time without error for forward compatibility. A
+top-level `default-config` block is NOT silently skipped — it raises a
+helpful error pointing users at the correct nesting under `agent`.
 """
 from __future__ import annotations
 
@@ -149,6 +151,17 @@ def _parse_template(node, source: Path) -> Template:
             )
         value_str = _coerce_value(raw)
         if key == "agent":
+            # Validate against AgentKind here (not at cmd_new time) so a
+            # typo in settings.kdl surfaces as a ConfigError with the
+            # offending path — matches the agent-block validator.
+            try:
+                AgentKind.from_str(value_str)
+            except ActorError as e:
+                valid = ", ".join(k.value for k in AgentKind)
+                raise ConfigError(
+                    f"template '{name}' in {source}: unknown agent "
+                    f"'{value_str}' (valid: {valid})"
+                ) from e
             tpl.agent = value_str
         elif key == "prompt":
             tpl.prompt = value_str
@@ -176,12 +189,25 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
             f"accept properties"
         )
     out: Dict[str, str] = {}
+    seen_keys: set[str] = set()
     for child in node.nodes:
         key = child.name
-        if key in out:
+        if key in seen_keys:
             raise ConfigError(
                 f"agent '{agent_name}' in {source}: duplicate key '{key}' "
                 f"in default-config"
+            )
+        seen_keys.add(key)
+        # `prompt` and `agent` are the template-level reserved names;
+        # inside default-config they have no well-defined semantics.
+        # Without this check, `prompt "be brief"` would silently become
+        # a `--prompt` CLI flag via ClaudeAgent._config_args — almost
+        # never what the user intended.
+        if key in ("prompt", "agent"):
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: '{key}' is not a "
+                f"valid default-config key (it's a template-level field, "
+                f"not an agent config key)"
             )
         if not child.args:
             raise ConfigError(
@@ -206,9 +232,12 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
 
     Validates the agent name via `AgentKind.from_str` so typos
     (`agent "cluade"`) fail fast with the same canonical allowlist the
-    rest of the codebase uses. Children other than `default-config` are
-    silently ignored so future tickets (hooks etc.) can share the block
-    without breaking today's parser.
+    rest of the codebase uses. Block-style children other than
+    `default-config` (those with no args, e.g. `hooks { … }`) are
+    silently accepted as forward-compat no-ops for follow-up tickets.
+    Key-with-value children directly under `agent` (e.g. `model "opus"`
+    instead of `default-config { model "opus" }`) raise so the user's
+    keys aren't silently dropped.
     """
     if not node.args:
         raise ConfigError(
@@ -326,11 +355,16 @@ def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
 
     # Agent defaults merge per key, not per agent block: a user-wide
     # `model` plus a project-scoped `effort` both survive. Same-key
-    # conflicts resolve project-wins (over beats base).
+    # conflicts resolve project-wins (over beats base). Skip empty
+    # incoming dicts so the parser invariant "presence in agent_defaults
+    # implies at least one declared key" survives programmatic
+    # AppConfig construction too.
     merged_agent_defaults: Dict[str, Dict[str, str]] = {
         agent: dict(keys) for agent, keys in base.agent_defaults.items()
     }
     for agent, keys in over.agent_defaults.items():
+        if not keys:
+            continue
         existing = merged_agent_defaults.setdefault(agent, {})
         existing.update(keys)
 

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -277,8 +277,17 @@ def _parse_kdl_file(path: Path) -> AppConfig:
 def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
     merged_templates = dict(base.templates)
     merged_templates.update(over.templates)
-    merged_agent_defaults = dict(base.agent_defaults)
-    merged_agent_defaults.update(over.agent_defaults)
+
+    # Agent defaults merge per key, not per agent block: a user-wide
+    # `model` plus a project-scoped `effort` both survive. Same-key
+    # conflicts resolve project-wins (over beats base).
+    merged_agent_defaults: Dict[str, Dict[str, str]] = {
+        agent: dict(keys) for agent, keys in base.agent_defaults.items()
+    }
+    for agent, keys in over.agent_defaults.items():
+        existing = merged_agent_defaults.setdefault(agent, {})
+        existing.update(keys)
+
     return AppConfig(
         templates=merged_templates,
         agent_defaults=merged_agent_defaults,

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -23,6 +23,12 @@ from .errors import ActorError, ConfigError
 from .types import AgentKind
 
 
+# Template-level field names — rejected inside `default-config` and
+# when dropped bare under an `agent` block. Centralised so the two
+# parser checks can't drift apart.
+_RESERVED_TEMPLATE_KEYS = ("prompt", "agent")
+
+
 @dataclass
 class Template:
     name: str
@@ -34,6 +40,11 @@ class Template:
 @dataclass
 class AppConfig:
     templates: Dict[str, Template] = field(default_factory=dict)
+    # Parser invariant: every key present in `agent_defaults` maps to a
+    # non-empty dict — an `agent "claude" { default-config {} }` block
+    # contributes nothing, so the key is omitted entirely. `_merge`
+    # filters empty dicts on both sides so this invariant survives
+    # programmatic construction too.
     agent_defaults: Dict[str, Dict[str, str]] = field(default_factory=dict)
 
 
@@ -198,11 +209,21 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
         # / prompt "b"` reports the reserved-key error (which tells the
         # user the real fix — move `prompt` to the template) rather than
         # a misleading "duplicate prompt".
-        if key in ("prompt", "agent"):
+        if key in _RESERVED_TEMPLATE_KEYS:
             raise ConfigError(
                 f"agent '{agent_name}' in {source}: '{key}' is not a "
                 f"valid default-config key (it's a template-level field, "
                 f"not an agent config key)"
+            )
+        # Nested `default-config { default-config { … } }` is almost
+        # always a misread of the schema — without this branch the
+        # user gets a misleading "'default-config' needs a value"
+        # message from the args check below.
+        if key == "default-config":
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: `default-config` "
+                f"cannot be nested inside another `default-config` — "
+                f"list config keys directly"
             )
         if key in seen_keys:
             raise ConfigError(
@@ -295,6 +316,15 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
         # silently accepted as forward-compat no-ops for follow-up
         # tickets (e.g. `hooks {}` from #30).
         if child.args:
+            # `prompt` / `agent` are template-level fields, not config
+            # keys — pointing the user at `default-config` would be
+            # actively wrong because those names are rejected there too.
+            if child.name in _RESERVED_TEMPLATE_KEYS:
+                raise ConfigError(
+                    f"agent '{name}' in {source}: `{child.name}` is a "
+                    f"template-level field, not an agent config key — "
+                    f"put it on a `template` block instead"
+                )
             raise ConfigError(
                 f"agent '{name}' in {source}: `{child.name}` cannot sit "
                 f"directly under an `agent` block — nest config keys "

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -132,21 +132,23 @@ def _parse_template(node, source: Path) -> Template:
     seen_keys: set[str] = set()
     for child in node.nodes:
         key = child.name
-        if key in seen_keys:
-            raise ConfigError(
-                f"template '{name}' in {source}: duplicate key '{key}'"
-            )
-        seen_keys.add(key)
         # Catch a common mix-up: `default-config {}` belongs under an
-        # `agent "..."` block, not under a template. Without this check
-        # the user gets "'default-config' needs a value" because the
-        # node has only children, no args — which hides the real fix.
+        # `agent "..."` block, not under a template. Check BEFORE the
+        # duplicate-key check so a repeated misplacement still surfaces
+        # the helpful redirect, and before the args check so that the
+        # block shape (no args, only children) doesn't get reported as
+        # "needs a value" — which hides the real fix.
         if key == "default-config":
             raise ConfigError(
                 f"template '{name}' in {source}: `default-config` blocks "
                 f"belong under `agent \"claude\" {{ … }}` / "
                 f"`agent \"codex\" {{ … }}`, not inside a template"
             )
+        if key in seen_keys:
+            raise ConfigError(
+                f"template '{name}' in {source}: duplicate key '{key}'"
+            )
+        seen_keys.add(key)
         if not child.args:
             raise ConfigError(
                 f"template '{name}' in {source}: '{key}' needs a value"

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -174,9 +174,11 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
     """Parse a `default-config { … }` block inside an `agent` block.
 
     Same shape rules as template children: each child is `key "value"`
-    with exactly one scalar arg, no props, no duplicates. Unknown keys
-    pass through (no fixed schema — they're consumed by the agent at
-    spawn time).
+    with exactly one scalar arg, no props, no duplicates. Keys other
+    than the template-level reserved names (`prompt`, `agent`) pass
+    through — no fixed schema, they're consumed by the agent at spawn
+    time. Using `prompt` or `agent` here raises; they belong on the
+    template, not inside a block whose scope is already one agent.
     """
     if node.args:
         raise ConfigError(
@@ -192,22 +194,30 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
     seen_keys: set[str] = set()
     for child in node.nodes:
         key = child.name
+        # Reject reserved keys BEFORE the duplicate check so `prompt "a"
+        # / prompt "b"` reports the reserved-key error (which tells the
+        # user the real fix — move `prompt` to the template) rather than
+        # a misleading "duplicate prompt".
+        if key in ("prompt", "agent"):
+            raise ConfigError(
+                f"agent '{agent_name}' in {source}: '{key}' is not a "
+                f"valid default-config key (it's a template-level field, "
+                f"not an agent config key)"
+            )
         if key in seen_keys:
             raise ConfigError(
                 f"agent '{agent_name}' in {source}: duplicate key '{key}' "
                 f"in default-config"
             )
         seen_keys.add(key)
-        # `prompt` and `agent` are the template-level reserved names;
-        # inside default-config they have no well-defined semantics.
-        # Without this check, `prompt "be brief"` would silently become
-        # a `--prompt` CLI flag via ClaudeAgent._config_args — almost
-        # never what the user intended.
-        if key in ("prompt", "agent"):
+        # Props check runs BEFORE the args check so `model name="opus"`
+        # (which has no positional args, just a property) reports the
+        # real issue — properties are rejected — instead of a
+        # misleading "needs a value".
+        if getattr(child, "props", None):
             raise ConfigError(
-                f"agent '{agent_name}' in {source}: '{key}' is not a "
-                f"valid default-config key (it's a template-level field, "
-                f"not an agent config key)"
+                f"agent '{agent_name}' in {source}: '{key}' does not accept "
+                f"properties"
             )
         if not child.args:
             raise ConfigError(
@@ -217,11 +227,6 @@ def _parse_default_config(node, agent_name: str, source: Path) -> Dict[str, str]
             raise ConfigError(
                 f"agent '{agent_name}' in {source}: '{key}' has extra args "
                 f"(only a single value is supported)"
-            )
-        if getattr(child, "props", None):
-            raise ConfigError(
-                f"agent '{agent_name}' in {source}: '{key}' does not accept "
-                f"properties"
             )
         out[key] = _coerce_value(child.args[0])
     return out
@@ -344,8 +349,10 @@ def _parse_kdl_file(path: Path) -> AppConfig:
                 f"supported — nest it inside `agent \"claude\" {{ … }}` "
                 f"or `agent \"codex\" {{ … }}`"
             )
-        # Silently ignore hooks / alias — those belong to follow-up
-        # tickets #30 / #33 and are not implemented here.
+        # Any other top-level node (e.g. `hooks`, `alias` for follow-up
+        # tickets #30 / #33, or anything else not listed above) parses
+        # as a no-op. Template and agent blocks are the only two shapes
+        # this ticket knows about.
     return cfg
 
 
@@ -355,12 +362,14 @@ def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
 
     # Agent defaults merge per key, not per agent block: a user-wide
     # `model` plus a project-scoped `effort` both survive. Same-key
-    # conflicts resolve project-wins (over beats base). Skip empty
-    # incoming dicts so the parser invariant "presence in agent_defaults
-    # implies at least one declared key" survives programmatic
-    # AppConfig construction too.
+    # conflicts resolve project-wins (over beats base). Empty incoming
+    # dicts are skipped on BOTH sides so the parser invariant "presence
+    # in agent_defaults implies at least one declared key" survives
+    # programmatic AppConfig construction too.
     merged_agent_defaults: Dict[str, Dict[str, str]] = {
-        agent: dict(keys) for agent, keys in base.agent_defaults.items()
+        agent: dict(keys)
+        for agent, keys in base.agent_defaults.items()
+        if keys
     }
     for agent, keys in over.agent_defaults.items():
         if not keys:

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -245,16 +245,27 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, Dict[str, str]]:
     defaults: Dict[str, str] = {}
     seen_default_config = False
     for child in node.nodes:
-        if child.name != "default-config":
-            # Forward-compat: e.g. hooks (#30). Silently skipped today.
+        if child.name == "default-config":
+            if seen_default_config:
+                raise ConfigError(
+                    f"agent '{name}' in {source}: multiple `default-config` "
+                    f"blocks (only one is allowed)"
+                )
+            seen_default_config = True
+            defaults = _parse_default_config(child, name, source)
             continue
-        if seen_default_config:
+        # Mirror of the template-side guard: a user who writes
+        # `model "opus"` directly under `agent "claude" { … }` (forgetting
+        # the `default-config { … }` wrapper) would otherwise see their
+        # key silently dropped. Block-style children with no args stay
+        # silently accepted as forward-compat no-ops for follow-up
+        # tickets (e.g. `hooks {}` from #30).
+        if child.args:
             raise ConfigError(
-                f"agent '{name}' in {source}: multiple `default-config` "
-                f"blocks (only one is allowed)"
+                f"agent '{name}' in {source}: `{child.name}` cannot sit "
+                f"directly under an `agent` block — nest config keys "
+                f"inside `default-config {{ … }}`"
             )
-        seen_default_config = True
-        defaults = _parse_default_config(child, name, source)
     return name, defaults
 
 
@@ -268,6 +279,11 @@ def _parse_kdl_file(path: Path) -> AppConfig:
     except kdl.ParseError as e:
         raise ConfigError(f"parse error in {path}: {e}") from e
     cfg = AppConfig()
+    # Track seen agent names separately from `cfg.agent_defaults`, which
+    # only records agents that contributed at least one key. Without the
+    # separate set, a first empty `agent "claude" { … }` block would not
+    # be detected as a duplicate when a later block declared real keys.
+    seen_agents: set[str] = set()
     for node in doc.nodes:
         if node.name == "template":
             tpl = _parse_template(node, path)
@@ -278,15 +294,27 @@ def _parse_kdl_file(path: Path) -> AppConfig:
             cfg.templates[tpl.name] = tpl
         elif node.name == "agent":
             name, defaults = _parse_agent_block(node, path)
-            if name in cfg.agent_defaults:
+            if name in seen_agents:
                 raise ConfigError(
                     f"duplicate agent block '{name}' in {path}"
                 )
+            seen_agents.add(name)
             # An agent block with no `default-config` child contributes
             # nothing — preserve the invariant "presence in
             # agent_defaults implies at least one declared key".
             if defaults:
                 cfg.agent_defaults[name] = defaults
+        elif node.name == "default-config":
+            # Symmetric with the template-side guard: a top-level
+            # `default-config` block is a common misread of the schema.
+            # Without this branch it would fall through to the
+            # "forward-compat no-op" bucket and the user's keys would
+            # silently vanish.
+            raise ConfigError(
+                f"top-level `default-config` block in {path} is not "
+                f"supported — nest it inside `agent \"claude\" {{ … }}` "
+                f"or `agent \"codex\" {{ … }}`"
+            )
         # Silently ignore hooks / alias — those belong to follow-up
         # tickets #30 / #33 and are not implemented here.
     return cfg

--- a/src/actor/server.py
+++ b/src/actor/server.py
@@ -6,6 +6,7 @@ import asyncio
 import sys
 import threading
 import traceback
+from pathlib import Path
 from typing import Any, List, Literal
 
 from . import __version__
@@ -15,6 +16,7 @@ from mcp.server.stdio import stdio_server
 from mcp.shared.message import SessionMessage
 from mcp.types import JSONRPCMessage, JSONRPCNotification
 
+from .config import load_config
 from .db import Database
 from .errors import ActorError
 from .git import RealGit
@@ -237,6 +239,11 @@ def new_actor(
     """
     db = _db()
     git = RealGit()
+    # Project-scoped settings.kdl is discovered by walking up from `dir`
+    # when given, otherwise from the server's cwd. User-wide settings
+    # always load from $HOME.
+    config_cwd = Path(dir) if dir else None
+    app_config = load_config(cwd=config_cwd)
     actor = cmd_new(
         db, git,
         name=name,
@@ -245,6 +252,7 @@ def new_actor(
         base=base,
         agent_name=agent,
         config_pairs=config or [],
+        app_config=app_config,
     )
 
     if prompt is not None:

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -695,6 +695,159 @@ class TestCmdNewTemplate(unittest.TestCase):
 
 
 # ──────────────────────────────────────────────────────────────────────
+#  Test: cmd_new with per-agent default-config (ticket #31)
+# ──────────────────────────────────────────────────────────────────────
+
+class TestCmdNewAgentDefaults(unittest.TestCase):
+
+    def _db(self) -> Database:
+        return Database.open(":memory:")
+
+    def _cfg(self, **kwargs):
+        from actor import AppConfig
+        return AppConfig(**kwargs)
+
+    def test_agent_defaults_applied_for_claude(self):
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={"claude": {"model": "opus"}})
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="claude", config_pairs=[],
+            app_config=cfg,
+        )
+        self.assertEqual(actor.config["model"], "opus")
+
+    def test_only_chosen_agent_defaults_apply(self):
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={
+            "claude": {"model": "opus"},
+            "codex": {"sandbox": "danger-full-access"},
+        })
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="codex", config_pairs=[],
+            app_config=cfg,
+        )
+        self.assertEqual(actor.config, {"sandbox": "danger-full-access"})
+        self.assertNotIn("model", actor.config)
+
+    def test_cli_config_pair_overrides_agent_default(self):
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={"claude": {"model": "opus"}})
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="claude", config_pairs=["model=haiku"],
+            app_config=cfg,
+        )
+        self.assertEqual(actor.config["model"], "haiku")
+
+    def test_template_config_overrides_agent_default(self):
+        # Agent defaults sit BELOW templates in the precedence ladder.
+        from actor import AppConfig, Template
+        db = self._db()
+        git = FakeGit()
+        cfg = AppConfig(
+            templates={"qa": Template(
+                name="qa", agent="claude", config={"model": "sonnet"},
+            )},
+            agent_defaults={"claude": {"model": "opus", "effort": "max"}},
+        )
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name=None, config_pairs=[],
+            template_name="qa", app_config=cfg,
+        )
+        self.assertEqual(actor.config["model"], "sonnet")
+        self.assertEqual(actor.config["effort"], "max")
+
+    def test_cli_overrides_both_template_and_agent_default(self):
+        from actor import AppConfig, Template
+        db = self._db()
+        git = FakeGit()
+        cfg = AppConfig(
+            templates={"qa": Template(
+                name="qa", agent="claude", config={"model": "sonnet"},
+            )},
+            agent_defaults={"claude": {"model": "opus"}},
+        )
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name=None, config_pairs=["model=haiku"],
+            template_name="qa", app_config=cfg,
+        )
+        self.assertEqual(actor.config["model"], "haiku")
+
+    def test_defaults_follow_cli_agent_not_template_agent(self):
+        # Template says claude, but CLI --agent=codex wins → codex
+        # defaults apply, claude defaults do NOT.
+        from actor import AppConfig, Template
+        db = self._db()
+        git = FakeGit()
+        cfg = AppConfig(
+            templates={"qa": Template(name="qa", agent="claude")},
+            agent_defaults={
+                "claude": {"model": "opus"},
+                "codex": {"sandbox": "danger-full-access"},
+            },
+        )
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="codex", config_pairs=[],
+            template_name="qa", app_config=cfg,
+        )
+        self.assertEqual(actor.agent, AgentKind.CODEX)
+        self.assertEqual(actor.config, {"sandbox": "danger-full-access"})
+
+    def test_no_defaults_for_agent_is_noop(self):
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={"codex": {"sandbox": "x"}})
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="claude", config_pairs=[],
+            app_config=cfg,
+        )
+        self.assertEqual(actor.config, {})
+
+    def test_none_app_config_is_noop(self):
+        # Backward-compat: callers that don't pass app_config see the old
+        # behavior (no defaults applied).
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="claude", config_pairs=["model=sonnet"],
+        )
+        self.assertEqual(actor.config, {"model": "sonnet"})
+
+    def test_defaults_applied_when_agent_name_defaults_to_claude(self):
+        # agent_name=None + no template → chosen agent is claude.
+        # Claude defaults should still apply.
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={"claude": {"model": "opus"}})
+        actor = cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name=None, config_pairs=[],
+            app_config=cfg,
+        )
+        self.assertEqual(actor.agent, AgentKind.CLAUDE)
+        self.assertEqual(actor.config["model"], "opus")
+
+
+# ──────────────────────────────────────────────────────────────────────
 #  Test: cmd_run  (8 tests from run.rs)
 # ──────────────────────────────────────────────────────────────────────
 

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -846,6 +846,26 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
         self.assertEqual(actor.agent, AgentKind.CLAUDE)
         self.assertEqual(actor.config["model"], "opus")
 
+    def test_agent_defaults_are_persisted_in_db(self):
+        # Snapshot-at-creation: later settings.kdl edits do NOT retroactively
+        # affect the actor. The resolved merge is written to the DB and
+        # retrievable via get_actor.
+        db = self._db()
+        git = FakeGit()
+        cfg = self._cfg(agent_defaults={
+            "claude": {"model": "opus", "effort": "max"},
+        })
+        cmd_new(
+            db, git,
+            name="a", dir="/tmp", no_worktree=True, base=None,
+            agent_name="claude", config_pairs=["strip-api-keys=true"],
+            app_config=cfg,
+        )
+        reloaded = db.get_actor("a")
+        self.assertEqual(reloaded.config, {
+            "model": "opus", "effort": "max", "strip-api-keys": "true",
+        })
+
 
 # ──────────────────────────────────────────────────────────────────────
 #  Test: cmd_run  (8 tests from run.rs)

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import io
 import sys
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from actor import __version__
@@ -474,6 +475,29 @@ class McpToolTests(unittest.TestCase):
             server.run_actor(name="foo", prompt="do x", config=["model=opus"])
         args, kwargs = spawn.call_args
         self.assertEqual(kwargs["config_pairs"], ["model=opus"])
+
+    def test_new_actor_forwards_app_config_from_dir(self):
+        # Regression guard: `new_actor` must route `dir` through
+        # `load_config(cwd=...)` and forward the result to `cmd_new` so
+        # per-agent `default-config` keys from the project settings.kdl
+        # actually apply. Dropping the `app_config=` kwarg at the call
+        # site would silently disable per-agent defaults for MCP
+        # callers.
+        from actor import server
+        from actor.config import AppConfig
+        fake_cfg = AppConfig()
+        with patch("actor.server.load_config") as load_config, \
+             patch("actor.server.cmd_new") as cmd_new, \
+             patch("actor.server._spawn_background_run"):
+            load_config.return_value = fake_cfg
+            fake_actor = MagicMock()
+            fake_actor.dir = "/tmp/foo"
+            cmd_new.return_value = fake_actor
+            server.new_actor(name="foo", dir="/tmp/project")
+        load_kwargs = load_config.call_args.kwargs
+        self.assertEqual(load_kwargs.get("cwd"), Path("/tmp/project"))
+        cmd_kwargs = cmd_new.call_args.kwargs
+        self.assertIs(cmd_kwargs.get("app_config"), fake_cfg)
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -291,5 +291,88 @@ class TestLoadConfigCwdUnderHome(unittest.TestCase):
             self.assertEqual(cfg.templates["qa"].agent, "codex")
 
 
+class TestLoadConfigAgentDefaults(unittest.TestCase):
+
+    def _load(self, body: str) -> AppConfig:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(body)
+            return load_config(cwd=Path(cwd), home=Path(home))
+
+    def test_single_key_default_config(self):
+        cfg = self._load(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n'
+        )
+        self.assertEqual(cfg.agent_defaults, {"claude": {"model": "opus"}})
+
+    def test_multiple_keys_in_default_config(self):
+        cfg = self._load(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '        effort "max"\n'
+            '        strip-api-keys true\n'
+            '    }\n'
+            '}\n'
+        )
+        self.assertEqual(cfg.agent_defaults["claude"], {
+            "model": "opus", "effort": "max", "strip-api-keys": "true",
+        })
+
+    def test_blocks_for_multiple_agents(self):
+        cfg = self._load(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n'
+            'agent "codex" {\n'
+            '    default-config {\n'
+            '        sandbox "danger-full-access"\n'
+            '    }\n'
+            '}\n'
+        )
+        self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+        self.assertEqual(cfg.agent_defaults["codex"], {"sandbox": "danger-full-access"})
+
+    def test_empty_default_config_block_yields_empty_dict(self):
+        cfg = self._load(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '    }\n'
+            '}\n'
+        )
+        # Empty default-config contributes no keys; presence in
+        # agent_defaults implies at least one declared key.
+        self.assertNotIn("claude", cfg.agent_defaults)
+
+    def test_agent_block_without_default_config_is_ignored(self):
+        # Forward-compat: hooks etc. may live under `agent` in future
+        # tickets; an agent block with no `default-config` child parses
+        # without error and contributes no defaults.
+        cfg = self._load('agent "claude" {\n}\n')
+        self.assertNotIn("claude", cfg.agent_defaults)
+
+    def test_non_default_config_children_of_agent_are_ignored(self):
+        # Forward-compat: #30 will add `hooks {}` under `agent`. Unknown
+        # children parse as no-ops today.
+        cfg = self._load(
+            'agent "claude" {\n'
+            '    hooks {\n'
+            '        on-start "echo hi"\n'
+            '    }\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n'
+        )
+        self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -490,5 +490,97 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
         )
 
 
+class TestLoadConfigAgentDefaultsMerge(unittest.TestCase):
+
+    def _write(self, path: Path, body: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    def test_project_wins_on_same_key(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "sonnet"\n'
+                '    }\n'
+                '}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+
+    def test_distinct_keys_merge(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        effort "max"\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.agent_defaults["claude"], {
+                "model": "opus", "effort": "max",
+            })
+
+    def test_distinct_agents_in_user_and_project_both_survive(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "codex" {\n'
+                '    default-config {\n'
+                '        sandbox "danger-full-access"\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+            self.assertEqual(cfg.agent_defaults["codex"], {"sandbox": "danger-full-access"})
+
+    def test_templates_and_agent_defaults_coexist_in_same_file(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'template "qa" {\n'
+                '    agent "claude"\n'
+                '    prompt "you are qa"\n'
+                '}\n'
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.templates["qa"].agent, "claude")
+            self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ class TestLoadConfigEmpty(unittest.TestCase):
             cfg = load_config(cwd=Path(cwd), home=Path(home))
             self.assertIsInstance(cfg, AppConfig)
             self.assertEqual(cfg.templates, {})
+            self.assertEqual(cfg.agent_defaults, {})
 
     def test_missing_user_file_but_project_file_loads_project(self):
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
@@ -225,6 +226,15 @@ class TestLoadConfigParseStrict(unittest.TestCase):
         self._expect_error(
             'template "" {\n    agent "claude"\n}\n',
             "non-empty",
+        )
+
+    def test_unknown_agent_in_template_raises(self):
+        # Mirror the agent-block validator: a typo in template `agent`
+        # should also surface as ConfigError with the valid allowlist,
+        # not wait until `cmd_new` raises ActorError later.
+        self._expect_error(
+            'template "qa" {\n    agent "cluade"\n}\n',
+            "unknown agent 'cluade'",
         )
 
 
@@ -556,6 +566,31 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
             "nest config keys",
         )
 
+    def test_prompt_key_in_default_config_raises(self):
+        # `prompt` is a template-level field; silently allowing it under
+        # `default-config` would otherwise emit `--prompt <value>` as a
+        # CLI flag on every spawn — almost never the user's intent.
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        prompt "be brief"\n'
+            '    }\n'
+            '}\n',
+            "'prompt' is not a valid default-config key",
+        )
+
+    def test_agent_key_in_default_config_raises(self):
+        # Same reasoning: `agent` belongs at template level, not inside
+        # the block whose scope is already one agent.
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        agent "codex"\n'
+            '    }\n'
+            '}\n',
+            "'agent' is not a valid default-config key",
+        )
+
     def test_forward_compat_block_children_of_agent_still_silently_parse(self):
         # The key-with-value guard must not break forward-compat: a
         # block-style child (e.g. `hooks { … }` from #30) has no args
@@ -702,6 +737,26 @@ class TestLoadConfigAgentDefaultsMerge(unittest.TestCase):
             cfg = load_config(cwd=Path(cwd), home=Path(home))
             self.assertEqual(cfg.templates["qa"].agent, "claude")
             self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+
+
+class TestMergeInvariant(unittest.TestCase):
+    """`_merge` must preserve the parser invariant 'presence in
+    agent_defaults implies at least one declared key' even when callers
+    construct AppConfig programmatically."""
+
+    def test_merge_skips_empty_dict_from_over(self):
+        from actor.config import _merge
+        base = AppConfig()
+        over = AppConfig(agent_defaults={"claude": {}})
+        merged = _merge(base, over)
+        self.assertNotIn("claude", merged.agent_defaults)
+
+    def test_merge_skips_empty_dict_without_clobbering_existing(self):
+        from actor.config import _merge
+        base = AppConfig(agent_defaults={"claude": {"model": "opus"}})
+        over = AppConfig(agent_defaults={"claude": {}})
+        merged = _merge(base, over)
+        self.assertEqual(merged.agent_defaults["claude"], {"model": "opus"})
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -374,5 +374,121 @@ class TestLoadConfigAgentDefaults(unittest.TestCase):
         self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
 
 
+class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
+    """Parser should reject silently-dropped / ambiguous agent-block input."""
+
+    def _expect_error(self, kdl_text: str, needle: str) -> None:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(kdl_text)
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn(needle, str(ctx.exception))
+
+    def test_unknown_agent_name_raises(self):
+        self._expect_error(
+            'agent "gpt4" {\n    default-config {\n        model "x"\n    }\n}\n',
+            "gpt4",
+        )
+
+    def test_agent_block_without_name_raises(self):
+        self._expect_error(
+            'agent {\n    default-config {\n        model "x"\n    }\n}\n',
+            "name",
+        )
+
+    def test_empty_agent_name_raises(self):
+        self._expect_error(
+            'agent "" {\n    default-config {\n    }\n}\n',
+            "non-empty",
+        )
+
+    def test_non_string_agent_name_raises(self):
+        self._expect_error(
+            'agent 42 {\n    default-config {\n    }\n}\n',
+            "name",
+        )
+
+    def test_extra_positional_on_agent_raises(self):
+        self._expect_error(
+            'agent "claude" "extra" {\n    default-config {\n    }\n}\n',
+            "extra",
+        )
+
+    def test_props_on_agent_node_raises(self):
+        self._expect_error(
+            'agent "claude" flag="x" {\n    default-config {\n    }\n}\n',
+            "claude",
+        )
+
+    def test_duplicate_agent_block_in_file_raises(self):
+        self._expect_error(
+            'agent "claude" {\n    default-config {\n        model "opus"\n    }\n}\n'
+            'agent "claude" {\n    default-config {\n        model "sonnet"\n    }\n}\n',
+            "claude",
+        )
+
+    def test_multiple_default_config_blocks_in_one_agent_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n        model "opus"\n    }\n'
+            '    default-config {\n        model "sonnet"\n    }\n'
+            '}\n',
+            "default-config",
+        )
+
+    def test_duplicate_key_in_default_config_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '        model "sonnet"\n'
+            '    }\n'
+            '}\n',
+            "model",
+        )
+
+    def test_child_without_value_in_default_config_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model\n'
+            '    }\n'
+            '}\n',
+            "model",
+        )
+
+    def test_extra_args_on_default_config_child_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus" "sonnet"\n'
+            '    }\n'
+            '}\n',
+            "model",
+        )
+
+    def test_props_on_default_config_child_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model name="opus"\n'
+            '    }\n'
+            '}\n',
+            "model",
+        )
+
+    def test_positional_args_on_default_config_block_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config "oops" {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n',
+            "default-config",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -479,6 +479,22 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
             "model",
         )
 
+    def test_block_shaped_child_under_default_config_raises(self):
+        # `model { nested "x" }` has no positional args but does have
+        # children. The bare "needs a value" error would be misleading
+        # because the user *did* supply a value — just in the wrong
+        # shape.
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model {\n'
+            '            nested "x"\n'
+            '        }\n'
+            '    }\n'
+            '}\n',
+            "nested blocks are not supported inside `default-config`",
+        )
+
     def test_props_on_default_config_child_raises(self):
         self._expect_error(
             'agent "claude" {\n'
@@ -622,6 +638,19 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
         self._expect_error(
             'agent "claude" {\n'
             '    agent "codex"\n'
+            '}\n',
+            "put it on a `template` block",
+        )
+
+    def test_reserved_name_as_block_under_agent_points_to_template(self):
+        # Without an argless check, `prompt { something }` would fall
+        # into the forward-compat no-op branch and silently vanish.
+        # Reserved names must raise regardless of shape.
+        self._expect_error(
+            'agent "claude" {\n'
+            '    prompt {\n'
+            '        something "x"\n'
+            '    }\n'
             '}\n',
             "put it on a `template` block",
         )
@@ -803,6 +832,15 @@ class TestMergeInvariant(unittest.TestCase):
         over = AppConfig()
         merged = _merge(base, over)
         self.assertNotIn("claude", merged.agent_defaults)
+
+    def test_appconfig_post_init_strips_empty_agent_dicts(self):
+        # First line of defence: programmatic construction with an
+        # empty dict must not leave the parser invariant ("presence
+        # implies at least one key") violated, even if a caller never
+        # routes the value through `_merge`.
+        cfg = AppConfig(agent_defaults={"claude": {}, "codex": {"model": "gpt"}})
+        self.assertNotIn("claude", cfg.agent_defaults)
+        self.assertEqual(cfg.agent_defaults["codex"], {"model": "gpt"})
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -591,6 +591,41 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
             "'agent' is not a valid default-config key",
         )
 
+    def test_nested_default_config_raises_helpful_error(self):
+        # Without the dedicated branch, nesting `default-config` inside
+        # itself would fall through to the args check and emit
+        # "'default-config' needs a value", which tells the user nothing
+        # useful.
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        default-config {\n'
+            '            model "opus"\n'
+            '        }\n'
+            '    }\n'
+            '}\n',
+            "cannot be nested inside another `default-config`",
+        )
+
+    def test_prompt_directly_under_agent_points_to_template(self):
+        # The generic "nest config keys inside default-config" hint is
+        # actively wrong for `prompt` / `agent` — those names are
+        # rejected there too. Users need to be pointed at `template`.
+        self._expect_error(
+            'agent "claude" {\n'
+            '    prompt "be brief"\n'
+            '}\n',
+            "put it on a `template` block",
+        )
+
+    def test_agent_directly_under_agent_points_to_template(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    agent "codex"\n'
+            '}\n',
+            "put it on a `template` block",
+        )
+
     def test_forward_compat_block_children_of_agent_still_silently_parse(self):
         # The key-with-value guard must not break forward-compat: a
         # block-style child (e.g. `hooks { … }` from #30) has no args

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -486,7 +486,7 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
             '        model name="opus"\n'
             '    }\n'
             '}\n',
-            "model",
+            "does not accept properties",
         )
 
     def test_positional_args_on_default_config_block_raises(self):
@@ -757,6 +757,17 @@ class TestMergeInvariant(unittest.TestCase):
         over = AppConfig(agent_defaults={"claude": {}})
         merged = _merge(base, over)
         self.assertEqual(merged.agent_defaults["claude"], {"model": "opus"})
+
+    def test_merge_skips_empty_dict_from_base(self):
+        # Symmetric with `test_merge_skips_empty_dict_from_over`: an
+        # empty dict sitting in `base.agent_defaults` (e.g. a
+        # programmatically constructed AppConfig) should not leak into
+        # the merged result as a bare agent key with no configuration.
+        from actor.config import _merge
+        base = AppConfig(agent_defaults={"claude": {}})
+        over = AppConfig()
+        merged = _merge(base, over)
+        self.assertNotIn("claude", merged.agent_defaults)
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from actor.config import AppConfig, Template, load_config
+from actor.config import AppConfig, load_config
 from actor.errors import ConfigError
 
 
@@ -145,7 +145,7 @@ class TestLoadConfigParseShapes(unittest.TestCase):
             self.assertEqual(cfg.templates["x"].config["max-budget-usd"], "5")
 
     def test_unknown_top_level_nodes_are_ignored(self):
-        # Forward-compat: hooks/agent/alias exist in follow-up tickets but
+        # Forward-compat: hooks/alias belong to tickets #30 / #33 and
         # should parse as no-ops today rather than erroring.
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
             p = Path(cwd) / ".actor" / "settings.kdl"
@@ -340,7 +340,7 @@ class TestLoadConfigAgentDefaults(unittest.TestCase):
         self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
         self.assertEqual(cfg.agent_defaults["codex"], {"sandbox": "danger-full-access"})
 
-    def test_empty_default_config_block_yields_empty_dict(self):
+    def test_empty_default_config_block_omits_agent_from_defaults(self):
         cfg = self._load(
             'agent "claude" {\n'
             '    default-config {\n'
@@ -483,6 +483,27 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
         self._expect_error(
             'agent "claude" {\n'
             '    default-config "oops" {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n',
+            "default-config",
+        )
+
+    def test_props_on_default_config_block_raises(self):
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config flag="x" {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n',
+            "default-config",
+        )
+
+    def test_default_config_as_template_child_raises_helpful_error(self):
+        self._expect_error(
+            'template "qa" {\n'
+            '    agent "claude"\n'
+            '    default-config {\n'
             '        model "opus"\n'
             '    }\n'
             '}\n',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -526,6 +526,9 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
         )
 
     def test_default_config_as_template_child_raises_helpful_error(self):
+        # Needle is the redirect phrase, not just "default-config" — so
+        # a regression that swaps in "'default-config' needs a value"
+        # (the generic block-shape error) still fails this test.
         self._expect_error(
             'template "qa" {\n'
             '    agent "claude"\n'
@@ -533,7 +536,7 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
             '        model "opus"\n'
             '    }\n'
             '}\n',
-            "default-config",
+            "belong under",
         )
 
     def test_duplicate_agent_block_detected_even_if_first_is_empty(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -407,7 +407,7 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
     def test_non_string_agent_name_raises(self):
         self._expect_error(
             'agent 42 {\n    default-config {\n    }\n}\n',
-            "name",
+            "must be a string",
         )
 
     def test_extra_positional_on_agent_raises(self):
@@ -419,14 +419,14 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
     def test_props_on_agent_node_raises(self):
         self._expect_error(
             'agent "claude" flag="x" {\n    default-config {\n    }\n}\n',
-            "claude",
+            "does not accept properties",
         )
 
     def test_duplicate_agent_block_in_file_raises(self):
         self._expect_error(
             'agent "claude" {\n    default-config {\n        model "opus"\n    }\n}\n'
             'agent "claude" {\n    default-config {\n        model "sonnet"\n    }\n}\n',
-            "claude",
+            "duplicate agent block 'claude'",
         )
 
     def test_multiple_default_config_blocks_in_one_agent_raises(self):
@@ -510,6 +510,72 @@ class TestLoadConfigAgentDefaultsStrict(unittest.TestCase):
             "default-config",
         )
 
+    def test_duplicate_agent_block_detected_even_if_first_is_empty(self):
+        # Regression: the duplicate check used to key off
+        # `cfg.agent_defaults`, which skipped empty blocks. A first empty
+        # block would therefore let a second block pass unchecked.
+        self._expect_error(
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '    }\n'
+            '}\n'
+            'agent "claude" {\n'
+            '    default-config {\n'
+            '        model "opus"\n'
+            '    }\n'
+            '}\n',
+            "duplicate agent block 'claude'",
+        )
+
+    def test_duplicate_agent_block_detected_when_both_empty(self):
+        self._expect_error(
+            'agent "claude" {\n}\n'
+            'agent "claude" {\n}\n',
+            "duplicate agent block 'claude'",
+        )
+
+    def test_top_level_default_config_raises_helpful_error(self):
+        # A top-level `default-config {}` is almost always a misread of
+        # the schema. Without this check the keys would silently vanish
+        # into the forward-compat no-op bucket.
+        self._expect_error(
+            'default-config {\n'
+            '    model "opus"\n'
+            '}\n',
+            "top-level `default-config`",
+        )
+
+    def test_key_with_value_directly_under_agent_raises_helpful_error(self):
+        # User writing `model "opus"` directly under `agent "claude"`
+        # (forgetting the `default-config {}` wrapper) would otherwise
+        # see their config silently dropped.
+        self._expect_error(
+            'agent "claude" {\n'
+            '    model "opus"\n'
+            '}\n',
+            "nest config keys",
+        )
+
+    def test_forward_compat_block_children_of_agent_still_silently_parse(self):
+        # The key-with-value guard must not break forward-compat: a
+        # block-style child (e.g. `hooks { … }` from #30) has no args
+        # and should still be ignored as a no-op.
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'agent "claude" {\n'
+                '    hooks {\n'
+                '        on-start "echo hi"\n'
+                '    }\n'
+                '    default-config {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
+
 
 class TestLoadConfigAgentDefaultsMerge(unittest.TestCase):
 
@@ -582,6 +648,41 @@ class TestLoadConfigAgentDefaultsMerge(unittest.TestCase):
             cfg = load_config(cwd=Path(cwd), home=Path(home))
             self.assertEqual(cfg.agent_defaults["claude"], {"model": "opus"})
             self.assertEqual(cfg.agent_defaults["codex"], {"sandbox": "danger-full-access"})
+
+    def test_asymmetric_mix_user_has_two_agents_project_only_one(self):
+        # User defines both claude + codex; project only touches claude.
+        # Expect: claude per-key merges (project wins), codex passes
+        # through unchanged.
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "opus"\n'
+                '        effort "max"\n'
+                '    }\n'
+                '}\n'
+                'agent "codex" {\n'
+                '    default-config {\n'
+                '        sandbox "danger-full-access"\n'
+                '    }\n'
+                '}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    default-config {\n'
+                '        model "sonnet"\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(cfg.agent_defaults["claude"], {
+                "model": "sonnet", "effort": "max",
+            })
+            self.assertEqual(cfg.agent_defaults["codex"], {
+                "sandbox": "danger-full-access",
+            })
 
     def test_templates_and_agent_defaults_coexist_in_same_file(self):
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:


### PR DESCRIPTION
## Summary

- Adds per-agent `default-config` blocks in `~/.actor/settings.kdl` and `<repo>/.actor/settings.kdl` — e.g. `agent "claude" { default-config { model "opus" } }`.
- Applies those defaults as the lowest layer at `actor new`, underneath `--template` and explicit `--config` flags (precedence: per-agent defaults → template → CLI `--config`).
- Merges user-wide and project-local agent defaults per key, with project winning on conflicts; the resolved merge is snapshotted into the DB at creation time.

## Test plan

- [x] `uv run python -m unittest discover tests` (387 tests, all green)
- [x] Parser rejects unknown agents, malformed blocks, duplicate agent blocks, block-shaped children, and `default-config` misplaced inside a `template` — each with a message that points to the fix.
- [x] `AppConfig.__post_init__` strips empty agent dicts so `agent_defaults` keys always map to non-empty configs.
- [x] MCP `new_actor` forwards `AppConfig` loaded from the requested `dir`.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)