### PR TITLE
Per-agent defaults (redesign) (#31)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,76 @@ prompt / stdin) override the template. `agent` and `prompt` are promoted to
 top-level fields; every other child is stored as a config key (values
 coerced to strings).
 
-Unknown top-level nodes (e.g. `hooks`, `agent`, `alias`) are silently
-ignored for forward-compat with follow-up tickets.
+### Per-agent defaults
+
+`agent "claude" { … }` / `agent "codex" { … }` blocks set defaults that
+apply to every actor of that kind:
+
+```kdl
+agent "claude" {
+    use-subscription true
+    defaults {
+        permission-mode "auto"
+        model "opus"
+    }
+}
+
+agent "codex" {
+    defaults {
+        m "o3"
+        sandbox "workspace-write"
+    }
+}
+```
+
+Two shapes live inside an `agent` block:
+
+- **Flat keys** (e.g. `use-subscription`) are actor-sh interpreted —
+  they're never forwarded to the agent binary. The whitelist of allowed
+  flat keys per agent is `ACTOR_DEFAULTS` on the Agent subclass (currently
+  just `use-subscription` for both agents). Unknown flat keys raise
+  `ConfigError`.
+- **`defaults { }` children** become CLI flags on the agent binary.
+  Claude uses semantic long flags: `permission-mode "auto"` →
+  `--permission-mode auto`. Codex uses native flag names verbatim:
+  1-character keys become short flags (`m "o3"` → `-m o3`, `a "never"`
+  → `-a never`), longer keys become long flags (`sandbox
+  "workspace-write"` → `--sandbox workspace-write`).
+
+A `null` value cancels a lower-precedence default:
+
+```kdl
+agent "claude" {
+    defaults {
+        permission-mode null   # drop the built-in "auto" default
+    }
+}
+```
+
+Merge precedence at actor creation (`actor new`), lowest → highest:
+class `AGENT_DEFAULTS` + `ACTOR_DEFAULTS` (hardcoded on the Agent
+subclass) → user kdl `agent` block → project kdl `agent` block →
+template config (`--template`) → CLI `--config key=value`. The resolved
+merge is snapshotted into the DB at creation; later edits to
+`settings.kdl` don't retroactively change existing actors — use `actor
+config <name> key=value` to mutate an actor's stored config. At run
+time (`actor run`), the stored config is the base and per-run
+`--config` arguments layer on top for that run only. `null` at a higher
+layer cancels lower defaults; the emitter drops keys whose final value
+is `None`.
+
+Built-in class defaults today:
+
+- `ClaudeAgent.AGENT_DEFAULTS = {"permission-mode": "auto"}` and
+  `ClaudeAgent.ACTOR_DEFAULTS = {"use-subscription": "true"}`.
+- `CodexAgent.AGENT_DEFAULTS = {"sandbox": "danger-full-access", "a":
+  "never"}` and `CodexAgent.ACTOR_DEFAULTS = {"use-subscription":
+  "true"}`.
+
+Unknown top-level nodes (e.g. `hooks`, `alias`) are silently ignored
+for forward-compat with follow-up tickets. A `defaults { ... }` block
+inside a template is rejected with a helpful error pointing users at
+the per-agent `agent "..." { defaults { ... } }` shape.
 
 Load programmatically via `actor.config.load_config(cwd=..., home=...)` —
 both args default to `Path.cwd()` / `$HOME` so tests can inject temp dirs.

--- a/spec/PLAN-AGENT-DEFAULTS-REDESIGN.md
+++ b/spec/PLAN-AGENT-DEFAULTS-REDESIGN.md
@@ -1,0 +1,898 @@
+# Per-agent defaults (redesign) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `strip-api-keys`/`default-config`/compound-bypass flags with a uniform per-agent defaults system: flat actor-keys + a `defaults { }` sub-block, hardcoded in agent classes, configurable per-user/project/template/CLI with `null` cancelling lower layers. Claude's default `permission-mode` moves to `"auto"`; Codex's compound bypass flag is replaced with explicit sandbox+approval.
+
+**Architecture:** Agent subclasses expose two class-level dicts — `ACTOR_DEFAULTS` (flat keys, env-filtering only) and `AGENT_DEFAULTS` (keys under `defaults { }`, emitted as CLI flags). Two methods on every agent: `emit_agent_args(defaults)` → `List[str]` and `apply_actor_keys(flat, env)` → `dict`. KDL layer adds `AgentDefaults {actor_keys, agent_args}` plus `AppConfig.agent_defaults: Dict[agent, AgentDefaults]`. Merge precedence (low→high): class defaults → user kdl → project kdl → template → CLI. `null` value at any merged layer pops the key from the merged dict, so the emitter skips it.
+
+**Tech Stack:** Python 3.10+, `kdl-py` (already a dep), `unittest`, no new runtime deps.
+
+---
+
+## Scope guardrails
+
+- Rename `strip-api-keys` → `use-subscription` (same polarity: true = strip env key).
+- Rename `default-config` → `defaults`.
+- No back-compat — no aliases, no deprecation shim. Tests with old names get rewritten.
+- No settings.kdl shipped at install time. Built-in defaults live in agent-class constants.
+- Stay strictly inside this spec. Hooks (#30) and aliases (#33) stay forward-compat no-ops in the parser (no tests for them).
+
+---
+
+## Built-in defaults (baseline everything else merges over)
+
+```kdl
+agent "claude" {
+    use-subscription true
+    defaults {
+        permission-mode "auto"
+    }
+}
+
+agent "codex" {
+    use-subscription true
+    defaults {
+        sandbox "danger-full-access"
+        a "never"
+    }
+}
+```
+
+Emitter maps:
+- **Claude:** `permission-mode "auto"` → `--permission-mode auto`.
+- **Codex:** `sandbox "danger-full-access"` → `--sandbox danger-full-access`; `a "never"` → `-a never`.
+
+---
+
+## File Structure
+
+- `src/actor/interfaces.py` — add `Agent.AGENT_DEFAULTS`, `ACTOR_DEFAULTS`, `emit_agent_args`, `apply_actor_keys`. Type `DefaultsConfig = Dict[str, Optional[str]]`.
+- `src/actor/agents/claude.py` — fill the two dicts + implement the two methods; remove `_INTERNAL_KEYS` / `_permission_args` / `_config_args`; delete bypass rewrite.
+- `src/actor/agents/codex.py` — same shape; drop compound bypass; `--sandbox` and `-a` come straight from `AGENT_DEFAULTS`.
+- `src/actor/config.py` — add `AgentDefaults` dataclass + `AppConfig.agent_defaults`; parse `agent "claude|codex" { … defaults { … } }`; handle KDL `null`; per-key merge across user+project; reject unknown flat keys against the agent's `ACTOR_DEFAULTS` whitelist; reject `defaults { … }` at template level with helpful redirect.
+- `src/actor/commands.py` — in `cmd_new`, resolve effective config: class defaults → kdl (user+project merged by `load_config`) → template → CLI `--config`. `null` handling happens during merge, so stored actor `config` is `Dict[str, str]`.
+- `src/actor/cli.py` — rename `--strip-api-keys` / `--no-strip-api-keys` → `--use-subscription` / `--no-use-subscription`.
+- `src/actor/__init__.py` — re-export any new public helpers; drop exports that go away.
+- `src/actor/_skill/SKILL.md`, `_skill/claude-config.md`, `_skill/codex-config.md` — document flat vs defaults, null, Codex flag-name asymmetry, new defaults.
+- `CLAUDE.md` — same update in the config-files section.
+- `tests/test_actor.py` — rewrite `test_config_args_*` around new emitter name; remove `_INTERNAL_KEYS` assumptions.
+- `tests/test_config.py` — replace `strip-api-keys` sample with `use-subscription`; add tests for `agent … defaults { }`, null-cancel, unknown-flat-key rejection.
+- `tests/test_cli_and_mcp.py` — rename `--strip-api-keys` tests to `--use-subscription`; assert new emitter's flag shape.
+
+No new files. No splits. Every edit is scoped to a file that already exists.
+
+---
+
+## Precedence & emitter invariants (single source of truth)
+
+1. Each layer (class defaults, user kdl, project kdl, template, CLI) contributes a `Dict[str, Optional[str]]` for the agent-args bucket and a `Dict[str, Optional[str]]` for the actor-keys bucket.
+2. `merge(low, high)` = `{k: v for k, v in {**low, **high}.items() if v is not None}` (None from the higher layer pops the key out of the merged result).
+3. After final merge the dicts are `Dict[str, str]`.
+4. Emitter — Claude: `--{key}` + (value if non-empty else nothing). Codex: `-{k}` for `len(key) == 1`, `--{key}` otherwise, then the value if non-empty.
+5. Both agents use the SAME emitter body — only the dash-prefix rule differs. Factor a helper.
+6. Actor-keys — Claude interprets `use-subscription` as env filter for `ANTHROPIC_API_KEY`. Codex interprets `use-subscription` as env filter for `OPENAI_API_KEY`. That's the only actor key today; `ACTOR_DEFAULTS` is the whitelist.
+
+---
+
+## Task 1 — Rename `strip-api-keys` → `use-subscription` (CLI, tests, skill text)
+
+**Files:**
+- Modify: `src/actor/cli.py` (flag + help + epilog)
+- Modify: `src/actor/agents/claude.py` (ACTOR_DEFAULTS placeholder still to come in Task 3 — for now just rename the string)
+- Modify: `src/actor/agents/codex.py` (same)
+- Modify: `src/actor/_skill/SKILL.md`, `_skill/cli.md`, `_skill/claude-config.md`, `_skill/codex-config.md`
+- Modify: `CLAUDE.md`
+- Modify: `tests/test_config.py`
+- Modify: `tests/test_cli_and_mcp.py`
+- Test: `tests/test_config.py::TestLoadConfigParseShapes::test_bool_value_coerced_to_string`
+
+- [ ] **Step 1.1: Update failing test for template bool coercion**
+
+Edit `tests/test_config.py` lines that use `strip-api-keys` — replace with `use-subscription`:
+
+```python
+def test_bool_value_coerced_to_string(self):
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+        p = Path(cwd) / ".actor" / "settings.kdl"
+        p.parent.mkdir()
+        p.write_text('template "x" {\n    use-subscription true\n}\n')
+        cfg = load_config(cwd=Path(cwd), home=Path(home))
+        self.assertEqual(cfg.templates["x"].config["use-subscription"], "true")
+```
+
+- [ ] **Step 1.2: Update CLI tests for new flag names**
+
+Edit `tests/test_cli_and_mcp.py`: `--no-strip-api-keys` → `--no-use-subscription`; `--strip-api-keys` → `--use-subscription`; `strip-api-keys=…` config pair → `use-subscription=…`.
+
+- [ ] **Step 1.3: Run tests — expect FAIL (old CLI flag still in cli.py)**
+
+```bash
+uv run python -m unittest discover tests 2>&1 | tail -20
+```
+Expected: failures in test_cli_and_mcp (flag not recognized) and test_actor (`strip` in config default).
+
+- [ ] **Step 1.4: Rename CLI flag + help**
+
+Edit `src/actor/cli.py` around the `--strip-api-keys` argparse block — swap name to `--use-subscription` / `--no-use-subscription`, `dest="use_subscription"`, and update the example epilog line. Update the post-parse block that builds `config_pairs`.
+
+- [ ] **Step 1.5: Rename inside agent code**
+
+Edit `src/actor/agents/claude.py` line 23 and 47 — `strip-api-keys` → `use-subscription`. Same for codex.py line 32 and 71.
+
+- [ ] **Step 1.6: Update docs**
+
+Edit `_skill/SKILL.md` (lines referencing `strip-api-keys`), `_skill/cli.md` (line 38), `_skill/claude-config.md`, `_skill/codex-config.md`, `CLAUDE.md`. Global replace in these files (verify by grep before + after).
+
+- [ ] **Step 1.7: Run tests — expect PASS**
+
+```bash
+uv run python -m unittest discover tests 2>&1 | tail -10
+```
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add -A
+git commit -m "Rename strip-api-keys to use-subscription (#31)"
+```
+
+---
+
+## Task 2 — Uniform `Agent` interface: `AGENT_DEFAULTS` / `ACTOR_DEFAULTS` / `emit_agent_args` / `apply_actor_keys`
+
+**Files:**
+- Modify: `src/actor/interfaces.py`
+- Modify: `src/actor/agents/claude.py`
+- Modify: `src/actor/agents/codex.py`
+- Modify: `src/actor/commands.py` (public wrappers `claude_config_args`, `codex_config_args`)
+- Modify: `src/actor/__init__.py` (exports)
+- Test: `tests/test_actor.py` (TestClaudeAgent / TestCodexAgent sections)
+
+Implementation invariants from the spec reiterated here so the task is self-contained:
+- `AGENT_DEFAULTS` / `ACTOR_DEFAULTS`: `Dict[str, Optional[str]]`, class-level, built-in baseline.
+- `emit_agent_args(defaults: Dict[str, str]) -> List[str]`: straight flag mapping. Skips `None` (defensive even though resolver should have dropped them), emits bare flag for empty string, `--key value` or `-k value` otherwise. Keys sorted for deterministic output.
+- `apply_actor_keys(flat: Dict[str, str], env: Dict[str, str]) -> Dict[str, str]`: returns a NEW env dict.
+
+- [ ] **Step 2.1: Write failing test for Claude emitter**
+
+Add to `tests/test_actor.py::TestClaudeAgent`:
+
+```python
+def test_emit_agent_args_basic(self):
+    from actor.agents.claude import ClaudeAgent
+    a = ClaudeAgent()
+    args = a.emit_agent_args({"model": "sonnet", "permission-mode": "auto"})
+    self.assertEqual(args, ["--model", "sonnet", "--permission-mode", "auto"])
+
+def test_emit_agent_args_empty_string_is_bare_flag(self):
+    from actor.agents.claude import ClaudeAgent
+    a = ClaudeAgent()
+    self.assertEqual(a.emit_agent_args({"verbose": ""}), ["--verbose"])
+
+def test_apply_actor_keys_strips_anthropic_key(self):
+    from actor.agents.claude import ClaudeAgent
+    a = ClaudeAgent()
+    env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "secret"}
+    out = a.apply_actor_keys({"use-subscription": "true"}, env)
+    self.assertNotIn("ANTHROPIC_API_KEY", out)
+    self.assertEqual(out["PATH"], "/bin")
+
+def test_apply_actor_keys_keeps_anthropic_key_when_false(self):
+    from actor.agents.claude import ClaudeAgent
+    a = ClaudeAgent()
+    env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "secret"}
+    out = a.apply_actor_keys({"use-subscription": "false"}, env)
+    self.assertEqual(out["ANTHROPIC_API_KEY"], "secret")
+```
+
+Also replace the old `test_config_args_builds_flags` with a failing assertion that exercises `emit_agent_args` — or rather delete the old test since the public wrapper is replaced by the method.
+
+- [ ] **Step 2.2: Write failing test for Codex emitter**
+
+Add to `tests/test_actor.py::TestCodexAgent`:
+
+```python
+def test_emit_agent_args_short_and_long(self):
+    from actor.agents.codex import CodexAgent
+    c = CodexAgent()
+    args = c.emit_agent_args({"m": "o3", "sandbox": "danger-full-access", "a": "never"})
+    # Sorted: a < m < sandbox
+    self.assertEqual(args, ["-a", "never", "-m", "o3", "--sandbox", "danger-full-access"])
+
+def test_apply_actor_keys_strips_openai_key(self):
+    from actor.agents.codex import CodexAgent
+    c = CodexAgent()
+    env = {"OPENAI_API_KEY": "x"}
+    out = c.apply_actor_keys({"use-subscription": "true"}, env)
+    self.assertNotIn("OPENAI_API_KEY", out)
+```
+
+Replace old `test_config_args_*` tests for Codex.
+
+- [ ] **Step 2.3: Run tests — expect FAIL**
+
+```bash
+uv run python -m unittest discover tests 2>&1 | tail
+```
+
+- [ ] **Step 2.4: Implement the ABCs**
+
+Edit `src/actor/interfaces.py`: inside `class Agent(abc.ABC):` add:
+
+```python
+# Per-agent defaults split. Subclasses fill these in.
+# Keys in ACTOR_DEFAULTS are interpreted by actor-sh (env filtering etc.)
+# and are NEVER passed to the agent binary. Keys in AGENT_DEFAULTS go
+# under `defaults { }` in settings.kdl and map straight to CLI flags.
+AGENT_DEFAULTS: "Dict[str, Optional[str]]" = {}
+ACTOR_DEFAULTS: "Dict[str, Optional[str]]" = {}
+
+@abc.abstractmethod
+def emit_agent_args(self, defaults: "Config") -> List[str]:
+    """Turn the resolved `defaults { }` dict into CLI flags."""
+
+@abc.abstractmethod
+def apply_actor_keys(self, flat: "Config", env: Dict[str, str]) -> Dict[str, str]:
+    """Return a NEW env dict with actor-key side effects applied (e.g. stripping API keys)."""
+```
+
+Add imports: `from typing import Dict, List, Optional`.
+
+- [ ] **Step 2.5: Implement Claude side**
+
+Edit `src/actor/agents/claude.py`:
+
+```python
+class ClaudeAgent(Agent):
+    AGENT_DEFAULTS: Dict[str, Optional[str]] = {
+        "permission-mode": "auto",
+    }
+    ACTOR_DEFAULTS: Dict[str, Optional[str]] = {
+        "use-subscription": "true",
+    }
+
+    def emit_agent_args(self, defaults: Config) -> List[str]:
+        args: List[str] = []
+        for key, value in sorted(defaults.items()):
+            if value is None:
+                continue
+            args.append(f"--{key}")
+            if value != "":
+                args.append(value)
+        return args
+
+    def apply_actor_keys(self, flat: Config, env: Dict[str, str]) -> Dict[str, str]:
+        out = dict(env)
+        if flat.get("use-subscription", "true") != "false":
+            out.pop("ANTHROPIC_API_KEY", None)
+        return out
+```
+
+Delete `_INTERNAL_KEYS`, `_permission_args`, `_config_args`. Update `_spawn_and_track` to call `apply_actor_keys(config, os.environ)` instead of the inline strip. Update `start`, `resume`, `interactive_argv` to use `emit_agent_args(agent_args)` instead of `_permission_args + _config_args` — see Task 4 for the split of `config` into actor vs agent buckets.
+
+- [ ] **Step 2.6: Implement Codex side**
+
+Edit `src/actor/agents/codex.py`:
+
+```python
+class CodexAgent(Agent):
+    AGENT_DEFAULTS: Dict[str, Optional[str]] = {
+        "sandbox": "danger-full-access",
+        "a": "never",
+    }
+    ACTOR_DEFAULTS: Dict[str, Optional[str]] = {
+        "use-subscription": "true",
+    }
+
+    def emit_agent_args(self, defaults: Config) -> List[str]:
+        args: List[str] = []
+        for key, value in sorted(defaults.items()):
+            if value is None:
+                continue
+            prefix = "-" if len(key) == 1 else "--"
+            args.append(f"{prefix}{key}")
+            if value != "":
+                args.append(value)
+        return args
+
+    def apply_actor_keys(self, flat: Config, env: Dict[str, str]) -> Dict[str, str]:
+        out = dict(env)
+        if flat.get("use-subscription", "true") != "false":
+            out.pop("OPENAI_API_KEY", None)
+        return out
+```
+
+Delete `_INTERNAL_KEYS`, `_permission_args`, `_config_args`. Update `_spawn_and_capture` to use `apply_actor_keys`, and `start/resume/interactive_argv` to use `emit_agent_args`.
+
+NOTE: The split "which keys are actor-keys vs agent-args" lives in Task 4. For this task, write the methods assuming the caller has already split — and update `start/resume/interactive_argv` to use a temporary helper `_split_config(config)` that partitions by `ACTOR_DEFAULTS.keys()`.
+
+- [ ] **Step 2.7: Update public wrappers + exports**
+
+Remove `claude_config_args` and `codex_config_args` from `src/actor/commands.py` and `src/actor/__init__.py` `__all__`. They expose the old shape.
+
+- [ ] **Step 2.8: Run tests — expect PASS**
+
+```bash
+uv run python -m unittest discover tests 2>&1 | tail -10
+```
+
+- [ ] **Step 2.9: Commit**
+
+```bash
+git add -A
+git commit -m "Agent.AGENT_DEFAULTS/ACTOR_DEFAULTS + emit_agent_args/apply_actor_keys (#31)"
+```
+
+---
+
+## Task 3 — New defaults + behavior changes
+
+**Files:**
+- Modify: `src/actor/agents/claude.py`
+- Modify: `src/actor/agents/codex.py`
+- Test: `tests/test_actor.py::TestClaudeAgent::test_permission_mode_default_is_auto`
+- Test: `tests/test_actor.py::TestClaudeAgent::test_bypass_permissions_emits_straight`
+- Test: `tests/test_actor.py::TestCodexAgent::test_default_emits_explicit_sandbox_and_approval`
+
+- [ ] **Step 3.1: Write failing tests**
+
+```python
+# In TestClaudeAgent:
+def test_permission_mode_default_is_auto(self):
+    from actor.agents.claude import ClaudeAgent
+    self.assertEqual(ClaudeAgent.AGENT_DEFAULTS.get("permission-mode"), "auto")
+
+def test_bypass_permissions_emits_straight(self):
+    from actor.agents.claude import ClaudeAgent
+    a = ClaudeAgent()
+    args = a.emit_agent_args({"permission-mode": "bypassPermissions"})
+    self.assertEqual(args, ["--permission-mode", "bypassPermissions"])
+
+# In TestCodexAgent:
+def test_default_emits_explicit_sandbox_and_approval(self):
+    from actor.agents.codex import CodexAgent
+    self.assertEqual(
+        CodexAgent.AGENT_DEFAULTS,
+        {"sandbox": "danger-full-access", "a": "never"},
+    )
+```
+
+- [ ] **Step 3.2: Run tests — should pass if Task 2 was done right**
+
+Task 2 already sets the constants correctly and removes the rewrite.  If any of the three fail, fix in the spec shape (not add back a rewrite).
+
+- [ ] **Step 3.3: Manual smoke test against real CLIs**
+
+```bash
+# Both must exit 0 or show usage — we're checking the flag set is accepted.
+claude --permission-mode auto -p --help >/dev/null 2>&1 && echo "claude OK" || echo "claude FAIL"
+codex exec --sandbox danger-full-access -a never --help >/dev/null 2>&1 && echo "codex OK" || echo "codex FAIL"
+```
+
+If the binaries aren't available locally, note the skipped smoke test in the commit body; CI has them.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add -A
+git commit -m "Claude default permission-mode=auto; Codex explicit sandbox+approval (#31)"
+```
+
+---
+
+## Task 4 — Split `config` into actor-keys vs agent-args at the call site
+
+**Files:**
+- Modify: `src/actor/agents/claude.py` — `start`, `resume`, `interactive_argv`, `_spawn_and_track`
+- Modify: `src/actor/agents/codex.py` — `start`, `resume`, `interactive_argv`, `_spawn_and_capture`
+- Test: `tests/test_actor.py` — a small test that `start`'s argv contains `--permission-mode auto` when `config={"permission-mode": "auto"}` and does NOT contain `--use-subscription` (because it's an actor key).
+
+- [ ] **Step 4.1: Add `_split_config` helper on Agent base class**
+
+In `src/actor/interfaces.py`:
+
+```python
+def _split_config(self, config: "Config") -> tuple["Config", "Config"]:
+    """Partition a flat config dict into (actor_keys, agent_args)."""
+    actor_keys = {k: v for k, v in config.items() if k in self.ACTOR_DEFAULTS}
+    agent_args = {k: v for k, v in config.items() if k not in self.ACTOR_DEFAULTS}
+    return actor_keys, agent_args
+```
+
+- [ ] **Step 4.2: Update ClaudeAgent.start/resume/interactive_argv + _spawn_and_track**
+
+```python
+def _spawn_and_track(self, args, cwd, config):
+    actor_keys, _ = self._split_config(config)
+    env = self.apply_actor_keys(actor_keys, os.environ)
+    proc = subprocess.Popen(args, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT, cwd=str(cwd), env=env)
+    ...
+
+def start(self, dir, prompt, config):
+    _, agent_args = self._split_config(config)
+    session_id = str(uuid.uuid4())
+    args = ["claude", *self._CHANNEL_ARGS, "-p", "--session-id", session_id,
+            *self.emit_agent_args(agent_args), "--", prompt]
+    pid = self._spawn_and_track(args, dir, config)
+    return pid, session_id
+```
+
+Do the same shape in `resume` and `interactive_argv`. Remove the old `_permission_args` / `_config_args` call sites.
+
+- [ ] **Step 4.3: Update CodexAgent equivalents (same pattern)**
+
+- [ ] **Step 4.4: Write test asserting argv flag presence**
+
+Hard to test argv directly without stubbing Popen. Skip end-to-end assertion; rely on `emit_agent_args` tests + manual smoke test in Task 3. Move on.
+
+- [ ] **Step 4.5: Run tests**
+
+```bash
+uv run python -m unittest discover tests 2>&1 | tail -10
+```
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add -A
+git commit -m "Split config into actor_keys/agent_args at agent call sites (#31)"
+```
+
+---
+
+## Task 5 — KDL parser: `agent "X" { flat… defaults { … } }` with null support
+
+**Files:**
+- Modify: `src/actor/config.py`
+- Test: `tests/test_config.py`
+
+- [ ] **Step 5.1: Write failing tests**
+
+```python
+class TestLoadConfigAgentBlocks(unittest.TestCase):
+    def _write_kdl(self, path, body):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    def test_agent_defaults_parsed(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write_kdl(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    use-subscription false\n'
+                '    defaults {\n'
+                '        permission-mode "bypassPermissions"\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            d = cfg.agent_defaults["claude"]
+            self.assertEqual(d.actor_keys, {"use-subscription": "false"})
+            self.assertEqual(d.agent_args, {"permission-mode": "bypassPermissions", "model": "opus"})
+
+    def test_null_in_defaults_represented_as_none(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write_kdl(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    defaults {\n'
+                '        permission-mode #null\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            d = cfg.agent_defaults["claude"]
+            self.assertIn("permission-mode", d.agent_args)
+            self.assertIsNone(d.agent_args["permission-mode"])
+
+    def test_unknown_agent_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text('agent "bogus" { defaults { x 1 } }\n')
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("bogus", str(ctx.exception))
+
+    def test_unknown_flat_key_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text('agent "claude" { not-a-real-flat-key "x" }\n')
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("not-a-real-flat-key", str(ctx.exception))
+
+    def test_project_agent_defaults_override_user_per_key(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write_kdl(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    defaults {\n'
+                '        model "sonnet"\n'
+                '        permission-mode "auto"\n'
+                '    }\n'
+                '}\n',
+            )
+            self._write_kdl(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    defaults {\n'
+                '        permission-mode #null\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            d = cfg.agent_defaults["claude"]
+            self.assertEqual(d.agent_args.get("model"), "sonnet")
+            self.assertNotIn("permission-mode", d.agent_args)
+
+    def test_defaults_block_at_template_level_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text('template "qa" { defaults { model "opus" } }\n')
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("belong under", str(ctx.exception))
+```
+
+- [ ] **Step 5.2: Run tests — expect FAIL**
+
+```bash
+uv run python -m unittest discover tests.test_config 2>&1 | tail -15
+```
+
+- [ ] **Step 5.3: Implement `AgentDefaults` + parser**
+
+Edit `src/actor/config.py`:
+
+```python
+from typing import Dict, Optional, Tuple
+
+_VALID_AGENTS = ("claude", "codex")
+
+@dataclass
+class AgentDefaults:
+    actor_keys: Dict[str, Optional[str]] = field(default_factory=dict)
+    agent_args: Dict[str, Optional[str]] = field(default_factory=dict)
+
+@dataclass
+class AppConfig:
+    templates: Dict[str, Template] = field(default_factory=dict)
+    agent_defaults: Dict[str, AgentDefaults] = field(default_factory=dict)
+```
+
+Add helper `_coerce_value_or_none(raw)` that returns `None` for the kdl `null` literal (kdl-py yields Python `None` already) and otherwise delegates to `_coerce_value`. Handle null before the type check.
+
+Add `_parse_agent_block(node, source) -> (agent_name, AgentDefaults)` that:
+- Requires `len(node.args) == 1` and `node.args[0] in _VALID_AGENTS`.
+- Iterates children — `defaults` child (no args) handled specially; its nested children become `agent_args` (nulls preserved as None). All other children are flat keys and go into `actor_keys`.
+- If a flat child has no args → ConfigError (same message shape as templates).
+- Reject nested `defaults` inside `defaults` with a helpful message.
+- Reject a `defaults "x"` with positional args (forbid second-arg form per spec).
+
+Update `_parse_kdl_file` top-level dispatch:
+- `"template"` → `_parse_template`
+- `"agent"` → `_parse_agent_block`; duplicate agent names raise ConfigError.
+- Anything else (`hooks`, `alias`, etc.) — still silently ignored per the forward-compat rule.
+
+Update `_parse_template`:
+- If a child key is `"defaults"` and it's a block (no args, has nodes), raise with "`defaults { ... }` blocks belong under `agent \"claude\" { … }` / `agent \"codex\" { … }`, not inside a template". Keep the existing checks after.
+
+Update `_merge`:
+
+```python
+def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
+    merged_templates = {**base.templates, **over.templates}
+    merged_defaults: Dict[str, AgentDefaults] = {}
+    for agent in set(base.agent_defaults) | set(over.agent_defaults):
+        b = base.agent_defaults.get(agent, AgentDefaults())
+        o = over.agent_defaults.get(agent, AgentDefaults())
+        merged_defaults[agent] = AgentDefaults(
+            actor_keys=_merge_dict(b.actor_keys, o.actor_keys),
+            agent_args=_merge_dict(b.agent_args, o.agent_args),
+        )
+    # Drop empty AgentDefaults so tests can assert `"claude" not in cfg.agent_defaults`.
+    merged_defaults = {
+        k: v for k, v in merged_defaults.items()
+        if v.actor_keys or v.agent_args
+    }
+    return AppConfig(templates=merged_templates, agent_defaults=merged_defaults)
+
+def _merge_dict(
+    low: Dict[str, Optional[str]], high: Dict[str, Optional[str]]
+) -> Dict[str, Optional[str]]:
+    out: Dict[str, Optional[str]] = {}
+    for k, v in low.items():
+        if v is not None:
+            out[k] = v
+    for k, v in high.items():
+        if v is None:
+            out.pop(k, None)
+        else:
+            out[k] = v
+    return out
+```
+
+Note: the parser layer preserves None values inside a single file (so the test `test_null_in_defaults_represented_as_none` can read them back). `_merge_dict` is what actually cancels. At final load time after all merges, surviving Nones are filtered out — or we can document that the parser-level AgentDefaults retains Nones and only the merged result is None-free. Simpler: `_merge_dict` drops Nones as it merges. If only one file is loaded, no merge happens — the parser-retained Nones propagate to the caller. Adjust the `_parse_single` layer to leave Nones, and add a final pass in `load_config` that calls `_merge_dict(AgentDefaults(), parsed)` on the single-file path so None-stripping is uniform.
+
+Actually simpler: `load_config` always calls `_merge` (with an empty `AppConfig` as base), so all surviving Nones get dropped on the way out. The per-file parser can hold Nones, but they never leak to callers of `load_config`. Tests for the "null parsed as None" case need to inspect AT the parser level (call `_parse_kdl_file` directly) — update test accordingly.
+
+Revised test for null:
+
+```python
+def test_null_in_defaults_is_stripped_by_merge(self):
+    # Null cancels the key in the merged result. Starting from an empty
+    # base, null at top level is equivalent to omitting the key.
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+        self._write_kdl(
+            Path(cwd) / ".actor" / "settings.kdl",
+            'agent "claude" {\n'
+            '    defaults {\n'
+            '        permission-mode #null\n'
+            '    }\n'
+            '}\n',
+        )
+        cfg = load_config(cwd=Path(cwd), home=Path(home))
+        self.assertNotIn("claude", cfg.agent_defaults)
+```
+
+Replace step 5.1's `test_null_in_defaults_represented_as_none` with this.
+
+- [ ] **Step 5.4: Run tests — expect PASS**
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add -A
+git commit -m "Parse agent \"X\" { flat; defaults { ... } } with null-cancel semantics (#31)"
+```
+
+---
+
+## Task 6 — Wire per-agent defaults into `cmd_new`
+
+**Files:**
+- Modify: `src/actor/commands.py` (`cmd_new`)
+- Test: `tests/test_actor.py::TestCmdNewTemplates` — add precedence tests
+
+- [ ] **Step 6.1: Write failing test for precedence ladder**
+
+```python
+class TestCmdNewAgentDefaults(unittest.TestCase):
+    def test_agent_defaults_applied_as_lowest_layer(self):
+        # AGENT_DEFAULTS baseline + kdl + template + CLI, in precedence order.
+        from actor import AppConfig, Template
+        from actor.config import AgentDefaults
+
+        db, _, git, pm = _fresh_db_and_fakes()
+        app = AppConfig(
+            templates={"qa": Template(name="qa", config={"permission-mode": "plan"})},
+            agent_defaults={
+                "claude": AgentDefaults(
+                    actor_keys={"use-subscription": "false"},
+                    agent_args={"model": "opus"},
+                ),
+            },
+        )
+        a = cmd_new(db, git, name="foo", dir=None, no_worktree=True, base=None,
+                    agent_name="claude",
+                    config_pairs=["model=haiku"],  # CLI wins
+                    template_name="qa",            # template supplies permission-mode=plan
+                    app_config=app)
+        self.assertEqual(a.config.get("model"), "haiku")                  # CLI > kdl
+        self.assertEqual(a.config.get("permission-mode"), "plan")          # template
+        self.assertEqual(a.config.get("use-subscription"), "false")        # kdl flat key
+        # Class-level AGENT_DEFAULTS baseline must also show when nobody overrode it:
+        # (auto for Claude's permission-mode was overridden by template here, so we test
+        # the absence case with a separate scenario.)
+
+    def test_class_defaults_applied_when_nothing_else_sets_key(self):
+        from actor import AppConfig
+        db, _, git, pm = _fresh_db_and_fakes()
+        app = AppConfig()  # empty
+        a = cmd_new(db, git, name="bar", dir=None, no_worktree=True, base=None,
+                    agent_name="claude",
+                    config_pairs=[], template_name=None, app_config=app)
+        self.assertEqual(a.config.get("permission-mode"), "auto")
+        self.assertEqual(a.config.get("use-subscription"), "true")
+```
+
+Add a helper `_fresh_db_and_fakes()` if one doesn't already exist; mirror the existing pattern used in `test_actor.py` for fake DBs.
+
+- [ ] **Step 6.2: Run tests — expect FAIL**
+
+- [ ] **Step 6.3: Implement precedence in cmd_new**
+
+Edit `src/actor/commands.py::cmd_new`. After the `agent_kind` is resolved and before the current `config` dict is built, insert:
+
+```python
+# Precedence ladder (low → high):
+#   1. Agent class hardcoded defaults
+#   2. User+project kdl agent_defaults (already merged by load_config)
+#   3. Template config
+#   4. CLI --config
+agent_cls = type(_create_agent(agent_kind))
+# Start with class baseline — ACTOR_DEFAULTS and AGENT_DEFAULTS are all merged
+# into a single flat dict since the actor stores one `config`.
+config: Dict[str, Optional[str]] = {}
+for k, v in agent_cls.ACTOR_DEFAULTS.items():
+    if v is not None:
+        config[k] = v
+for k, v in agent_cls.AGENT_DEFAULTS.items():
+    if v is not None:
+        config[k] = v
+
+# KDL layer
+if app_config is not None:
+    defaults = app_config.agent_defaults.get(agent_kind.value)
+    if defaults is not None:
+        for k, v in defaults.actor_keys.items():
+            if v is None:
+                config.pop(k, None)
+            else:
+                config[k] = v
+        for k, v in defaults.agent_args.items():
+            if v is None:
+                config.pop(k, None)
+            else:
+                config[k] = v
+
+# Template layer (flat bag — agent_kind already decided above)
+if template is not None:
+    for k, v in template.config.items():
+        config[k] = v
+
+# CLI layer (flat bag)
+for k, v in parse_config(config_pairs).items():
+    config[k] = v
+
+# Strip Nones (safety net) and sort for determinism.
+config_final: Dict[str, str] = {k: v for k, v in config.items() if v is not None}
+config_final = _sorted_config(config_final)
+```
+
+Replace the existing build with this. Keep the rest of `cmd_new` the same. `actor.config = config_final`.
+
+- [ ] **Step 6.4: Run tests**
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add -A
+git commit -m "Apply per-agent defaults as lowest layer in cmd_new (#31)"
+```
+
+---
+
+## Task 7 — Skill + CLAUDE.md docs
+
+**Files:**
+- Modify: `src/actor/_skill/SKILL.md` (settings.kdl block: explain flat vs defaults, null, Codex flag-name quirk, new defaults text; update "Important Notes" at the bottom).
+- Modify: `src/actor/_skill/claude-config.md` (permission-mode default → auto; document bypassPermissions is still reachable explicitly).
+- Modify: `src/actor/_skill/codex-config.md` (sandbox + approval default; drop the compound flag reference).
+- Modify: `CLAUDE.md` (extend the "Config files & templates" section to cover per-agent defaults and null semantics).
+
+- [ ] **Step 7.1: SKILL.md — add a subsection under "Templates" titled "Per-agent defaults"**
+
+Describe:
+```kdl
+agent "claude" {
+    use-subscription true
+    defaults {
+        permission-mode "auto"
+        model "opus"
+    }
+}
+```
+- Flat keys = actor-sh controls (only `use-subscription` today).
+- `defaults { }` keys = agent CLI flags.
+- Claude uses semantic names (`model`, `permission-mode`). Codex uses the binary's native short flags (`m`, `a`, `sandbox`). No translation layer on either side.
+- `null` cancels a lower-precedence value (e.g. project file sets `permission-mode #null` to erase user file's bypass setting).
+- Precedence low→high: class defaults → user kdl → project kdl → template → CLI.
+
+- [ ] **Step 7.2: claude-config.md — flip default**
+
+Update permission-mode options: move `auto` to "default" and explain that `bypassPermissions` is opt-in for autonomous worktree runs.
+
+- [ ] **Step 7.3: codex-config.md — drop compound, add explicit**
+
+Remove the "When neither sandbox nor approval is set" paragraphs. State the default is explicit: `sandbox=danger-full-access` + `a=never`. Document that Codex config uses Codex's own flag names verbatim.
+
+- [ ] **Step 7.4: CLAUDE.md — extend config section**
+
+Add a paragraph under "Config files & templates" covering per-agent defaults, null semantics, Codex asymmetry.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add -A
+git commit -m "Docs: per-agent defaults, null semantics, new Claude/Codex defaults (#31)"
+```
+
+---
+
+## Task 8 — Full test sweep + CR loop prep
+
+- [ ] **Step 8.1: Full test suite**
+
+```bash
+uv run python -m unittest discover tests 2>&1 | tail -10
+```
+
+All green. If anything else referenced `claude_config_args`, `codex_config_args`, `_INTERNAL_KEYS`, `_permission_args`, `_config_args`, `--strip-api-keys`, or `default-config`, fix now.
+
+- [ ] **Step 8.2: Grep for stragglers**
+
+```bash
+grep -rn "strip-api-keys\|strip_api_keys\|default-config\|_INTERNAL_KEYS\|claude_config_args\|codex_config_args\|_permission_args\|_config_args\|dangerously-skip-permissions\|dangerously-bypass-approvals-and-sandbox" src/ tests/ CLAUDE.md 2>/dev/null
+```
+
+Expected: no hits. Any hit = residual doc or test needs updating.
+
+- [ ] **Step 8.3: Push branch**
+
+```bash
+git push -u origin per-agent-defaults-redesign
+```
+
+- [ ] **Step 8.4: Open PR**
+
+```bash
+gh pr create --title "Per-agent defaults (redesign) (#31)" --body "$(cat <<'EOF'
+## Summary
+
+- Per-agent defaults in `settings.kdl` split into flat actor-keys and a `defaults { }` sub-block (passed to the agent binary as flags).
+- `strip-api-keys` → `use-subscription`; `default-config` → `defaults`. No back-compat shim.
+- Agent subclasses expose `ACTOR_DEFAULTS` + `AGENT_DEFAULTS` class constants and `emit_agent_args` / `apply_actor_keys` methods. Emitter is straight flag mapping — Claude uses `--key`, Codex uses `-k` for 1-char keys and `--key` otherwise.
+- Built-in defaults: Claude `permission-mode "auto"` (replaces `bypassPermissions`); Codex `sandbox "danger-full-access"` + `a "never"` (replaces the compound bypass flag).
+- `null` in any layer cancels a lower-precedence value.
+
+## Test plan
+
+- [ ] Unit tests cover: emit_agent_args for both agents, apply_actor_keys env filtering, kdl parse for agent blocks + null + unknown-key rejection, precedence ladder in cmd_new.
+- [ ] Manual smoke: `claude --permission-mode auto` and `codex exec --sandbox danger-full-access -a never` both accepted.
+
+Closes #31
+EOF
+)"
+```
+
+- [ ] **Step 8.5: Run the cr-loop**
+
+Invoke the `cr-loop` skill with Path A (7 agents, verbatim Law 3 prompt). Loop until a 7-agent round returns zero findings. Do not exit dirty.
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+| Spec item | Task covering it |
+|---|---|
+| Rename `strip-api-keys` → `use-subscription` | Task 1 |
+| Rename `default-config` → `defaults` | Task 5 |
+| `agent "X" { flat; defaults { } }` shape, no second-arg form | Task 5 |
+| No `settings.kdl` shipped; hardcoded in class constants | Task 2 (constants) |
+| Precedence: class → user → project → template → CLI | Task 6 |
+| `null` cancels | Task 5 (`_merge_dict`) |
+| Claude: `key "value"` → `--key value`; empty string → bare `--key` | Task 2 (Claude emitter) |
+| Codex: `-k` or `--key` based on length | Task 2 (Codex emitter) |
+| Claude default `permission-mode "auto"` | Task 3 |
+| Drop `bypassPermissions` → `--dangerously-skip-permissions` rewrite | Task 2 (remove `_permission_args`) |
+| Drop Codex compound bypass flag | Task 2 (remove `_permission_args`) |
+| Codex explicit defaults (sandbox + a) | Task 3 |
+| Uniform `Agent` interface (AGENT_DEFAULTS/ACTOR_DEFAULTS/emit/apply) | Task 2 |
+| Fix double `--permission-mode` emit bug | Task 2 (unified emitter removes the helper that emitted it twice) |
+| Docs updates (CLAUDE.md, SKILL.md, configs) | Task 7 |
+| cr-loop Path A, no exit-dirty | Task 8 |
+| `gh pr close 50` + fresh PR title | Already done; Task 8 opens the new PR |
+| No new deps; pre-existing tests still pass (except rewritten) | Constraints respected throughout |
+
+Placeholder scan: none. Every step has the concrete edit or command.
+
+Type consistency: `Dict[str, Optional[str]]` everywhere until the final merged storage, which is `Dict[str, str]` (matching `Actor.config`). `emit_agent_args` takes `Config` (= `Dict[str, str]`) and defensively skips Nones.

--- a/src/actor/__init__.py
+++ b/src/actor/__init__.py
@@ -77,8 +77,6 @@ from .commands import (
     worktree_path,
     encode_dir,
     claude_session_file_path,
-    claude_config_args,
-    codex_config_args,
     claude_read_logs,
 )
 
@@ -141,8 +139,6 @@ __all__ = [
     "worktree_path",
     "encode_dir",
     "claude_session_file_path",
-    "claude_config_args",
-    "codex_config_args",
     "claude_read_logs",
     # CLI
     "main",

--- a/src/actor/__init__.py
+++ b/src/actor/__init__.py
@@ -84,6 +84,8 @@ from .commands import (
 from .cli import main, _build_parser, _db_path, _create_agent
 
 __all__ = [
+    # Version
+    "__version__",
     # Errors
     "ActorError",
     "AlreadyExistsError",

--- a/src/actor/__init__.py
+++ b/src/actor/__init__.py
@@ -26,7 +26,7 @@ from .types import (
     Status,
     Actor,
     Run,
-    Config,
+    ActorConfig,
     validate_name,
     parse_config,
     _now_iso,
@@ -101,7 +101,7 @@ __all__ = [
     "Status",
     "Actor",
     "Run",
-    "Config",
+    "ActorConfig",
     "validate_name",
     "parse_config",
     # Config

--- a/src/actor/__init__.py
+++ b/src/actor/__init__.py
@@ -35,7 +35,7 @@ from .types import (
 )
 
 # Config
-from .config import AppConfig, Template, load_config
+from .config import AgentDefaults, AppConfig, Template, load_config
 
 # Interfaces
 from .interfaces import (
@@ -103,6 +103,7 @@ __all__ = [
     "validate_name",
     "parse_config",
     # Config
+    "AgentDefaults",
     "AppConfig",
     "Template",
     "load_config",

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -97,7 +97,7 @@ template "qa" {
     agent "claude"
     model "opus"
     effort "max"
-    strip-api-keys true
+    use-subscription true
     prompt "You're a QA engineer. Run the tests, report what fails."
 }
 
@@ -115,7 +115,7 @@ template "reviewer" {
   on the CLI.
 - Any key from the agent's config reference ([claude-config.md](claude-config.md),
   [codex-config.md](codex-config.md)) — e.g. `model`, `effort`,
-  `strip-api-keys`, `max-budget-usd`. Values may be strings, booleans, or
+  `use-subscription`, `max-budget-usd`. Values may be strings, booleans, or
   numbers; they're all coerced to strings to match the actor config
   pipeline.
 

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -288,7 +288,7 @@ Choose based on context.
 
 ## Important Notes
 
-- Actors run with full permissions by default (Claude: `permission-mode "auto"`; Codex: `sandbox "danger-full-access"` + `a "never"`). Change via config — see the agent config reference.
+- Actors run autonomous-leaning by default — Claude uses `permission-mode "auto"` (agent decides when to ask; effectively autonomous inside a worktree), Codex uses `sandbox "danger-full-access"` + `a "never"` (truly unrestricted). To fully bypass Claude's permission checks, set `permission-mode "bypassPermissions"`. See the agent config reference for other options.
 - Each actor gets its own git worktree by default so parallel actors don't conflict.
 - Actor sessions persist — multiple runs against the same actor keep context.
 - If an actor errors, check verbose logs (`logs_actor(name=..., verbose=True)`) and retry with `run_actor`.

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -119,9 +119,53 @@ template "reviewer" {
   numbers; they're all coerced to strings to match the actor config
   pipeline.
 
-Unknown top-level nodes (`hooks`, `agent`, `alias`) parse as no-ops today —
+Unknown top-level nodes (`hooks`, `alias`) parse as no-ops today —
 they're reserved for follow-up tickets. Malformed KDL raises an error
 with the file path.
+
+**Per-agent defaults** live alongside templates and apply automatically
+to every new actor of that agent kind:
+
+```kdl
+agent "claude" {
+    use-subscription true
+    defaults {
+        permission-mode "auto"
+        model "opus"
+    }
+}
+
+agent "codex" {
+    defaults {
+        m "o3"
+        sandbox "workspace-write"
+    }
+}
+```
+
+- **Flat keys** (outside `defaults { }`) are actor-sh controls. Today
+  only `use-subscription` is valid (strips `ANTHROPIC_API_KEY` /
+  `OPENAI_API_KEY` from the child env so the subscription login is
+  used instead of the API key).
+- **Keys inside `defaults { }`** map directly to the agent binary's
+  CLI flags. Claude uses semantic long flags (`model`, `permission-mode`).
+  Codex uses whatever flag names `codex` itself accepts — `-m` / `-a`
+  (short), `--sandbox` / `--config` (long). No translation layer on
+  either side.
+- **`null` cancels a lower-precedence value.** For example, a project
+  file can set `permission-mode null` under `agent "claude"` to erase
+  a user-level default without forcing a replacement.
+
+Precedence at `actor new` (low → high): class-level hardcoded defaults →
+user kdl → project kdl → template → CLI `--config`. The resolved merge
+is snapshotted onto the actor at creation time; later kdl edits don't
+retroactively mutate existing actors (use `actor config <name>` for
+that).
+
+Built-in class defaults (no kdl file needed):
+- Claude: `use-subscription "true"`, `permission-mode "auto"`.
+- Codex: `use-subscription "true"`, `sandbox "danger-full-access"`,
+  `a "never"`.
 
 **Applying a template** (CLI only — see note below):
 
@@ -244,7 +288,7 @@ Choose based on context.
 
 ## Important Notes
 
-- Actors run with full permissions by default (`--dangerously-skip-permissions` for Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex). Change via config — see the agent config reference.
+- Actors run with full permissions by default (Claude: `permission-mode "auto"`; Codex: `sandbox "danger-full-access"` + `a "never"`). Change via config — see the agent config reference.
 - Each actor gets its own git worktree by default so parallel actors don't conflict.
 - Actor sessions persist — multiple runs against the same actor keep context.
 - If an actor errors, check verbose logs (`logs_actor(name=..., verbose=True)`) and retry with `run_actor`.

--- a/src/actor/_skill/claude-config.md
+++ b/src/actor/_skill/claude-config.md
@@ -1,6 +1,14 @@
 # Claude Agent Configuration
 
-All options below are set via `--config key=value` on `actor new` or `actor config`. They are passed to `claude` on every run.
+All options below are set via `--config key=value` on `actor new` or `actor config`. Most are passed straight through to `claude` as `--key value` on every run; a few (listed as "actor-sh interpreted") are consumed by actor-sh itself and never reach the agent binary.
+
+## Use Subscription
+
+Actor-sh interpreted. When `true` (the default), actor-sh strips `ANTHROPIC_API_KEY` from the agent's environment so Claude uses the logged-in `claude` subscription. Set to `false` to keep the API key and bill requests against it.
+
+```
+actor new my-feature --config use-subscription=false
+```
 
 ## Model
 
@@ -21,8 +29,8 @@ actor new my-feature --config permission-mode=auto
 ```
 
 Options:
-- `bypassPermissions` (default) — skip all permission checks, fully autonomous
-- `auto` — agent decides when to ask for approval
+- `auto` (default) — agent decides when to ask for approval; in an actor worktree this is effectively autonomous
+- `bypassPermissions` — skip all permission checks (reachable by setting `permission-mode=bypassPermissions` explicitly)
 - `acceptEdits` — auto-approve file edits, ask for other actions
 - `default` — standard permission prompts
 - `dontAsk` — never ask, skip actions that need approval

--- a/src/actor/_skill/cli.md
+++ b/src/actor/_skill/cli.md
@@ -35,7 +35,7 @@ actor new fix-nav --base develop "..."                                      # br
 actor new fix-nav --dir /path/to/repo "..."                                 # worktree from another repo
 actor new fix-nav --no-worktree "..."                                       # no worktree
 actor new fix-nav --config model=opus "..."                                 # saved defaults
-actor new fix-nav --no-strip-api-keys "..."                                 # pass API keys through
+actor new fix-nav --no-use-subscription "..."                               # pass API keys through
 actor new fix-nav --template qa                                             # apply a template from settings.kdl
 echo "fix it" | actor new fix-nav                                           # prompt from stdin
 ```

--- a/src/actor/_skill/codex-config.md
+++ b/src/actor/_skill/codex-config.md
@@ -1,18 +1,28 @@
 # Codex Agent Configuration
 
-All options below are set via `--config key=value` on `actor new` or `actor config`. They are passed to `codex` on every run.
+All options below are set via `--config key=value` on `actor new` or `actor config`. Most are passed straight through to `codex` as CLI flags on every run (one-character keys like `m`, `a` become short flags `-m`, `-a`; longer keys become `--key value`); a few (listed as "actor-sh interpreted") are consumed by actor-sh itself and never reach the agent binary.
 
-## Model
+Codex uses its native flag names verbatim — the key you write in config is the flag name Codex receives. This is different from the Claude agent's semantic long-flag naming.
+
+## Use Subscription
+
+Actor-sh interpreted. When `true` (the default), actor-sh strips `OPENAI_API_KEY` from the agent's environment so Codex uses the logged-in `codex` subscription. Set to `false` to keep the API key and bill requests against it.
+
+```
+actor new my-feature --agent codex --config use-subscription=false
+```
+
+## Model (`m`)
 
 Select which model to use. Can also be set via `--model` on `actor new`.
 
 ```
-actor new my-feature --agent codex --config model=o3
+actor new my-feature --agent codex --config m=o3
 ```
 
 Default: agent's default model.
 
-## Sandbox
+## Sandbox (`sandbox`)
 
 Controls the sandbox policy for shell commands.
 
@@ -25,22 +35,18 @@ Options:
 - `workspace-write` — allow writes only in the workspace
 - `read-only` — no writes allowed
 
-When neither `sandbox` nor `approval` is set, the default is `--dangerously-bypass-approvals-and-sandbox` (full access, no approval prompts).
-
-## Approval
+## Approval (`a`)
 
 Controls when the agent asks for approval before running commands.
 
 ```
-actor new my-feature --agent codex --config approval=on-request
+actor new my-feature --agent codex --config a=on-request
 ```
 
 Options:
 - `never` (default) — never ask, execute everything
 - `on-request` — agent decides when to ask
 - `untrusted` — only auto-approve trusted commands (ls, cat, etc.)
-
-When neither `sandbox` nor `approval` is set, the default is `--dangerously-bypass-approvals-and-sandbox` (full access, no approval prompts).
 
 ## Additional Directories
 

--- a/src/actor/agents/claude.py
+++ b/src/actor/agents/claude.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Mapping, Optional, Tuple
 
 from ..errors import ActorError
 from ..interfaces import Agent, LogEntry, LogEntryKind
-from ..types import Config
+from ..types import ActorConfig
 
 
 class ClaudeAgent(Agent):
@@ -26,14 +26,14 @@ class ClaudeAgent(Agent):
         self._children: Dict[int, subprocess.Popen] = {}  # type: ignore[type-arg]
         self._lock = threading.Lock()
 
-    def emit_agent_args(self, defaults: Config) -> List[str]:
-        """Map the resolved `defaults { }` dict to claude CLI flags.
+    def emit_agent_args(self, defaults: Dict[str, str]) -> List[str]:
+        """Map the resolved `agent_args` dict to claude CLI flags.
 
         Straight mapping: `key "value"` → `--key value`; empty string becomes
-        a bare `--key`. `None` values are skipped defensively — the resolver
-        in cmd_new is expected to have stripped kdl-layer `None` cancel
-        markers before this runs, but we drop them here too so a misrouted
-        caller can't feed `None` into subprocess.Popen."""
+        a bare `--key`. `None` values are skipped defensively — ActorConfig
+        is supposed to contain only concrete strings (the cmd_new resolver
+        strips kdl-layer `None` cancel markers), but we drop them here too
+        so a misrouted caller can't feed `None` into subprocess.Popen."""
         args: List[str] = []
         for key, value in sorted(defaults.items()):
             if value is None:
@@ -44,18 +44,17 @@ class ClaudeAgent(Agent):
         return args
 
     def apply_actor_keys(
-        self, flat: Config, env: Mapping[str, str]
+        self, actor_keys: Dict[str, str], env: Mapping[str, str]
     ) -> Dict[str, str]:
         """Strip ANTHROPIC_API_KEY from the env when use-subscription is on
         (default true) so Claude falls back to the logged-in subscription."""
         out = dict(env)
-        if flat.get("use-subscription", "true") != "false":
+        if actor_keys.get("use-subscription", "true") != "false":
             out.pop("ANTHROPIC_API_KEY", None)
         return out
 
-    def _spawn_and_track(self, args: List[str], cwd: Path, config: Config) -> int:
-        actor_keys, _ = self._split_config(config)
-        env = self.apply_actor_keys(actor_keys, os.environ)
+    def _spawn_and_track(self, args: List[str], cwd: Path, config: ActorConfig) -> int:
+        env = self.apply_actor_keys(config.actor_keys, os.environ)
         proc = subprocess.Popen(
             args,
             stdin=subprocess.DEVNULL,
@@ -87,8 +86,7 @@ class ClaudeAgent(Agent):
     # orchestrate their own children identically to the top-level Claude session.
     _CHANNEL_ARGS = ["--dangerously-load-development-channels", "server:actor"]
 
-    def start(self, dir: Path, prompt: str, config: Config) -> Tuple[int, Optional[str]]:
-        _, agent_args = self._split_config(config)
+    def start(self, dir: Path, prompt: str, config: ActorConfig) -> Tuple[int, Optional[str]]:
         session_id = str(uuid.uuid4())
         args = [
             "claude",
@@ -96,22 +94,21 @@ class ClaudeAgent(Agent):
             "-p",
             "--session-id",
             session_id,
-            *self.emit_agent_args(agent_args),
+            *self.emit_agent_args(config.agent_args),
             "--",
             prompt,
         ]
         pid = self._spawn_and_track(args, dir, config)
         return pid, session_id
 
-    def resume(self, dir: Path, session_id: str, prompt: str, config: Config) -> int:
-        _, agent_args = self._split_config(config)
+    def resume(self, dir: Path, session_id: str, prompt: str, config: ActorConfig) -> int:
         args = [
             "claude",
             *self._CHANNEL_ARGS,
             "-p",
             "--resume",
             session_id,
-            *self.emit_agent_args(agent_args),
+            *self.emit_agent_args(config.agent_args),
             "--",
             prompt,
         ]
@@ -216,13 +213,12 @@ class ClaudeAgent(Agent):
 
         return entries
 
-    def interactive_argv(self, session_id: str, config: Config) -> List[str]:
-        _, agent_args = self._split_config(config)
+    def interactive_argv(self, session_id: str, config: ActorConfig) -> List[str]:
         return [
             "claude",
             *self._CHANNEL_ARGS,
             "--resume", session_id,
-            *self.emit_agent_args(agent_args),
+            *self.emit_agent_args(config.agent_args),
         ]
 
     def stop(self, pid: int) -> None:

--- a/src/actor/agents/claude.py
+++ b/src/actor/agents/claude.py
@@ -30,10 +30,14 @@ class ClaudeAgent(Agent):
         """Map the resolved `defaults { }` dict to claude CLI flags.
 
         Straight mapping: `key "value"` → `--key value`; empty string becomes
-        a bare `--key`. `defaults` is `Config` (Dict[str, str]) — the kdl-layer
-        `None` cancel markers are stripped in cmd_new before this runs."""
+        a bare `--key`. `None` values are skipped defensively — the resolver
+        in cmd_new is expected to have stripped kdl-layer `None` cancel
+        markers before this runs, but we drop them here too so a misrouted
+        caller can't feed `None` into subprocess.Popen."""
         args: List[str] = []
         for key, value in sorted(defaults.items()):
+            if value is None:
+                continue
             args.append(f"--{key}")
             if value != "":
                 args.append(value)

--- a/src/actor/agents/claude.py
+++ b/src/actor/agents/claude.py
@@ -20,7 +20,7 @@ class ClaudeAgent(Agent):
         self._lock = threading.Lock()
 
     # Config keys that are handled specially and not passed as CLI flags
-    _INTERNAL_KEYS = {"strip-api-keys"}
+    _INTERNAL_KEYS = {"use-subscription"}
 
     @staticmethod
     def _config_args(config: Config) -> List[str]:
@@ -44,8 +44,8 @@ class ClaudeAgent(Agent):
         return ["--permission-mode", mode]
 
     def _spawn_and_track(self, args: List[str], cwd: Path, config: Config) -> int:
-        strip = config.get("strip-api-keys", "true") != "false"
-        if strip:
+        use_sub = config.get("use-subscription", "true") != "false"
+        if use_sub:
             env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
         else:
             env = dict(os.environ)

--- a/src/actor/agents/claude.py
+++ b/src/actor/agents/claude.py
@@ -15,10 +15,10 @@ from ..types import Config
 
 
 class ClaudeAgent(Agent):
-    AGENT_DEFAULTS: Dict[str, Optional[str]] = {
+    AGENT_DEFAULTS: Dict[str, str] = {
         "permission-mode": "auto",
     }
-    ACTOR_DEFAULTS: Dict[str, Optional[str]] = {
+    ACTOR_DEFAULTS: Dict[str, str] = {
         "use-subscription": "true",
     }
 

--- a/src/actor/agents/claude.py
+++ b/src/actor/agents/claude.py
@@ -7,7 +7,7 @@ import subprocess
 import threading
 import uuid
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple
 
 from ..errors import ActorError
 from ..interfaces import Agent, LogEntry, LogEntryKind
@@ -15,40 +15,45 @@ from ..types import Config
 
 
 class ClaudeAgent(Agent):
+    AGENT_DEFAULTS: Dict[str, Optional[str]] = {
+        "permission-mode": "auto",
+    }
+    ACTOR_DEFAULTS: Dict[str, Optional[str]] = {
+        "use-subscription": "true",
+    }
+
     def __init__(self) -> None:
         self._children: Dict[int, subprocess.Popen] = {}  # type: ignore[type-arg]
         self._lock = threading.Lock()
 
-    # Config keys that are handled specially and not passed as CLI flags
-    _INTERNAL_KEYS = {"use-subscription"}
+    def emit_agent_args(self, defaults: Config) -> List[str]:
+        """Map the resolved `defaults { }` dict to claude CLI flags.
 
-    @staticmethod
-    def _config_args(config: Config) -> List[str]:
-        """Build common config flags. Each key becomes --key value.
-        Empty values become bare flags (--key). Internal keys are skipped."""
+        Straight mapping: `key "value"` → `--key value`; empty string becomes
+        a bare `--key`; None is skipped (defensive — the resolver should have
+        already dropped it)."""
         args: List[str] = []
-        for key, value in sorted(config.items()):
-            if key in ClaudeAgent._INTERNAL_KEYS:
+        for key, value in sorted(defaults.items()):
+            if value is None:
                 continue
             args.append(f"--{key}")
-            if value:
+            if value != "":
                 args.append(value)
         return args
 
-    @staticmethod
-    def _permission_args(config: Config) -> List[str]:
-        """Build permission flags from config."""
-        mode = config.get("permission-mode", "bypassPermissions")
-        if mode == "bypassPermissions":
-            return ["--dangerously-skip-permissions"]
-        return ["--permission-mode", mode]
+    def apply_actor_keys(
+        self, flat: Config, env: Mapping[str, str]
+    ) -> Dict[str, str]:
+        """Strip ANTHROPIC_API_KEY from the env when use-subscription is on
+        (default true) so Claude falls back to the logged-in subscription."""
+        out = dict(env)
+        if flat.get("use-subscription", "true") != "false":
+            out.pop("ANTHROPIC_API_KEY", None)
+        return out
 
     def _spawn_and_track(self, args: List[str], cwd: Path, config: Config) -> int:
-        use_sub = config.get("use-subscription", "true") != "false"
-        if use_sub:
-            env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
-        else:
-            env = dict(os.environ)
+        actor_keys, _ = self._split_config(config)
+        env = self.apply_actor_keys(actor_keys, os.environ)
         proc = subprocess.Popen(
             args,
             stdin=subprocess.DEVNULL,
@@ -81,15 +86,15 @@ class ClaudeAgent(Agent):
     _CHANNEL_ARGS = ["--dangerously-load-development-channels", "server:actor"]
 
     def start(self, dir: Path, prompt: str, config: Config) -> Tuple[int, Optional[str]]:
+        _, agent_args = self._split_config(config)
         session_id = str(uuid.uuid4())
         args = [
             "claude",
             *self._CHANNEL_ARGS,
             "-p",
-            *self._permission_args(config),
             "--session-id",
             session_id,
-            *self._config_args(config),
+            *self.emit_agent_args(agent_args),
             "--",
             prompt,
         ]
@@ -97,14 +102,14 @@ class ClaudeAgent(Agent):
         return pid, session_id
 
     def resume(self, dir: Path, session_id: str, prompt: str, config: Config) -> int:
+        _, agent_args = self._split_config(config)
         args = [
             "claude",
             *self._CHANNEL_ARGS,
             "-p",
-            *self._permission_args(config),
             "--resume",
             session_id,
-            *self._config_args(config),
+            *self.emit_agent_args(agent_args),
             "--",
             prompt,
         ]
@@ -210,12 +215,12 @@ class ClaudeAgent(Agent):
         return entries
 
     def interactive_argv(self, session_id: str, config: Config) -> List[str]:
+        _, agent_args = self._split_config(config)
         return [
             "claude",
             *self._CHANNEL_ARGS,
-            *self._permission_args(config),
             "--resume", session_id,
-            *self._config_args(config),
+            *self.emit_agent_args(agent_args),
         ]
 
     def stop(self, pid: int) -> None:

--- a/src/actor/agents/claude.py
+++ b/src/actor/agents/claude.py
@@ -30,12 +30,10 @@ class ClaudeAgent(Agent):
         """Map the resolved `defaults { }` dict to claude CLI flags.
 
         Straight mapping: `key "value"` → `--key value`; empty string becomes
-        a bare `--key`; None is skipped (defensive — the resolver should have
-        already dropped it)."""
+        a bare `--key`. `defaults` is `Config` (Dict[str, str]) — the kdl-layer
+        `None` cancel markers are stripped in cmd_new before this runs."""
         args: List[str] = []
         for key, value in sorted(defaults.items()):
-            if value is None:
-                continue
             args.append(f"--{key}")
             if value != "":
                 args.append(value)

--- a/src/actor/agents/codex.py
+++ b/src/actor/agents/codex.py
@@ -24,11 +24,11 @@ class _CodexChild:
 
 
 class CodexAgent(Agent):
-    AGENT_DEFAULTS: Dict[str, Optional[str]] = {
+    AGENT_DEFAULTS: Dict[str, str] = {
         "sandbox": "danger-full-access",
         "a": "never",
     }
-    ACTOR_DEFAULTS: Dict[str, Optional[str]] = {
+    ACTOR_DEFAULTS: Dict[str, str] = {
         "use-subscription": "true",
     }
 

--- a/src/actor/agents/codex.py
+++ b/src/actor/agents/codex.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Mapping, Optional, Tuple
 
 from ..errors import ActorError
 from ..interfaces import Agent, LogEntry, LogEntryKind
-from ..types import Config
+from ..types import ActorConfig
 
 
 class _CodexChild:
@@ -36,16 +36,16 @@ class CodexAgent(Agent):
         self._children: Dict[int, _CodexChild] = {}
         self._lock = threading.Lock()
 
-    def emit_agent_args(self, defaults: Config) -> List[str]:
-        """Map the resolved `defaults { }` dict to codex CLI flags.
+    def emit_agent_args(self, defaults: Dict[str, str]) -> List[str]:
+        """Map the resolved `agent_args` dict to codex CLI flags.
 
         Users write Codex's native flag names verbatim (e.g. `m`, `a`,
         `sandbox`). One-character keys emit a short flag (`-k value`);
         longer keys emit a long flag (`--key value`). Empty string becomes
-        a bare flag. `None` values are skipped defensively — the resolver
-        in cmd_new is expected to have stripped kdl-layer `None` cancel
-        markers before this runs, but we drop them here too so a misrouted
-        caller can't feed `None` into subprocess.Popen."""
+        a bare flag. `None` values are skipped defensively — ActorConfig
+        is supposed to contain only concrete strings (the cmd_new resolver
+        strips kdl-layer `None` cancel markers), but we drop them here too
+        so a misrouted caller can't feed `None` into subprocess.Popen."""
         args: List[str] = []
         for key, value in sorted(defaults.items()):
             if value is None:
@@ -57,20 +57,19 @@ class CodexAgent(Agent):
         return args
 
     def apply_actor_keys(
-        self, flat: Config, env: Mapping[str, str]
+        self, actor_keys: Dict[str, str], env: Mapping[str, str]
     ) -> Dict[str, str]:
         """Strip OPENAI_API_KEY from the env when use-subscription is on
         (default true) so Codex falls back to the logged-in subscription."""
         out = dict(env)
-        if flat.get("use-subscription", "true") != "false":
+        if actor_keys.get("use-subscription", "true") != "false":
             out.pop("OPENAI_API_KEY", None)
         return out
 
     def _spawn_and_capture(
-        self, args: List[str], cwd: Optional[Path], config: Config
+        self, args: List[str], cwd: Optional[Path], config: ActorConfig
     ) -> Tuple[int, Optional[str]]:
-        actor_keys, _ = self._split_config(config)
-        env = self.apply_actor_keys(actor_keys, os.environ)
+        env = self.apply_actor_keys(config.actor_keys, os.environ)
         kwargs: dict = dict(
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
@@ -164,28 +163,26 @@ class CodexAgent(Agent):
         except Exception as e:
             raise ActorError(f"codex DB query failed: {e}")
 
-    def start(self, dir: Path, prompt: str, config: Config) -> Tuple[int, Optional[str]]:
-        _, agent_args = self._split_config(config)
+    def start(self, dir: Path, prompt: str, config: ActorConfig) -> Tuple[int, Optional[str]]:
         args = [
             "codex",
             "exec",
             "--json",
             "-C",
             str(dir),
-            *self.emit_agent_args(agent_args),
+            *self.emit_agent_args(config.agent_args),
             prompt,
         ]
         return self._spawn_and_capture(args, cwd=None, config=config)
 
-    def resume(self, dir: Path, session_id: str, prompt: str, config: Config) -> int:
-        _, agent_args = self._split_config(config)
+    def resume(self, dir: Path, session_id: str, prompt: str, config: ActorConfig) -> int:
         args = [
             "codex",
             "exec",
             "resume",
             session_id,
             "--json",
-            *self.emit_agent_args(agent_args),
+            *self.emit_agent_args(config.agent_args),
             prompt,
         ]
         pid, _ = self._spawn_and_capture(args, cwd=dir, config=config)
@@ -271,13 +268,12 @@ class CodexAgent(Agent):
 
         return entries
 
-    def interactive_argv(self, session_id: str, config: Config) -> List[str]:
+    def interactive_argv(self, session_id: str, config: ActorConfig) -> List[str]:
         # Propagate agent flags so interactive sessions honor the same
         # defaults as non-interactive runs (parity with Claude).
-        _, agent_args = self._split_config(config)
         return [
             "codex", "resume", session_id,
-            *self.emit_agent_args(agent_args),
+            *self.emit_agent_args(config.agent_args),
         ]
 
     def stop(self, pid: int) -> None:

--- a/src/actor/agents/codex.py
+++ b/src/actor/agents/codex.py
@@ -29,7 +29,7 @@ class CodexAgent(Agent):
         self._lock = threading.Lock()
 
     # Config keys that are handled specially and not passed as CLI flags
-    _INTERNAL_KEYS = {"strip-api-keys", "sandbox", "approval"}
+    _INTERNAL_KEYS = {"use-subscription", "sandbox", "approval"}
 
     @staticmethod
     def _config_args(config: Config) -> List[str]:
@@ -68,8 +68,8 @@ class CodexAgent(Agent):
     def _spawn_and_capture(
         self, args: List[str], cwd: Optional[Path], config: Config
     ) -> Tuple[int, Optional[str]]:
-        strip = config.get("strip-api-keys", "true") != "false"
-        if strip:
+        use_sub = config.get("use-subscription", "true") != "false"
+        if use_sub:
             env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
         else:
             env = dict(os.environ)

--- a/src/actor/agents/codex.py
+++ b/src/actor/agents/codex.py
@@ -42,11 +42,10 @@ class CodexAgent(Agent):
         Users write Codex's native flag names verbatim (e.g. `m`, `a`,
         `sandbox`). One-character keys emit a short flag (`-k value`);
         longer keys emit a long flag (`--key value`). Empty string becomes
-        a bare flag; None is skipped."""
+        a bare flag. `defaults` is `Config` (Dict[str, str]) — the kdl-layer
+        `None` cancel markers are stripped in cmd_new before this runs."""
         args: List[str] = []
         for key, value in sorted(defaults.items()):
-            if value is None:
-                continue
             prefix = "-" if len(key) == 1 else "--"
             args.append(f"{prefix}{key}")
             if value != "":

--- a/src/actor/agents/codex.py
+++ b/src/actor/agents/codex.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import threading
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple
 
 from ..errors import ActorError
 from ..interfaces import Agent, LogEntry, LogEntryKind
@@ -24,55 +24,50 @@ class _CodexChild:
 
 
 class CodexAgent(Agent):
+    AGENT_DEFAULTS: Dict[str, Optional[str]] = {
+        "sandbox": "danger-full-access",
+        "a": "never",
+    }
+    ACTOR_DEFAULTS: Dict[str, Optional[str]] = {
+        "use-subscription": "true",
+    }
+
     def __init__(self) -> None:
         self._children: Dict[int, _CodexChild] = {}
         self._lock = threading.Lock()
 
-    # Config keys that are handled specially and not passed as CLI flags
-    _INTERNAL_KEYS = {"use-subscription", "sandbox", "approval"}
+    def emit_agent_args(self, defaults: Config) -> List[str]:
+        """Map the resolved `defaults { }` dict to codex CLI flags.
 
-    @staticmethod
-    def _config_args(config: Config) -> List[str]:
-        """Build config flags for Codex.
-        model key becomes -m <value>, internal keys are skipped,
-        empty values become -c key=true (TOML boolean),
-        all others become -c key=value.
-        """
+        Users write Codex's native flag names verbatim (e.g. `m`, `a`,
+        `sandbox`). One-character keys emit a short flag (`-k value`);
+        longer keys emit a long flag (`--key value`). Empty string becomes
+        a bare flag; None is skipped."""
         args: List[str] = []
-        for key, value in sorted(config.items()):
-            if key in CodexAgent._INTERNAL_KEYS:
+        for key, value in sorted(defaults.items()):
+            if value is None:
                 continue
-            if key == "model":
-                args.append("-m")
+            prefix = "-" if len(key) == 1 else "--"
+            args.append(f"{prefix}{key}")
+            if value != "":
                 args.append(value)
-            else:
-                args.append("-c")
-                args.append(f"{key}={value if value else 'true'}")
         return args
 
-    @staticmethod
-    def _permission_args(config: Config) -> List[str]:
-        """Build permission/sandbox flags from config."""
-        sandbox = config.get("sandbox")
-        approval = config.get("approval")
-        # If neither is set, use the dangerous bypass (default)
-        if sandbox is None and approval is None:
-            return ["--dangerously-bypass-approvals-and-sandbox"]
-        args: List[str] = []
-        if sandbox is not None:
-            args.extend(["--sandbox", sandbox])
-        if approval is not None:
-            args.extend(["-a", approval])
-        return args
+    def apply_actor_keys(
+        self, flat: Config, env: Mapping[str, str]
+    ) -> Dict[str, str]:
+        """Strip OPENAI_API_KEY from the env when use-subscription is on
+        (default true) so Codex falls back to the logged-in subscription."""
+        out = dict(env)
+        if flat.get("use-subscription", "true") != "false":
+            out.pop("OPENAI_API_KEY", None)
+        return out
 
     def _spawn_and_capture(
         self, args: List[str], cwd: Optional[Path], config: Config
     ) -> Tuple[int, Optional[str]]:
-        use_sub = config.get("use-subscription", "true") != "false"
-        if use_sub:
-            env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
-        else:
-            env = dict(os.environ)
+        actor_keys, _ = self._split_config(config)
+        env = self.apply_actor_keys(actor_keys, os.environ)
         kwargs: dict = dict(
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
@@ -167,27 +162,27 @@ class CodexAgent(Agent):
             raise ActorError(f"codex DB query failed: {e}")
 
     def start(self, dir: Path, prompt: str, config: Config) -> Tuple[int, Optional[str]]:
+        _, agent_args = self._split_config(config)
         args = [
             "codex",
             "exec",
-            *self._permission_args(config),
             "--json",
             "-C",
             str(dir),
-            *self._config_args(config),
+            *self.emit_agent_args(agent_args),
             prompt,
         ]
         return self._spawn_and_capture(args, cwd=None, config=config)
 
     def resume(self, dir: Path, session_id: str, prompt: str, config: Config) -> int:
+        _, agent_args = self._split_config(config)
         args = [
             "codex",
             "exec",
             "resume",
             session_id,
-            *self._permission_args(config),
             "--json",
-            *self._config_args(config),
+            *self.emit_agent_args(agent_args),
             prompt,
         ]
         pid, _ = self._spawn_and_capture(args, cwd=dir, config=config)
@@ -274,12 +269,12 @@ class CodexAgent(Agent):
         return entries
 
     def interactive_argv(self, session_id: str, config: Config) -> List[str]:
-        # Propagate permission + config flags so interactive sessions honor
-        # the same defaults as non-interactive runs (parity with Claude).
+        # Propagate agent flags so interactive sessions honor the same
+        # defaults as non-interactive runs (parity with Claude).
+        _, agent_args = self._split_config(config)
         return [
             "codex", "resume", session_id,
-            *self._permission_args(config),
-            *self._config_args(config),
+            *self.emit_agent_args(agent_args),
         ]
 
     def stop(self, pid: int) -> None:

--- a/src/actor/agents/codex.py
+++ b/src/actor/agents/codex.py
@@ -42,10 +42,14 @@ class CodexAgent(Agent):
         Users write Codex's native flag names verbatim (e.g. `m`, `a`,
         `sandbox`). One-character keys emit a short flag (`-k value`);
         longer keys emit a long flag (`--key value`). Empty string becomes
-        a bare flag. `defaults` is `Config` (Dict[str, str]) — the kdl-layer
-        `None` cancel markers are stripped in cmd_new before this runs."""
+        a bare flag. `None` values are skipped defensively — the resolver
+        in cmd_new is expected to have stripped kdl-layer `None` cancel
+        markers before this runs, but we drop them here too so a misrouted
+        caller can't feed `None` into subprocess.Popen."""
         args: List[str] = []
         for key, value in sorted(defaults.items()):
+            if value is None:
+                continue
             prefix = "-" if len(key) == 1 else "--"
             args.append(f"{prefix}{key}")
             if value != "":

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -65,7 +65,7 @@ Examples:
   actor new my-feature                              Create (worktree from current repo)
   actor new my-feature "fix the nav bar"            Create and run with a prompt
   actor new my-feature --model sonnet               Use a specific model
-  actor new my-feature --no-strip-api-keys          Pass API keys to the agent
+  actor new my-feature --no-use-subscription        Pass API keys to the agent
   actor new my-feature --no-worktree                Use current directory directly
   actor new my-feature --dir /path/to/repo          Worktree from another repo
   actor new my-feature --base develop               Branch off develop
@@ -81,12 +81,12 @@ Examples:
     p_new.add_argument("--agent", default=None, help="Coding agent to use (defaults to template's agent or 'claude')")
     p_new.add_argument("--template", default=None, help="Apply a template from settings.kdl")
     p_new.add_argument("--model", default=None, help="Model for the agent to use")
-    # Tri-state: default None = "no override" so a template's strip-api-keys
-    # value wins. Explicit --strip-api-keys / --no-strip-api-keys set True/
-    # False and beat the template. When neither CLI nor template sets the
-    # key, it's omitted from config and the agent's own default applies.
-    p_new.add_argument("--strip-api-keys", action="store_const", const=True, default=None, dest="strip_api_keys", help="Strip API keys from environment (default)")
-    p_new.add_argument("--no-strip-api-keys", action="store_const", const=False, dest="strip_api_keys", help="Pass API keys through to the agent")
+    # Tri-state: default None = "no override" so a template's use-subscription
+    # value wins. Explicit --use-subscription / --no-use-subscription set
+    # True/False and beat the template. When neither CLI nor template sets
+    # the key, it's omitted from config and the agent's own default applies.
+    p_new.add_argument("--use-subscription", action="store_const", const=True, default=None, dest="use_subscription", help="Use the subscription by stripping API keys from the environment (default)")
+    p_new.add_argument("--no-use-subscription", action="store_const", const=False, dest="use_subscription", help="Pass API keys through to the agent (disables subscription use)")
     p_new.add_argument("--config", dest="config", action="append", default=[], metavar="KEY=VALUE", help="Config key=value pair (repeat for multiple)")
 
     # -- run --
@@ -344,9 +344,9 @@ def main(argv: Optional[List[str]] = None) -> None:
             config_pairs = list(args.config)
             if args.model is not None:
                 config_pairs.append(f"model={args.model}")
-            if args.strip_api_keys is not None:
+            if args.use_subscription is not None:
                 config_pairs.append(
-                    f"strip-api-keys={'true' if args.strip_api_keys else 'false'}"
+                    f"use-subscription={'true' if args.use_subscription else 'false'}"
                 )
             actor = cmd_new(
                 db, git,

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -6,13 +6,14 @@ import sys
 from typing import List, Optional
 
 from . import __version__
-from .errors import ActorError
+from .errors import ActorError, ConfigError
 from .interfaces import Agent
-from .types import AgentKind, Status
+from .types import ActorConfig, AgentKind, Status, parse_config
 from .db import Database
 from .git import RealGit
 from .process import RealProcessManager
 from .commands import (
+    _agent_class,
     _create_agent as _create_agent_impl,
     cmd_config,
     cmd_discard,
@@ -30,6 +31,50 @@ def _create_agent(kind: AgentKind) -> Agent:
     # Thin re-export of commands._create_agent so existing test patches and
     # sibling modules (server.py, watch.app) can keep importing from `cli`.
     return _create_agent_impl(kind)
+
+
+def _resolve_agent_kind_for_cli(
+    cli_agent: Optional[str],
+    template_name: Optional[str],
+    app_config,
+) -> AgentKind:
+    """Replicate cmd_new's agent resolution for CLI-side validation.
+
+    CLI validation of `--config` needs the target agent class to know which
+    keys are actor-keys. Agent precedence mirrors cmd_new: explicit flag →
+    template's `agent` → "claude"."""
+    if cli_agent is not None:
+        return AgentKind.from_str(cli_agent)
+    if template_name is not None and app_config is not None:
+        tpl = app_config.templates.get(template_name)
+        if tpl is not None and tpl.agent:
+            return AgentKind.from_str(tpl.agent)
+    return AgentKind.CLAUDE
+
+
+def _build_cli_overrides(
+    agent_cls,
+    config_pairs: list[str],
+    use_subscription: Optional[bool] = None,
+) -> ActorConfig:
+    """Translate raw CLI inputs into a structured ActorConfig.
+
+    `--config KEY=VALUE` always targets agent_args; if KEY collides with an
+    actor-key name (i.e. appears in the agent class's ACTOR_DEFAULTS), we
+    reject here with a helpful error pointing users at the dedicated flag.
+    Dedicated actor-key flags (currently just `--use-subscription` /
+    `--no-use-subscription`) populate actor_keys directly."""
+    agent_args = parse_config(config_pairs)
+    for key in agent_args:
+        if key in agent_cls.ACTOR_DEFAULTS:
+            raise ConfigError(
+                f"--config {key}={agent_args[key]}: actor-keys cannot be set "
+                f"via --config; use --{key} / --no-{key} instead."
+            )
+    actor_keys: dict[str, str] = {}
+    if use_subscription is not None:
+        actor_keys["use-subscription"] = "true" if use_subscription else "false"
+    return ActorConfig(actor_keys=actor_keys, agent_args=agent_args)
 
 
 def _db_path() -> str:
@@ -337,13 +382,22 @@ def main(argv: Optional[List[str]] = None) -> None:
             from .config import load_config
             app_config = load_config()
 
+            # --config goes into agent_args; --model is an agent_arg too.
+            # --use-subscription is an actor-key, so it routes separately.
             config_pairs = list(args.config)
             if args.model is not None:
                 config_pairs.append(f"model={args.model}")
-            if args.use_subscription is not None:
-                config_pairs.append(
-                    f"use-subscription={'true' if args.use_subscription else 'false'}"
-                )
+
+            agent_kind = _resolve_agent_kind_for_cli(
+                args.agent, args.template, app_config,
+            )
+            agent_cls = _agent_class(agent_kind)
+            cli_overrides = _build_cli_overrides(
+                agent_cls,
+                config_pairs,
+                use_subscription=args.use_subscription,
+            )
+
             actor = cmd_new(
                 db, git,
                 name=args.name,
@@ -351,7 +405,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 no_worktree=args.no_worktree,
                 base=args.base,
                 agent_name=args.agent,
-                config_pairs=config_pairs,
+                cli_overrides=cli_overrides,
                 template_name=args.template,
                 app_config=app_config,
             )
@@ -379,7 +433,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                         db, agent, proc_mgr,
                         name=args.name,
                         prompt=prompt,
-                        config_pairs=[],  # creation flags already saved as defaults
+                        cli_overrides=ActorConfig(),  # creation flags already saved as defaults
                     )
                 except Exception as e:
                     print(f"error: actor created but run failed: {e}", file=sys.stderr)
@@ -407,12 +461,15 @@ def main(argv: Optional[List[str]] = None) -> None:
                 print("error: prompt is required (pass as argument or pipe via stdin, or use -i)", file=sys.stderr)
                 sys.exit(1)
 
-            agent = agent_for(args.name)
+            actor_row = db.get_actor(args.name)
+            agent_cls = _agent_class(actor_row.agent)
+            cli_overrides = _build_cli_overrides(agent_cls, list(args.config))
+            agent = _create_agent(actor_row.agent)
             cmd_run(
                 db, agent, proc_mgr,
                 name=args.name,
                 prompt=prompt,
-                config_pairs=list(args.config),
+                cli_overrides=cli_overrides,
             )
 
         elif args.command == "list":

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -12,9 +12,8 @@ from .types import AgentKind, Status
 from .db import Database
 from .git import RealGit
 from .process import RealProcessManager
-from .agents.claude import ClaudeAgent
-from .agents.codex import CodexAgent
 from .commands import (
+    _create_agent as _create_agent_impl,
     cmd_config,
     cmd_discard,
     cmd_interactive,
@@ -28,12 +27,9 @@ from .commands import (
 
 
 def _create_agent(kind: AgentKind) -> Agent:
-    if kind == AgentKind.CLAUDE:
-        return ClaudeAgent()
-    elif kind == AgentKind.CODEX:
-        return CodexAgent()
-    else:
-        raise ActorError(f"unknown agent kind: {kind}")
+    # Thin re-export of commands._create_agent so existing test patches and
+    # sibling modules (server.py, watch.app) can keep importing from `cli`.
+    return _create_agent_impl(kind)
 
 
 def _db_path() -> str:

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -81,12 +81,12 @@ Examples:
     p_new.add_argument("--agent", default=None, help="Coding agent to use (defaults to template's agent or 'claude')")
     p_new.add_argument("--template", default=None, help="Apply a template from settings.kdl")
     p_new.add_argument("--model", default=None, help="Model for the agent to use")
-    # Tri-state: default None = "no override" so a template's use-subscription
-    # value wins. Explicit --use-subscription / --no-use-subscription set
-    # True/False and beat the template. When neither CLI nor template sets
-    # the key, it's omitted from config and the agent's own default applies.
-    p_new.add_argument("--use-subscription", action="store_const", const=True, default=None, dest="use_subscription", help="Use the subscription by stripping API keys from the environment (default)")
-    p_new.add_argument("--no-use-subscription", action="store_const", const=False, dest="use_subscription", help="Pass API keys through to the agent (disables subscription use)")
+    # Tri-state: default None = "no CLI override" so lower precedence layers
+    # (template, kdl agent-block, class default) supply the value. Explicit
+    # --use-subscription / --no-use-subscription force True/False as the
+    # highest-precedence (CLI) layer.
+    p_new.add_argument("--use-subscription", action="store_const", const=True, default=None, dest="use_subscription", help="Use the subscription by stripping API keys from the environment (overrides lower layers)")
+    p_new.add_argument("--no-use-subscription", action="store_const", const=False, dest="use_subscription", help="Pass API keys through to the agent (overrides lower layers)")
     p_new.add_argument("--config", dest="config", action="append", default=[], metavar="KEY=VALUE", help="Config key=value pair (repeat for multiple)")
 
     # -- run --

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -67,9 +67,13 @@ def _build_cli_overrides(
     agent_args = parse_config(config_pairs)
     for key in agent_args:
         if key in agent_cls.ACTOR_DEFAULTS:
+            # Channel-agnostic: same validation runs for CLI `--config` and
+            # MCP `config=[...]`. Name both dedicated entrypoints so the
+            # message is useful regardless of caller.
+            param = key.replace("-", "_")
             raise ConfigError(
-                f"--config {key}={agent_args[key]}: actor-keys cannot be set "
-                f"via --config; use --{key} / --no-{key} instead."
+                f"{key} is an actor-key and cannot be set via --config / config=[...]; "
+                f"use --{key} / --no-{key} (CLI) or {param}=true/false (MCP) instead."
             )
     actor_keys: dict[str, str] = {}
     if use_subscription is not None:

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -20,8 +20,8 @@ if TYPE_CHECKING:
 from .interfaces import Agent, GitOps, LogEntry, LogEntryKind, ProcessManager, binary_exists
 from .types import (
     Actor,
+    ActorConfig,
     AgentKind,
-    Config,
     Run,
     Status,
     _now_iso,
@@ -123,7 +123,7 @@ def cmd_new(
     no_worktree: bool,
     base: Optional[str],
     agent_name: Optional[str],
-    config_pairs: List[str],
+    cli_overrides: ActorConfig,
     template_name: Optional[str] = None,
     app_config: Optional["AppConfig"] = None,
 ) -> Actor:
@@ -143,47 +143,57 @@ def cmd_new(
     if not binary_exists(agent_kind.binary_name):
         print(f"warning: '{agent_kind.binary_name}' not found on PATH", file=sys.stderr)
 
-    # Config precedence (lowest → highest):
-    #   1. Agent class defaults (ACTOR_DEFAULTS + AGENT_DEFAULTS baseline)
+    # Config precedence (lowest → highest), merged into two side-by-side
+    # dicts (actor_keys, agent_args) — the split is preserved positionally
+    # across every layer; nothing downstream reconstructs it via name lookup:
+    #   1. Agent class defaults (ACTOR_DEFAULTS / AGENT_DEFAULTS baseline)
     #   2. kdl `agent "<name>" { ... }` block for this agent_kind
-    #   3. Template config
-    #   4. CLI --config pairs
-    # Only layer 2 can carry `None` (kdl's `null` cancel marker). Layers 1,
-    # 3, and 4 are typed `Dict[str, str]` so the type system enforces that
-    # they never contribute a `None` to the merge.
+    #   3. Template config (kdl template is a flat namespace; we partition
+    #      each key here using the agent class's ACTOR_DEFAULTS whitelist)
+    #   4. CLI overrides (already structured by the CLI layer, which also
+    #      validates that `--config` keys don't collide with actor-keys)
+    # Only layer 2 can carry `None` (kdl's `null` cancel marker). The other
+    # layers are typed `Dict[str, str]` and contribute only concrete values.
     agent_cls = _agent_class(agent_kind)
-    merged: Dict[str, Optional[str]] = {}
+    merged_actor_keys: Dict[str, Optional[str]] = dict(agent_cls.ACTOR_DEFAULTS)
+    merged_agent_args: Dict[str, Optional[str]] = dict(agent_cls.AGENT_DEFAULTS)
 
-    # Layer 1: class baseline — merge actor-keys + agent-args into one flat dict.
-    merged.update(agent_cls.ACTOR_DEFAULTS)
-    merged.update(agent_cls.AGENT_DEFAULTS)
-
-    # Layer 2: kdl agent_defaults for this agent_kind (if any).
+    # Layer 2: kdl agent_defaults for this agent_kind (if any). `None` values
+    # cancel lower-precedence entries by popping them from the bucket.
     if app_config is not None:
         kdl_defaults = app_config.agent_defaults.get(agent_kind.value)
         if kdl_defaults is not None:
             for k, v in kdl_defaults.actor_keys.items():
                 if v is None:
-                    merged.pop(k, None)
+                    merged_actor_keys.pop(k, None)
                 else:
-                    merged[k] = v
+                    merged_actor_keys[k] = v
             for k, v in kdl_defaults.agent_args.items():
                 if v is None:
-                    merged.pop(k, None)
+                    merged_agent_args.pop(k, None)
                 else:
-                    merged[k] = v
+                    merged_agent_args[k] = v
 
-    # Layer 3: template config.
+    # Layer 3: template config. The kdl template namespace is flat, so we
+    # partition by checking each key against the agent's ACTOR_DEFAULTS
+    # whitelist — this is an input-boundary split, not runtime routing.
     if template is not None:
         for k, v in template.config.items():
-            merged[k] = v
+            if k in agent_cls.ACTOR_DEFAULTS:
+                merged_actor_keys[k] = v
+            else:
+                merged_agent_args[k] = v
 
-    # Layer 4: CLI pairs.
-    for k, v in parse_config(config_pairs).items():
-        merged[k] = v
+    # Layer 4: CLI overrides (already split by the CLI layer).
+    for k, v in cli_overrides.actor_keys.items():
+        merged_actor_keys[k] = v
+    for k, v in cli_overrides.agent_args.items():
+        merged_agent_args[k] = v
 
-    config: Dict[str, str] = {k: v for k, v in merged.items() if v is not None}
-    config = _sorted_config(config)
+    config = ActorConfig(
+        actor_keys=_sorted_config({k: v for k, v in merged_actor_keys.items() if v is not None}),
+        agent_args=_sorted_config({k: v for k, v in merged_agent_args.items() if v is not None}),
+    )
 
     if dir is not None:
         try:
@@ -253,7 +263,7 @@ def cmd_run(
     proc_mgr: ProcessManager,
     name: str,
     prompt: str,
-    config_pairs: List[str],
+    cli_overrides: ActorConfig,
 ) -> str:
     actor = db.get_actor(name)
 
@@ -273,12 +283,18 @@ def cmd_run(
             f"actor directory '{actor.dir}' does not exist \u2014 use 'actor discard {name}' to clean up"
         )
 
-    # Merge config: actor defaults + run overrides
-    run_overrides = parse_config(config_pairs)
-    effective_config = dict(actor.config)
-    for k, v in run_overrides.items():
-        effective_config[k] = v
-    effective_config = _sorted_config(effective_config)
+    # Merge config: actor defaults + run overrides. The split is preserved
+    # — actor_keys and agent_args are layered independently. cli_overrides
+    # is already structured by the CLI (--config pairs are agent_args only,
+    # validated at the CLI boundary).
+    merged_actor_keys = dict(actor.config.actor_keys)
+    merged_actor_keys.update(cli_overrides.actor_keys)
+    merged_agent_args = dict(actor.config.agent_args)
+    merged_agent_args.update(cli_overrides.agent_args)
+    effective_config = ActorConfig(
+        actor_keys=_sorted_config(merged_actor_keys),
+        agent_args=_sorted_config(merged_agent_args),
+    )
 
     dir_p = Path(actor.dir)
 
@@ -489,8 +505,14 @@ def cmd_show(db: Database, pm: ProcessManager, name: str, runs_limit: int) -> st
     if actor.base_branch is not None:
         output += f"Base:      {actor.base_branch}\n"
 
-    if actor.config:
-        pairs = [f"{k}={v}" for k, v in sorted(actor.config.items())]
+    # Display-only: merge both buckets for the user-facing `Config:` line.
+    # Both dicts are disjoint by construction (an ACTOR_DEFAULTS key only
+    # lands in actor_keys; everything else lands in agent_args), so the
+    # merge is lossless.
+    if actor.config.actor_keys or actor.config.agent_args:
+        flat = dict(actor.config.agent_args)
+        flat.update(actor.config.actor_keys)
+        pairs = [f"{k}={v}" for k, v in sorted(flat.items())]
         output += f"Config:    {', '.join(pairs)}\n"
 
     if actor.agent_session is not None:
@@ -595,18 +617,34 @@ def cmd_config(db: Database, name: str, config_pairs: List[str]) -> str:
     actor = db.get_actor(name)
 
     if not config_pairs:
+        # Display merged view — both dicts are disjoint by construction so
+        # the flatten for display is lossless.
+        flat = dict(actor.config.agent_args)
+        flat.update(actor.config.actor_keys)
         output = ""
-        for key, value in sorted(actor.config.items()):
+        for key, value in sorted(flat.items()):
             output += f"{key}={value}\n"
         return output
 
-    new_config = parse_config(config_pairs)
+    # Partition new pairs into actor_keys / agent_args using the actor's
+    # agent class whitelist. This is the single boundary where user-entered
+    # flat pairs get lifted into the split structure; the merge itself and
+    # all downstream layers operate positionally.
+    updates = parse_config(config_pairs)
+    agent_cls = _agent_class(actor.agent)
+    new_actor_keys = dict(actor.config.actor_keys)
+    new_agent_args = dict(actor.config.agent_args)
+    for k, v in updates.items():
+        if k in agent_cls.ACTOR_DEFAULTS:
+            new_actor_keys[k] = v
+        else:
+            new_agent_args[k] = v
+    new_config = ActorConfig(
+        actor_keys=_sorted_config(new_actor_keys),
+        agent_args=_sorted_config(new_agent_args),
+    )
 
-    merged = dict(actor.config)
-    for key, value in new_config.items():
-        merged[key] = value
-
-    db.update_actor_config(name, _sorted_config(merged))
+    db.update_actor_config(name, new_config)
 
     return f"{name} config updated"
 

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -76,13 +76,21 @@ def _format_duration(started_at: str, finished_at: Optional[str]) -> str:
     return f"{remainder}s"
 
 
-def _create_agent(kind: AgentKind) -> Agent:
-    if kind == AgentKind.CLAUDE:
-        return ClaudeAgent()
-    elif kind == AgentKind.CODEX:
-        return CodexAgent()
-    else:
+_AGENT_CLASS_BY_KIND = {
+    AgentKind.CLAUDE: ClaudeAgent,
+    AgentKind.CODEX: CodexAgent,
+}
+
+
+def _agent_class(kind: AgentKind):
+    try:
+        return _AGENT_CLASS_BY_KIND[kind]
+    except KeyError:
         raise ActorError(f"unknown agent kind: {kind}")
+
+
+def _create_agent(kind: AgentKind) -> Agent:
+    return _agent_class(kind)()
 
 
 
@@ -140,23 +148,15 @@ def cmd_new(
     #   2. kdl `agent "<name>" { ... }` block for this agent_kind
     #   3. Template config
     #   4. CLI --config pairs
-    # Nones at any layer cancel the key from the merged result (safety net
-    # for bypass paths; normally load_config's _merge has already stripped
-    # Nones from steps 1/2).
-    agent_cls = type(_create_agent(agent_kind))
+    # A `None` value at layers 2-4 cancels whatever a lower layer set.
+    # Class dicts (layer 1) never contain None — enforced by
+    # test_claude_class_constants / test_codex_class_constants.
+    agent_cls = _agent_class(agent_kind)
     merged: Dict[str, Optional[str]] = {}
 
     # Layer 1: class baseline — merge actor-keys + agent-args into one flat dict.
-    for k, v in agent_cls.ACTOR_DEFAULTS.items():
-        if v is None:
-            merged.pop(k, None)
-        else:
-            merged[k] = v
-    for k, v in agent_cls.AGENT_DEFAULTS.items():
-        if v is None:
-            merged.pop(k, None)
-        else:
-            merged[k] = v
+    merged.update(agent_cls.ACTOR_DEFAULTS)
+    merged.update(agent_cls.AGENT_DEFAULTS)
 
     # Layer 2: kdl agent_defaults for this agent_kind (if any).
     if app_config is not None:

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -148,10 +148,9 @@ def cmd_new(
     #   2. kdl `agent "<name>" { ... }` block for this agent_kind
     #   3. Template config
     #   4. CLI --config pairs
-    # Only layer 2 can carry `None` (kdl's `null` cancel marker); layers
-    # 3 and 4 come from `Dict[str, str]` sources, and layer 1's class
-    # dicts never contain `None` (pinned by
-    # test_claude_class_constants / test_codex_class_constants).
+    # Only layer 2 can carry `None` (kdl's `null` cancel marker). Layers 1,
+    # 3, and 4 are typed `Dict[str, str]` so the type system enforces that
+    # they never contribute a `None` to the merge.
     agent_cls = _agent_class(agent_kind)
     merged: Dict[str, Optional[str]] = {}
 

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -135,10 +135,54 @@ def cmd_new(
     if not binary_exists(agent_kind.binary_name):
         print(f"warning: '{agent_kind.binary_name}' not found on PATH", file=sys.stderr)
 
-    # Config precedence: template's config is the base; CLI pairs overlay on top.
-    config: Dict[str, str] = dict(template.config) if template else {}
+    # Config precedence (lowest → highest):
+    #   1. Agent class defaults (ACTOR_DEFAULTS + AGENT_DEFAULTS baseline)
+    #   2. kdl `agent "<name>" { ... }` block for this agent_kind
+    #   3. Template config
+    #   4. CLI --config pairs
+    # Nones at any layer cancel the key from the merged result (safety net
+    # for bypass paths; normally load_config's _merge has already stripped
+    # Nones from steps 1/2).
+    agent_cls = type(_create_agent(agent_kind))
+    merged: Dict[str, Optional[str]] = {}
+
+    # Layer 1: class baseline — merge actor-keys + agent-args into one flat dict.
+    for k, v in agent_cls.ACTOR_DEFAULTS.items():
+        if v is None:
+            merged.pop(k, None)
+        else:
+            merged[k] = v
+    for k, v in agent_cls.AGENT_DEFAULTS.items():
+        if v is None:
+            merged.pop(k, None)
+        else:
+            merged[k] = v
+
+    # Layer 2: kdl agent_defaults for this agent_kind (if any).
+    if app_config is not None:
+        kdl_defaults = app_config.agent_defaults.get(agent_kind.value)
+        if kdl_defaults is not None:
+            for k, v in kdl_defaults.actor_keys.items():
+                if v is None:
+                    merged.pop(k, None)
+                else:
+                    merged[k] = v
+            for k, v in kdl_defaults.agent_args.items():
+                if v is None:
+                    merged.pop(k, None)
+                else:
+                    merged[k] = v
+
+    # Layer 3: template config.
+    if template is not None:
+        for k, v in template.config.items():
+            merged[k] = v
+
+    # Layer 4: CLI pairs.
     for k, v in parse_config(config_pairs).items():
-        config[k] = v
+        merged[k] = v
+
+    config: Dict[str, str] = {k: v for k, v in merged.items() if v is not None}
     config = _sorted_config(config)
 
     if dir is not None:

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -148,9 +148,10 @@ def cmd_new(
     #   2. kdl `agent "<name>" { ... }` block for this agent_kind
     #   3. Template config
     #   4. CLI --config pairs
-    # A `None` value at layers 2-4 cancels whatever a lower layer set.
-    # Class dicts (layer 1) never contain None — enforced by
-    # test_claude_class_constants / test_codex_class_constants.
+    # Only layer 2 can carry `None` (kdl's `null` cancel marker); layers
+    # 3 and 4 come from `Dict[str, str]` sources, and layer 1's class
+    # dicts never contain `None` (pinned by
+    # test_claude_class_constants / test_codex_class_constants).
     agent_cls = _agent_class(agent_kind)
     merged: Dict[str, Optional[str]] = {}
 

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -673,16 +673,6 @@ def claude_session_file_path(dir_path, session_id: str) -> str:
     return str(ClaudeAgent._session_file_path(Path(dir_path), session_id))
 
 
-def claude_config_args(config: Config) -> List[str]:
-    """Public wrapper for ClaudeAgent._config_args."""
-    return ClaudeAgent._config_args(config)
-
-
-def codex_config_args(config: Config) -> List[str]:
-    """Public wrapper for CodexAgent._config_args."""
-    return CodexAgent._config_args(config)
-
-
 def claude_read_logs(path: str) -> List[LogEntry]:
     """Read Claude JSONL logs from a file path, returning LogEntry objects.
 

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -180,6 +180,12 @@ def _parse_template(node, source: Path) -> Template:
                 f"template '{name}' in {source}: '{key}' does not accept properties"
             )
         raw = child.args[0]
+        if raw is None:
+            raise ConfigError(
+                f"template '{name}' in {source}: '{key}' cannot be null "
+                f"(templates set values; `null` only makes sense inside "
+                f"`agent \"...\" {{ ... }}` blocks as a cancel marker)"
+            )
         if key in ("agent", "prompt") and not isinstance(raw, str):
             raise ConfigError(
                 f"template '{name}' in {source}: '{key}' must be a string"
@@ -247,6 +253,12 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, AgentDefaults]:
                 raise ConfigError(
                     f"agent '{raw_name}' in {source}: "
                     f"`defaults` block does not accept properties"
+                )
+            if not child.nodes:
+                raise ConfigError(
+                    f"agent '{raw_name}' in {source}: "
+                    f"`defaults` block must have at least one key "
+                    f"(remove the block if you meant to unset nothing)"
                 )
             seen_args: set[str] = set()
             for gc in child.nodes:
@@ -357,21 +369,16 @@ def _merge_dict(
     low: Dict[str, Optional[str]],
     high: Dict[str, Optional[str]],
 ) -> Dict[str, Optional[str]]:
-    """Per-key overlay with null-as-cancel semantics.
+    """Per-key overlay that preserves `None` as a cancel marker.
 
-    Null in `low` is filtered out (it would have cancelled something deeper,
-    but nothing is deeper at this layer). Null in `high` pops the key —
-    covering the case where project config explicitly erases a user-level
-    default."""
-    out: Dict[str, Optional[str]] = {}
-    for k, v in low.items():
-        if v is not None:
-            out[k] = v
+    Higher-layer values overwrite lower-layer values. `None` is kept in the
+    result so the kdl layer can cancel values set further down the precedence
+    ladder (specifically the class-level `AGENT_DEFAULTS` / `ACTOR_DEFAULTS`
+    baked into `cmd_new`). The actual cancel happens when `cmd_new` walks the
+    merged dict and pops any key whose value is `None`."""
+    out: Dict[str, Optional[str]] = dict(low)
     for k, v in high.items():
-        if v is None:
-            out.pop(k, None)
-        else:
-            out[k] = v
+        out[k] = v
     return out
 
 

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -157,9 +157,10 @@ def _parse_template(node, source: Path) -> Template:
         key = child.name
         if key == "defaults":
             raise ConfigError(
-                f"template '{name}' in {source}: `defaults {{ ... }}` "
-                f"blocks belong under `agent \"claude\" {{ ... }}` / "
-                f"`agent \"codex\" {{ ... }}`, not inside a template"
+                f"template '{name}' in {source}: `defaults` is reserved "
+                f"for per-agent defaults; use `agent \"claude\" {{ "
+                f"defaults {{ ... }} }}` / `agent \"codex\" {{ "
+                f"defaults {{ ... }} }}` at the top level"
             )
         if key in seen_keys:
             raise ConfigError(
@@ -266,6 +267,13 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, AgentDefaults]:
                     raise ConfigError(
                         f"agent '{raw_name}' in {source}: "
                         f"nested `defaults` block not allowed"
+                    )
+                if gc.name in whitelist:
+                    raise ConfigError(
+                        f"agent '{raw_name}' in {source}: "
+                        f"'{gc.name}' is an actor-interpreted flag and belongs "
+                        f"at the top of `agent \"{raw_name}\" {{ ... }}`, "
+                        f"not inside `defaults {{ ... }}`"
                     )
                 if gc.name in seen_args:
                     raise ConfigError(

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -401,8 +401,11 @@ def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
             actor_keys=_merge_dict(b.actor_keys, o.actor_keys),
             agent_args=_merge_dict(b.agent_args, o.agent_args),
         )
-    # Drop entries where everything cancelled out so callers can use
-    # `agent not in cfg.agent_defaults` as "no overrides from kdl".
+    # Drop entries that ended up with no keys at all (e.g. an agent block
+    # written as `agent "claude" { }`) so callers can treat
+    # `agent not in cfg.agent_defaults` as "no mention in kdl". Entries
+    # whose only values are `None` cancel markers are retained — cmd_new
+    # needs them to cancel class-level defaults.
     merged_defaults = {
         k: v for k, v in merged_defaults.items()
         if v.actor_keys or v.agent_args

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -2,22 +2,41 @@
 
 Loads ~/.actor/settings.kdl (user) and <project>/.actor/settings.kdl
 (project), merges them, and exposes the merged AppConfig with its
-templates map. Project config overrides user config on same-key conflict.
+templates map and per-agent defaults. Project config overrides user
+config per-key.
 
-Out of scope (see tickets #30 / #31 / #33): hooks, per-agent default-config
-blocks, aliases. Their nodes are skipped at parse time without error for
-forward compatibility.
+Out of scope (see tickets #30 / #33): hooks, aliases. Their nodes are
+skipped at parse time without error for forward compatibility.
 """
 from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, FrozenSet, Optional, Tuple
 
 import kdl
 
 from .errors import ConfigError
+
+
+_VALID_AGENTS: Tuple[str, ...] = ("claude", "codex")
+
+
+def _actor_keys_whitelist(agent_name: str) -> FrozenSet[str]:
+    """Return the set of valid flat (non-defaults) keys for an agent.
+
+    Deferred import so config.py stays importable before agents subpackage
+    finishes loading, and to keep the whitelist in a single source of truth
+    (the agent class's `ACTOR_DEFAULTS` dict)."""
+    from .agents.claude import ClaudeAgent
+    from .agents.codex import CodexAgent
+
+    if agent_name == "claude":
+        return frozenset(ClaudeAgent.ACTOR_DEFAULTS.keys())
+    if agent_name == "codex":
+        return frozenset(CodexAgent.ACTOR_DEFAULTS.keys())
+    return frozenset()
 
 
 @dataclass
@@ -29,8 +48,22 @@ class Template:
 
 
 @dataclass
+class AgentDefaults:
+    """Per-agent baseline from settings.kdl.
+
+    `actor_keys` are flat keys interpreted by actor-sh (e.g. env filtering).
+    `agent_args` come from the `defaults { }` sub-block and map directly to
+    the agent binary's CLI flags. Values of `None` mean "unset" — they cancel
+    a lower-precedence value during merge.
+    """
+    actor_keys: Dict[str, Optional[str]] = field(default_factory=dict)
+    agent_args: Dict[str, Optional[str]] = field(default_factory=dict)
+
+
+@dataclass
 class AppConfig:
     templates: Dict[str, Template] = field(default_factory=dict)
+    agent_defaults: Dict[str, AgentDefaults] = field(default_factory=dict)
 
 
 def _find_project_config(
@@ -89,6 +122,16 @@ def _coerce_value(value: object) -> str:
     raise ConfigError(f"unsupported KDL value type: {type(value).__name__}")
 
 
+def _coerce_value_or_none(value: object) -> Optional[str]:
+    """Like `_coerce_value` but maps KDL `null` (Python `None`) → `None`.
+
+    Only used inside `agent { }` blocks, where null explicitly means "unset"
+    and cancels a lower-precedence value during merge."""
+    if value is None:
+        return None
+    return _coerce_value(value)
+
+
 def _parse_template(node, source: Path) -> Template:
     if not node.args or not isinstance(node.args[0], str):
         raise ConfigError(
@@ -112,6 +155,12 @@ def _parse_template(node, source: Path) -> Template:
     seen_keys: set[str] = set()
     for child in node.nodes:
         key = child.name
+        if key == "defaults":
+            raise ConfigError(
+                f"template '{name}' in {source}: `defaults {{ ... }}` "
+                f"blocks belong under `agent \"claude\" {{ ... }}` / "
+                f"`agent \"codex\" {{ ... }}`, not inside a template"
+            )
         if key in seen_keys:
             raise ConfigError(
                 f"template '{name}' in {source}: duplicate key '{key}'"
@@ -145,6 +194,135 @@ def _parse_template(node, source: Path) -> Template:
     return tpl
 
 
+def _parse_agent_block(node, source: Path) -> Tuple[str, AgentDefaults]:
+    """Parse an `agent "<name>" { ... }` node.
+
+    Shape: flat children are actor-keys (whitelisted against the agent's
+    `ACTOR_DEFAULTS`), a single nested `defaults { ... }` block holds
+    agent-arg keys, and null values survive as Python `None` so the merge
+    step can use them to cancel lower-precedence values."""
+    if not node.args:
+        raise ConfigError(
+            f"agent block in {source} must have a name "
+            f"(e.g. `agent \"claude\" {{ ... }}`)"
+        )
+    if len(node.args) > 1:
+        raise ConfigError(
+            f"agent block in {source} has extra positional args"
+        )
+    raw_name = node.args[0]
+    if not isinstance(raw_name, str) or not raw_name:
+        raise ConfigError(
+            f"agent block in {source} must have a non-empty string name"
+        )
+    if getattr(node, "props", None):
+        raise ConfigError(
+            f"agent '{raw_name}' in {source} does not accept properties"
+        )
+    if raw_name not in _VALID_AGENTS:
+        raise ConfigError(
+            f"unknown agent '{raw_name}' in {source} "
+            f"(valid: {', '.join(_VALID_AGENTS)})"
+        )
+
+    whitelist = _actor_keys_whitelist(raw_name)
+    defaults = AgentDefaults()
+    seen_flat: set[str] = set()
+    seen_defaults_block = False
+    for child in node.nodes:
+        key = child.name
+        if key == "defaults":
+            if seen_defaults_block:
+                raise ConfigError(
+                    f"agent '{raw_name}' in {source}: "
+                    f"duplicate `defaults` block"
+                )
+            seen_defaults_block = True
+            if child.args:
+                raise ConfigError(
+                    f"agent '{raw_name}' in {source}: "
+                    f"`defaults` block must not have positional args"
+                )
+            if getattr(child, "props", None):
+                raise ConfigError(
+                    f"agent '{raw_name}' in {source}: "
+                    f"`defaults` block does not accept properties"
+                )
+            seen_args: set[str] = set()
+            for gc in child.nodes:
+                if gc.name == "defaults":
+                    raise ConfigError(
+                        f"agent '{raw_name}' in {source}: "
+                        f"nested `defaults` block not allowed"
+                    )
+                if gc.name in seen_args:
+                    raise ConfigError(
+                        f"agent '{raw_name}' in {source}: "
+                        f"duplicate defaults key '{gc.name}'"
+                    )
+                seen_args.add(gc.name)
+                if not gc.args:
+                    raise ConfigError(
+                        f"agent '{raw_name}' in {source}: "
+                        f"defaults key '{gc.name}' needs a value "
+                        f"(use `null` to unset)"
+                    )
+                if len(gc.args) > 1:
+                    raise ConfigError(
+                        f"agent '{raw_name}' in {source}: "
+                        f"defaults key '{gc.name}' has extra args"
+                    )
+                if getattr(gc, "props", None):
+                    raise ConfigError(
+                        f"agent '{raw_name}' in {source}: "
+                        f"defaults key '{gc.name}' does not accept properties"
+                    )
+                if gc.nodes:
+                    raise ConfigError(
+                        f"agent '{raw_name}' in {source}: "
+                        f"defaults key '{gc.name}' must be a leaf value, "
+                        f"not a block"
+                    )
+                defaults.agent_args[gc.name] = _coerce_value_or_none(gc.args[0])
+        else:
+            if key in seen_flat:
+                raise ConfigError(
+                    f"agent '{raw_name}' in {source}: "
+                    f"duplicate key '{key}'"
+                )
+            seen_flat.add(key)
+            if key not in whitelist:
+                valid = ", ".join(sorted(whitelist)) if whitelist else "(none)"
+                raise ConfigError(
+                    f"agent '{raw_name}' in {source}: "
+                    f"unknown flat key '{key}' "
+                    f"(valid flat keys: {valid}; agent CLI flags belong "
+                    f"under `defaults {{ ... }}`)"
+                )
+            if not child.args:
+                raise ConfigError(
+                    f"agent '{raw_name}' in {source}: "
+                    f"'{key}' needs a value (use `null` to unset)"
+                )
+            if len(child.args) > 1:
+                raise ConfigError(
+                    f"agent '{raw_name}' in {source}: "
+                    f"'{key}' has extra args"
+                )
+            if getattr(child, "props", None):
+                raise ConfigError(
+                    f"agent '{raw_name}' in {source}: "
+                    f"'{key}' does not accept properties"
+                )
+            if child.nodes:
+                raise ConfigError(
+                    f"agent '{raw_name}' in {source}: "
+                    f"'{key}' must be a leaf value, not a block"
+                )
+            defaults.actor_keys[key] = _coerce_value_or_none(child.args[0])
+    return raw_name, defaults
+
+
 def _parse_kdl_file(path: Path) -> AppConfig:
     try:
         text = path.read_text()
@@ -163,15 +341,61 @@ def _parse_kdl_file(path: Path) -> AppConfig:
                     f"duplicate template '{tpl.name}' in {path}"
                 )
             cfg.templates[tpl.name] = tpl
-        # Silently ignore hooks / agent / alias — those belong to follow-up
-        # tickets #30 / #31 / #33 and are not implemented here.
+        elif node.name == "agent":
+            name, defaults = _parse_agent_block(node, path)
+            if name in cfg.agent_defaults:
+                raise ConfigError(
+                    f"duplicate agent block '{name}' in {path}"
+                )
+            cfg.agent_defaults[name] = defaults
+        # Silently ignore hooks / alias — those belong to follow-up
+        # tickets #30 / #33 and are not implemented here.
     return cfg
+
+
+def _merge_dict(
+    low: Dict[str, Optional[str]],
+    high: Dict[str, Optional[str]],
+) -> Dict[str, Optional[str]]:
+    """Per-key overlay with null-as-cancel semantics.
+
+    Null in `low` is filtered out (it would have cancelled something deeper,
+    but nothing is deeper at this layer). Null in `high` pops the key —
+    covering the case where project config explicitly erases a user-level
+    default."""
+    out: Dict[str, Optional[str]] = {}
+    for k, v in low.items():
+        if v is not None:
+            out[k] = v
+    for k, v in high.items():
+        if v is None:
+            out.pop(k, None)
+        else:
+            out[k] = v
+    return out
 
 
 def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
     merged_templates = dict(base.templates)
     merged_templates.update(over.templates)
-    return AppConfig(templates=merged_templates)
+    merged_defaults: Dict[str, AgentDefaults] = {}
+    for agent in set(base.agent_defaults) | set(over.agent_defaults):
+        b = base.agent_defaults.get(agent, AgentDefaults())
+        o = over.agent_defaults.get(agent, AgentDefaults())
+        merged_defaults[agent] = AgentDefaults(
+            actor_keys=_merge_dict(b.actor_keys, o.actor_keys),
+            agent_args=_merge_dict(b.agent_args, o.agent_args),
+        )
+    # Drop entries where everything cancelled out so callers can use
+    # `agent not in cfg.agent_defaults` as "no overrides from kdl".
+    merged_defaults = {
+        k: v for k, v in merged_defaults.items()
+        if v.actor_keys or v.agent_args
+    }
+    return AppConfig(
+        templates=merged_templates,
+        agent_defaults=merged_defaults,
+    )
 
 
 def load_config(

--- a/src/actor/db.py
+++ b/src/actor/db.py
@@ -9,13 +9,49 @@ from .errors import ActorError, AlreadyExistsError, NotFoundError
 from .interfaces import ProcessManager
 from .types import (
     Actor,
+    ActorConfig,
     AgentKind,
-    Config,
     Run,
     Status,
     _now_iso,
     _sorted_config,
 )
+
+
+def _actor_config_to_json(cfg: ActorConfig) -> str:
+    """Serialize an ActorConfig to the on-disk JSON shape.
+
+    Shape: `{"actor_keys": {...}, "agent_args": {...}}` — mirrors the
+    dataclass fields 1:1. Both sub-dicts are stored sorted so rows are
+    deterministic and diff-friendly when inspected.
+
+    This is a breaking schema change vs. the pre-refactor flat dict. There
+    is no migration — the repo is pre-1.0 and the refactor directive
+    accepts a hard break of existing `~/.actor/actor.db` files."""
+    return json.dumps({
+        "actor_keys": _sorted_config(cfg.actor_keys),
+        "agent_args": _sorted_config(cfg.agent_args),
+    })
+
+
+def _json_to_actor_config(s: str) -> ActorConfig:
+    """Deserialize the JSON column back into an ActorConfig.
+
+    Missing sub-dicts default to empty, so a row stamped as the legacy
+    empty dict `"{}"` yields `ActorConfig()` rather than blowing up. Any
+    other unexpected shape (e.g. non-dict sub-fields) raises via the
+    dataclass constructor."""
+    if not s:
+        return ActorConfig()
+    data = json.loads(s)
+    if not isinstance(data, dict):
+        raise ActorError(f"config JSON must be a dict, got {type(data).__name__}")
+    actor_keys = data.get("actor_keys", {}) or {}
+    agent_args = data.get("agent_args", {}) or {}
+    return ActorConfig(
+        actor_keys=_sorted_config(actor_keys),
+        agent_args=_sorted_config(agent_args),
+    )
 
 
 class Database:
@@ -86,7 +122,7 @@ class Database:
     # -- Actor CRUD --
 
     def insert_actor(self, actor: Actor) -> None:
-        config_json = json.dumps(_sorted_config(actor.config))
+        config_json = _actor_config_to_json(actor.config)
         try:
             self._conn.execute(
                 """INSERT INTO actors
@@ -167,8 +203,8 @@ class Database:
         if cur.rowcount == 0:
             raise NotFoundError(name)
 
-    def update_actor_config(self, name: str, config: Config) -> None:
-        config_json = json.dumps(_sorted_config(config))
+    def update_actor_config(self, name: str, config: ActorConfig) -> None:
+        config_json = _actor_config_to_json(config)
         now = _now_iso()
         cur = self._conn.execute(
             "UPDATE actors SET config = ?, updated_at = ? WHERE name = ?",
@@ -181,7 +217,7 @@ class Database:
     # -- Run CRUD --
 
     def insert_run(self, run: Run) -> int:
-        config_json = json.dumps(_sorted_config(run.config))
+        config_json = _actor_config_to_json(run.config)
         cur = self._conn.execute(
             """INSERT INTO runs
                (actor_name, prompt, status, exit_code, pid, config, started_at, finished_at)
@@ -274,7 +310,6 @@ class Database:
 
     @staticmethod
     def _row_to_actor(row: tuple) -> Actor:
-        config: Config = json.loads(row[8]) if row[8] else {}
         return Actor(
             name=row[0],
             agent=AgentKind.from_str(row[1]),
@@ -284,14 +319,13 @@ class Database:
             base_branch=row[5],
             worktree=bool(row[6]),
             parent=row[7],
-            config=_sorted_config(config),
+            config=_json_to_actor_config(row[8]),
             created_at=row[9],
             updated_at=row[10],
         )
 
     @staticmethod
     def _row_to_run(row: tuple) -> Run:
-        config: Config = json.loads(row[6]) if row[6] else {}
         return Run(
             id=row[0],
             actor_name=row[1],
@@ -299,7 +333,7 @@ class Database:
             status=Status.from_str(row[3]),
             exit_code=row[4],
             pid=row[5],
-            config=_sorted_config(config),
+            config=_json_to_actor_config(row[6]),
             started_at=row[7],
             finished_at=row[8],
         )

--- a/src/actor/interfaces.py
+++ b/src/actor/interfaces.py
@@ -5,7 +5,7 @@ import shutil
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple
 
 from .types import Config
 
@@ -29,6 +29,32 @@ class LogEntry:
 
 
 class Agent(abc.ABC):
+    # Per-agent defaults split. Subclasses fill these in.
+    #
+    # Keys in ACTOR_DEFAULTS are interpreted by actor-sh (e.g. env filtering)
+    # and are NEVER passed to the agent binary. Keys in AGENT_DEFAULTS live
+    # under `defaults { }` in settings.kdl and map straight to CLI flags.
+    AGENT_DEFAULTS: Dict[str, Optional[str]] = {}
+    ACTOR_DEFAULTS: Dict[str, Optional[str]] = {}
+
+    @abc.abstractmethod
+    def emit_agent_args(self, defaults: Config) -> List[str]:
+        """Turn the resolved `defaults { }` dict into CLI flags."""
+
+    @abc.abstractmethod
+    def apply_actor_keys(
+        self, flat: Config, env: Mapping[str, str]
+    ) -> Dict[str, str]:
+        """Return a NEW env dict with actor-key side effects applied
+        (e.g. stripping API keys)."""
+
+    def _split_config(self, config: Config) -> Tuple[Config, Config]:
+        """Partition a flat config dict into (actor_keys, agent_args)
+        using this agent's ACTOR_DEFAULTS whitelist."""
+        actor_keys = {k: v for k, v in config.items() if k in self.ACTOR_DEFAULTS}
+        agent_args = {k: v for k, v in config.items() if k not in self.ACTOR_DEFAULTS}
+        return actor_keys, agent_args
+
     @abc.abstractmethod
     def start(self, dir: Path, prompt: str, config: Config) -> Tuple[int, Optional[str]]:
         """Start a new agent session. Returns (pid, optional session_id)."""

--- a/src/actor/interfaces.py
+++ b/src/actor/interfaces.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Mapping, Optional, Tuple
 
-from .types import Config
+from .types import ActorConfig
 
 
 class LogEntryKind(Enum):
@@ -29,40 +29,40 @@ class LogEntry:
 
 
 class Agent(abc.ABC):
-    # Per-agent defaults split. Subclasses fill these in.
+    # Per-agent defaults. Subclasses fill these in.
     #
-    # Keys in ACTOR_DEFAULTS are interpreted by actor-sh (e.g. env filtering)
-    # and are NEVER passed to the agent binary. Keys in AGENT_DEFAULTS live
-    # under `defaults { }` in settings.kdl and map straight to CLI flags.
-    # Values are always concrete strings — `None` is a kdl-layer-only cancel
-    # marker and never appears in class-level defaults.
+    # These are used for two purposes only:
+    #   1. Hardcoded baseline defaults merged at actor creation time.
+    #   2. Validation whitelist — at the CLI layer, `--config key=value`
+    #      whose key appears in ACTOR_DEFAULTS is rejected (actor-keys
+    #      have dedicated flags).
+    #
+    # They are NOT used as a runtime routing table. Once an ActorConfig
+    # exists, `cfg.actor_keys` and `cfg.agent_args` carry the split
+    # positionally; nothing downstream looks keys up by name.
+    #
+    # Values are always concrete strings — `None` is a kdl-layer-only
+    # cancel marker and never appears in class-level defaults.
     AGENT_DEFAULTS: Dict[str, str] = {}
     ACTOR_DEFAULTS: Dict[str, str] = {}
 
     @abc.abstractmethod
-    def emit_agent_args(self, defaults: Config) -> List[str]:
-        """Turn the resolved `defaults { }` dict into CLI flags."""
+    def emit_agent_args(self, defaults: Dict[str, str]) -> List[str]:
+        """Turn the agent_args dict into CLI flags for the agent binary."""
 
     @abc.abstractmethod
     def apply_actor_keys(
-        self, flat: Config, env: Mapping[str, str]
+        self, actor_keys: Dict[str, str], env: Mapping[str, str]
     ) -> Dict[str, str]:
         """Return a NEW env dict with actor-key side effects applied
         (e.g. stripping API keys)."""
 
-    def _split_config(self, config: Config) -> Tuple[Config, Config]:
-        """Partition a flat config dict into (actor_keys, agent_args)
-        using this agent's ACTOR_DEFAULTS whitelist."""
-        actor_keys = {k: v for k, v in config.items() if k in self.ACTOR_DEFAULTS}
-        agent_args = {k: v for k, v in config.items() if k not in self.ACTOR_DEFAULTS}
-        return actor_keys, agent_args
-
     @abc.abstractmethod
-    def start(self, dir: Path, prompt: str, config: Config) -> Tuple[int, Optional[str]]:
+    def start(self, dir: Path, prompt: str, config: ActorConfig) -> Tuple[int, Optional[str]]:
         """Start a new agent session. Returns (pid, optional session_id)."""
 
     @abc.abstractmethod
-    def resume(self, dir: Path, session_id: str, prompt: str, config: Config) -> int:
+    def resume(self, dir: Path, session_id: str, prompt: str, config: ActorConfig) -> int:
         """Resume an existing session with a new prompt. Returns pid."""
 
     @abc.abstractmethod
@@ -78,7 +78,7 @@ class Agent(abc.ABC):
         """Kill a running agent process."""
 
     @abc.abstractmethod
-    def interactive_argv(self, session_id: str, config: Config) -> List[str]:
+    def interactive_argv(self, session_id: str, config: ActorConfig) -> List[str]:
         """Argv to launch an interactive session (TTY / PTY). No prompt."""
 
 

--- a/src/actor/interfaces.py
+++ b/src/actor/interfaces.py
@@ -34,8 +34,10 @@ class Agent(abc.ABC):
     # Keys in ACTOR_DEFAULTS are interpreted by actor-sh (e.g. env filtering)
     # and are NEVER passed to the agent binary. Keys in AGENT_DEFAULTS live
     # under `defaults { }` in settings.kdl and map straight to CLI flags.
-    AGENT_DEFAULTS: Dict[str, Optional[str]] = {}
-    ACTOR_DEFAULTS: Dict[str, Optional[str]] = {}
+    # Values are always concrete strings — `None` is a kdl-layer-only cancel
+    # marker and never appears in class-level defaults.
+    AGENT_DEFAULTS: Dict[str, str] = {}
+    ACTOR_DEFAULTS: Dict[str, str] = {}
 
     @abc.abstractmethod
     def emit_agent_args(self, defaults: Config) -> List[str]:

--- a/src/actor/server.py
+++ b/src/actor/server.py
@@ -224,6 +224,7 @@ def new_actor(
     base: str | None = None,
     no_worktree: bool = False,
     config: List[str] | None = None,
+    use_subscription: bool | None = None,
     ctx: Context | None = None,
 ) -> str:
     """Create a new actor. If a prompt is given, also runs it in the background.
@@ -236,16 +237,23 @@ def new_actor(
         base: Branch to create the worktree from (defaults to current branch).
         no_worktree: If True, skip worktree creation.
         config: Config key=value pairs saved as actor defaults (e.g. ["model=opus", "effort=max"]).
+            Agent-args only; actor-keys like "use-subscription" are rejected here — use the
+            dedicated parameter below.
+        use_subscription: When True, force subscription auth (strip the agent's API key env var).
+            When False, pass the API key through. When omitted (None), defer to lower-precedence
+            layers (template / settings.kdl / class default).
     """
     db = _db()
     git = RealGit()
-    # MCP exposes `config` as a flat list of key=value pairs, just like the
-    # CLI's `--config`. Route them into agent_args only (actor-keys would
-    # need dedicated MCP params, which we don't expose yet) and validate
-    # against the chosen agent's ACTOR_DEFAULTS whitelist.
+    # MCP mirrors the CLI's positional split: `config` pairs go into
+    # agent_args (rejected if they collide with an actor-key); the dedicated
+    # `use_subscription` param populates actor_keys directly. Validation
+    # and bucketing are the same code path as the CLI.
     agent_kind = _resolve_agent_kind_for_cli(agent, None, None)
     agent_cls = _agent_class(agent_kind)
-    cli_overrides = _build_cli_overrides(agent_cls, config or [])
+    cli_overrides = _build_cli_overrides(
+        agent_cls, config or [], use_subscription=use_subscription,
+    )
     actor = cmd_new(
         db, git,
         name=name,
@@ -274,6 +282,7 @@ def run_actor(
     name: str,
     prompt: str,
     config: List[str] | None = None,
+    use_subscription: bool | None = None,
     ctx: Context | None = None,
 ) -> str:
     """Run an existing actor with a prompt. Returns immediately — the actor runs in the background.
@@ -281,16 +290,24 @@ def run_actor(
     Args:
         name: Actor name.
         prompt: The task for the actor to work on.
-        config: Per-run config overrides (e.g. ["model=opus"]). Not saved to actor defaults — use config_actor to change defaults.
+        config: Per-run config overrides (e.g. ["model=opus"]). Not saved to actor defaults — use config_actor
+            to change defaults. Agent-args only; actor-keys like "use-subscription" are rejected here —
+            use the dedicated parameter below.
+        use_subscription: Per-run actor-key override. When True, force subscription auth for this run
+            (strip the agent's API key env var). When False, pass the API key through. When omitted
+            (None), use the actor's stored value.
     """
     prompt = prompt.strip()
     if not prompt:
         raise ActorError("prompt is required")
-    # Validate MCP `config` pairs against the actor's agent — run-time
-    # overrides are agent_args only.
+    # MCP mirrors the CLI's positional split: `config` pairs go into
+    # agent_args (rejected if they collide with an actor-key); the dedicated
+    # `use_subscription` param populates actor_keys directly.
     actor = _db().get_actor(name)
     agent_cls = _agent_class(actor.agent)
-    cli_overrides = _build_cli_overrides(agent_cls, config or [])
+    cli_overrides = _build_cli_overrides(
+        agent_cls, config or [], use_subscription=use_subscription,
+    )
     _spawn_background_run(name, prompt, cli_overrides=cli_overrides, ctx=ctx)
     return f"Actor '{name}' is running."
 

--- a/src/actor/server.py
+++ b/src/actor/server.py
@@ -19,7 +19,9 @@ from .db import Database
 from .errors import ActorError
 from .git import RealGit
 from .process import RealProcessManager
+from .types import ActorConfig
 from .commands import (
+    _agent_class,
     cmd_config,
     cmd_discard,
     cmd_list,
@@ -29,7 +31,7 @@ from .commands import (
     cmd_show,
     cmd_stop,
 )
-from .cli import _db_path, _create_agent
+from .cli import _build_cli_overrides, _db_path, _create_agent, _resolve_agent_kind_for_cli
 
 
 class ActorMCP(FastMCP):
@@ -165,7 +167,7 @@ def config_actor(name: str, pairs: List[str] | None = None) -> str:
 def _spawn_background_run(
     name: str,
     prompt: str,
-    config_pairs: list[str],
+    cli_overrides: ActorConfig,
     ctx: Context | None,
 ) -> None:
     """Kick off a run in a background thread; send a channel notification when it finishes."""
@@ -187,7 +189,7 @@ def _spawn_background_run(
                 thread_db, agent_impl, pm,
                 name=name,
                 prompt=prompt,
-                config_pairs=config_pairs,
+                cli_overrides=cli_overrides,
             )
         except Exception as e:
             output = str(e)
@@ -237,6 +239,13 @@ def new_actor(
     """
     db = _db()
     git = RealGit()
+    # MCP exposes `config` as a flat list of key=value pairs, just like the
+    # CLI's `--config`. Route them into agent_args only (actor-keys would
+    # need dedicated MCP params, which we don't expose yet) and validate
+    # against the chosen agent's ACTOR_DEFAULTS whitelist.
+    agent_kind = _resolve_agent_kind_for_cli(agent, None, None)
+    agent_cls = _agent_class(agent_kind)
+    cli_overrides = _build_cli_overrides(agent_cls, config or [])
     actor = cmd_new(
         db, git,
         name=name,
@@ -244,14 +253,14 @@ def new_actor(
         no_worktree=no_worktree,
         base=base,
         agent_name=agent,
-        config_pairs=config or [],
+        cli_overrides=cli_overrides,
     )
 
     if prompt is not None:
         prompt = prompt.strip()
     if prompt:
         try:
-            _spawn_background_run(name, prompt, config_pairs=[], ctx=ctx)
+            _spawn_background_run(name, prompt, cli_overrides=ActorConfig(), ctx=ctx)
         except Exception as e:
             print(f"[actor-mcp] new_actor '{name}' run failed to start: {e}", file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
@@ -277,7 +286,12 @@ def run_actor(
     prompt = prompt.strip()
     if not prompt:
         raise ActorError("prompt is required")
-    _spawn_background_run(name, prompt, config_pairs=config or [], ctx=ctx)
+    # Validate MCP `config` pairs against the actor's agent — run-time
+    # overrides are agent_args only.
+    actor = _db().get_actor(name)
+    agent_cls = _agent_class(actor.agent)
+    cli_overrides = _build_cli_overrides(agent_cls, config or [])
+    _spawn_background_run(name, prompt, cli_overrides=cli_overrides, ctx=ctx)
     return f"Actor '{name}' is running."
 
 

--- a/src/actor/types.py
+++ b/src/actor/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List, Optional
@@ -55,13 +55,30 @@ class Status(Enum):
         return self.value
 
 
-# Config is a sorted dict (matching Rust BTreeMap)
-Config = Dict[str, str]
-
-
 def _sorted_config(d: Dict[str, str]) -> Dict[str, str]:
     """Return a dict sorted by key (matching BTreeMap behavior)."""
     return dict(sorted(d.items()))
+
+
+@dataclass(frozen=True)
+class ActorConfig:
+    """Structured config for an actor, with actor_keys separated from agent_args.
+
+    - actor_keys: keys interpreted by actor-sh (e.g. use-subscription).
+      Never forwarded to the agent binary. Whitelist lives on the Agent
+      subclass as ACTOR_DEFAULTS.
+    - agent_args: keys that become CLI flags on the agent binary.
+
+    Both dicts contain concrete strings. None values (kdl-layer cancel
+    markers) are stripped before an ActorConfig is constructed — they do
+    not appear in this type.
+
+    Keys are sorted (matching Rust BTreeMap semantics) — callers that
+    construct ActorConfig should pass sorted dicts (use _sorted_config)
+    or rely on the stored order being sorted already.
+    """
+    actor_keys: Dict[str, str] = field(default_factory=dict)
+    agent_args: Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -74,7 +91,7 @@ class Actor:
     base_branch: Optional[str]
     worktree: bool
     parent: Optional[str]
-    config: Config
+    config: ActorConfig
     created_at: str
     updated_at: str
 
@@ -87,7 +104,7 @@ class Run:
     status: Status
     exit_code: Optional[int]
     pid: Optional[int]
-    config: Config
+    config: ActorConfig
     started_at: str
     finished_at: Optional[str]
 
@@ -108,9 +125,17 @@ def validate_name(name: str) -> None:
         raise InvalidNameError(f"'{name}' is a reserved name")
 
 
-def parse_config(pairs: List[str]) -> Config:
-    """Parse config pairs into a dict. Supports key=value and bare keys (boolean flags)."""
-    config: Config = {}
+def parse_config(pairs: List[str]) -> Dict[str, str]:
+    """Parse `key=value` pairs (CLI `--config`) into a sorted dict. Supports
+    bare keys (boolean flags) as `key=""`.
+
+    The returned dict is intended for ActorConfig.agent_args — `--config`
+    may only set agent-binary flags. actor-keys (like `use-subscription`)
+    have dedicated CLI flags and must not flow through `--config`. The CLI
+    layer is responsible for validating that keys here are not in the
+    chosen agent's ACTOR_DEFAULTS whitelist.
+    """
+    config: Dict[str, str] = {}
     for pair in pairs:
         idx = pair.find("=")
         if idx == -1:

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -298,7 +298,8 @@ class ActorWatchApp(App):
 
         status = self._prev_statuses.get(actor.name, Status.IDLE)
         info = self.query_one("#info-content", Static)
-        config_str = "\n".join(f"  {k}={v}" for k, v in sorted(actor.config.items())) if actor.config else "  (none)"
+        flat_config = {**actor.config.agent_args, **actor.config.actor_keys}
+        config_str = "\n".join(f"  {k}={v}" for k, v in sorted(flat_config.items())) if flat_config else "  (none)"
         info.update(
             f"Name:      {actor.name}\n"
             f"Agent:     {actor.agent.value}\n"
@@ -547,7 +548,7 @@ class ActorWatchApp(App):
                     agent=_create_agent(actor.agent),
                     session_id=actor.agent_session,
                     cwd=Path(actor.dir),
-                    config=dict(actor.config),
+                    config=actor.config,
                 )
             except Exception as e:
                 self.notify(f"failed to start interactive session: {e}", severity="error")

--- a/src/actor/watch/interactive/manager.py
+++ b/src/actor/watch/interactive/manager.py
@@ -16,7 +16,7 @@ from typing import Callable, Dict, List, Optional
 from ...commands import INTERACTIVE_PROMPT
 from ...db import Database
 from ...interfaces import Agent
-from ...types import Run, Status, _now_iso
+from ...types import ActorConfig, Run, Status, _now_iso
 from .diagnostics import DiagnosticRecorder, EventKind
 from .pty_session import PtySession
 from .screen import TerminalScreen
@@ -70,7 +70,7 @@ class InteractiveSessionManager:
         agent: Agent,
         session_id: str,
         cwd: Path,
-        config: dict,
+        config: ActorConfig,
     ) -> InteractiveSession:
         """Spawn a new interactive session for the given actor.
 
@@ -182,7 +182,7 @@ class InteractiveSessionManager:
 
     # -- DB integration ----------------------------------------------------
 
-    def _insert_run(self, actor_name: str, config: dict) -> int:
+    def _insert_run(self, actor_name: str, config: ActorConfig) -> int:
         with self._db_opener() as db:
             run = Run(
                 id=0,
@@ -191,7 +191,7 @@ class InteractiveSessionManager:
                 status=Status.RUNNING,
                 exit_code=None,
                 pid=None,
-                config=dict(config),
+                config=config,
                 started_at=_now_iso(),
                 finished_at=None,
             )

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -2312,13 +2312,6 @@ class TestClaudeAgent(unittest.TestCase):
             ["--verbose"],
         )
 
-    def test_emit_agent_args_skips_none_values(self):
-        from actor.agents.claude import ClaudeAgent
-        self.assertEqual(
-            ClaudeAgent().emit_agent_args({"model": "opus", "effort": None}),
-            ["--model", "opus"],
-        )
-
     def test_apply_actor_keys_strips_anthropic_key_by_default(self):
         from actor.agents.claude import ClaudeAgent
         env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "secret"}
@@ -2555,13 +2548,6 @@ class TestCodexAgent(unittest.TestCase):
         self.assertEqual(CodexAgent().emit_agent_args({"x": ""}), ["-x"])
         self.assertEqual(
             CodexAgent().emit_agent_args({"verbose": ""}), ["--verbose"]
-        )
-
-    def test_emit_agent_args_skips_none_values(self):
-        from actor.agents.codex import CodexAgent
-        self.assertEqual(
-            CodexAgent().emit_agent_args({"m": "o3", "a": None}),
-            ["-m", "o3"],
         )
 
     def test_apply_actor_keys_strips_openai_key_by_default(self):

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -2312,6 +2312,16 @@ class TestClaudeAgent(unittest.TestCase):
             ["--verbose"],
         )
 
+    def test_emit_agent_args_skips_none_values(self):
+        """Defensive: the resolver in cmd_new strips `None` cancel markers,
+        but emit_agent_args must also drop them so a misrouted caller can't
+        feed `None` into subprocess.Popen."""
+        from actor.agents.claude import ClaudeAgent
+        args = ClaudeAgent().emit_agent_args(
+            {"model": "sonnet", "permission-mode": None}  # type: ignore[dict-item]
+        )
+        self.assertEqual(args, ["--model", "sonnet"])
+
     def test_apply_actor_keys_strips_anthropic_key_by_default(self):
         from actor.agents.claude import ClaudeAgent
         env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "secret"}
@@ -2549,6 +2559,16 @@ class TestCodexAgent(unittest.TestCase):
         self.assertEqual(
             CodexAgent().emit_agent_args({"verbose": ""}), ["--verbose"]
         )
+
+    def test_emit_agent_args_skips_none_values(self):
+        """Defensive: the resolver in cmd_new strips `None` cancel markers,
+        but emit_agent_args must also drop them so a misrouted caller can't
+        feed `None` into subprocess.Popen."""
+        from actor.agents.codex import CodexAgent
+        args = CodexAgent().emit_agent_args(
+            {"m": "o3", "sandbox": None}  # type: ignore[dict-item]
+        )
+        self.assertEqual(args, ["-m", "o3"])
 
     def test_apply_actor_keys_strips_openai_key_by_default(self):
         from actor.agents.codex import CodexAgent

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -707,6 +707,198 @@ class TestCmdNewTemplate(unittest.TestCase):
         self.assertEqual(actor.agent, AgentKind.CLAUDE)
 
 
+class TestCmdNewAgentDefaults(unittest.TestCase):
+    """Precedence ladder: class defaults -> kdl agent_defaults ->
+    template -> CLI."""
+
+    def _db(self) -> Database:
+        return Database.open(":memory:")
+
+    def test_class_defaults_applied_when_nothing_else_sets_key(self):
+        from actor import AppConfig
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="bar",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=[],
+            template_name=None,
+            app_config=AppConfig(),
+        )
+        self.assertEqual(actor.config.get("permission-mode"), "auto")
+        self.assertEqual(actor.config.get("use-subscription"), "true")
+
+    def test_class_defaults_applied_when_app_config_is_none(self):
+        # Callers that don't pass app_config (e.g. older integration paths)
+        # should still get class-level defaults.
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="bar2",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=[],
+        )
+        self.assertEqual(actor.config.get("permission-mode"), "auto")
+        self.assertEqual(actor.config.get("use-subscription"), "true")
+
+    def test_class_defaults_apply_to_codex(self):
+        from actor import AppConfig
+        db = self._db()
+        git = FakeGit()
+        actor = cmd_new(
+            db, git,
+            name="c",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="codex",
+            config_pairs=[],
+            app_config=AppConfig(),
+        )
+        self.assertEqual(actor.config.get("sandbox"), "danger-full-access")
+        self.assertEqual(actor.config.get("a"), "never")
+        self.assertEqual(actor.config.get("use-subscription"), "true")
+
+    def test_kdl_agent_defaults_override_class_defaults(self):
+        from actor import AgentDefaults, AppConfig
+        db = self._db()
+        git = FakeGit()
+        app = AppConfig(
+            agent_defaults={
+                "claude": AgentDefaults(
+                    actor_keys={"use-subscription": "false"},
+                    agent_args={"permission-mode": "plan", "model": "opus"},
+                ),
+            },
+        )
+        actor = cmd_new(
+            db, git,
+            name="foo",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=[],
+            app_config=app,
+        )
+        self.assertEqual(actor.config.get("use-subscription"), "false")
+        self.assertEqual(actor.config.get("permission-mode"), "plan")
+        self.assertEqual(actor.config.get("model"), "opus")
+
+    def test_kdl_null_cancels_class_default(self):
+        from actor import AgentDefaults, AppConfig
+        db = self._db()
+        git = FakeGit()
+        app = AppConfig(
+            agent_defaults={
+                "claude": AgentDefaults(
+                    agent_args={"permission-mode": None},
+                ),
+            },
+        )
+        actor = cmd_new(
+            db, git,
+            name="n",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=[],
+            app_config=app,
+        )
+        self.assertNotIn("permission-mode", actor.config)
+        # Other class defaults still apply.
+        self.assertEqual(actor.config.get("use-subscription"), "true")
+
+    def test_template_overrides_kdl_agent_defaults(self):
+        from actor import AgentDefaults, AppConfig, Template
+        db = self._db()
+        git = FakeGit()
+        app = AppConfig(
+            templates={
+                "qa": Template(name="qa", config={"permission-mode": "plan"}),
+            },
+            agent_defaults={
+                "claude": AgentDefaults(agent_args={"permission-mode": "auto"}),
+            },
+        )
+        actor = cmd_new(
+            db, git,
+            name="t",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=[],
+            template_name="qa",
+            app_config=app,
+        )
+        self.assertEqual(actor.config.get("permission-mode"), "plan")
+
+    def test_cli_overrides_template_over_kdl_over_class_defaults(self):
+        from actor import AgentDefaults, AppConfig, Template
+        db = self._db()
+        git = FakeGit()
+        app = AppConfig(
+            templates={
+                "qa": Template(
+                    name="qa",
+                    config={"permission-mode": "plan", "extra": "tpl"},
+                ),
+            },
+            agent_defaults={
+                "claude": AgentDefaults(
+                    actor_keys={"use-subscription": "false"},
+                    agent_args={"model": "opus", "extra": "kdl"},
+                ),
+            },
+        )
+        actor = cmd_new(
+            db, git,
+            name="c1",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=["model=haiku"],
+            template_name="qa",
+            app_config=app,
+        )
+        self.assertEqual(actor.config.get("model"), "haiku")            # CLI wins
+        self.assertEqual(actor.config.get("extra"), "tpl")              # tpl > kdl
+        self.assertEqual(actor.config.get("permission-mode"), "plan")   # tpl
+        self.assertEqual(actor.config.get("use-subscription"), "false") # kdl > class
+
+    def test_codex_agent_defaults_do_not_leak_into_claude_actor(self):
+        from actor import AgentDefaults, AppConfig
+        db = self._db()
+        git = FakeGit()
+        app = AppConfig(
+            agent_defaults={
+                "codex": AgentDefaults(agent_args={"m": "o3"}),
+            },
+        )
+        actor = cmd_new(
+            db, git,
+            name="iso",
+            dir="/tmp",
+            no_worktree=True,
+            base=None,
+            agent_name="claude",
+            config_pairs=[],
+            app_config=app,
+        )
+        self.assertNotIn("m", actor.config)
+
+
 # ──────────────────────────────────────────────────────────────────────
 #  Test: cmd_run  (8 tests from run.rs)
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -106,6 +106,19 @@ class FakeAgent(Agent):
     def interactive_argv(self, session_id, config):
         return ["fake-agent", "--resume", session_id]
 
+    def emit_agent_args(self, defaults):
+        args: list[str] = []
+        for key, value in sorted(defaults.items()):
+            if value is None:
+                continue
+            args.append(f"--{key}")
+            if value != "":
+                args.append(value)
+        return args
+
+    def apply_actor_keys(self, flat, env):
+        return dict(env)
+
 
 class FakeGitCall:
     def __init__(self, op: str, **kwargs):
@@ -2056,14 +2069,69 @@ class TestClaudeAgent(unittest.TestCase):
                                 "-Users-mme-Projects-mysite", "abc-123.jsonl")
         self.assertEqual(path, expected)
 
-    # -- config_args test (1) --
+    # -- emit_agent_args / apply_actor_keys tests --
 
-    def test_config_args_builds_flags(self):
-        from actor import claude_config_args
-        config = {"model": "sonnet", "max-budget-usd": "5"}
-        args = claude_config_args(config)
+    def test_emit_agent_args_builds_sorted_flags(self):
+        from actor.agents.claude import ClaudeAgent
+        args = ClaudeAgent().emit_agent_args(
+            {"model": "sonnet", "max-budget-usd": "5"}
+        )
         # Sorted keys: max-budget-usd before model
         self.assertEqual(args, ["--max-budget-usd", "5", "--model", "sonnet"])
+
+    def test_emit_agent_args_empty_string_is_bare_flag(self):
+        from actor.agents.claude import ClaudeAgent
+        self.assertEqual(
+            ClaudeAgent().emit_agent_args({"verbose": ""}),
+            ["--verbose"],
+        )
+
+    def test_emit_agent_args_skips_none_values(self):
+        from actor.agents.claude import ClaudeAgent
+        self.assertEqual(
+            ClaudeAgent().emit_agent_args({"model": "opus", "effort": None}),
+            ["--model", "opus"],
+        )
+
+    def test_apply_actor_keys_strips_anthropic_key_by_default(self):
+        from actor.agents.claude import ClaudeAgent
+        env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "secret"}
+        out = ClaudeAgent().apply_actor_keys({}, env)
+        self.assertNotIn("ANTHROPIC_API_KEY", out)
+        self.assertEqual(out["PATH"], "/bin")
+
+    def test_apply_actor_keys_strips_anthropic_key_when_true(self):
+        from actor.agents.claude import ClaudeAgent
+        env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "secret"}
+        out = ClaudeAgent().apply_actor_keys({"use-subscription": "true"}, env)
+        self.assertNotIn("ANTHROPIC_API_KEY", out)
+
+    def test_apply_actor_keys_keeps_anthropic_key_when_false(self):
+        from actor.agents.claude import ClaudeAgent
+        env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "secret"}
+        out = ClaudeAgent().apply_actor_keys({"use-subscription": "false"}, env)
+        self.assertEqual(out["ANTHROPIC_API_KEY"], "secret")
+
+    def test_apply_actor_keys_returns_new_dict(self):
+        from actor.agents.claude import ClaudeAgent
+        env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "secret"}
+        out = ClaudeAgent().apply_actor_keys({}, env)
+        # Mutating the result must not touch the original.
+        out["ANTHROPIC_API_KEY"] = "restored"
+        self.assertNotIn("ANTHROPIC_API_KEY", {k: v for k, v in env.items() if k != "ANTHROPIC_API_KEY"})
+
+    def test_claude_class_constants(self):
+        from actor.agents.claude import ClaudeAgent
+        self.assertEqual(ClaudeAgent.ACTOR_DEFAULTS, {"use-subscription": "true"})
+        self.assertEqual(ClaudeAgent.AGENT_DEFAULTS, {"permission-mode": "auto"})
+
+    def test_bypass_permissions_emits_straight(self):
+        """The old --dangerously-skip-permissions rewrite is gone; users who
+        want bypassPermissions now write it literally and it flows through
+        as --permission-mode bypassPermissions."""
+        from actor.agents.claude import ClaudeAgent
+        args = ClaudeAgent().emit_agent_args({"permission-mode": "bypassPermissions"})
+        self.assertEqual(args, ["--permission-mode", "bypassPermissions"])
 
     # -- read_logs tests (12) --
 
@@ -2231,24 +2299,63 @@ class TestClaudeAgent(unittest.TestCase):
 
 class TestCodexAgent(unittest.TestCase):
 
-    def test_config_args_model_becomes_m_flag(self):
-        from actor import codex_config_args
-        config = {"model": "o3"}
-        args = codex_config_args(config)
+    def test_emit_agent_args_short_flag_for_one_char_keys(self):
+        from actor.agents.codex import CodexAgent
+        args = CodexAgent().emit_agent_args({"m": "o3"})
         self.assertEqual(args, ["-m", "o3"])
 
-    def test_config_args_other_keys_become_c_flags(self):
-        from actor import codex_config_args
-        config = {"instructions": "be helpful"}
-        args = codex_config_args(config)
-        self.assertEqual(args, ["-c", "instructions=be helpful"])
+    def test_emit_agent_args_long_flag_for_multi_char_keys(self):
+        from actor.agents.codex import CodexAgent
+        args = CodexAgent().emit_agent_args({"sandbox": "danger-full-access"})
+        self.assertEqual(args, ["--sandbox", "danger-full-access"])
 
-    def test_config_args_mixed(self):
-        from actor import codex_config_args
-        config = {"model": "o3", "sandbox_mode": "workspace-write"}
-        args = codex_config_args(config)
-        # Sorted keys: model < sandbox_mode
-        self.assertEqual(args, ["-m", "o3", "-c", "sandbox_mode=workspace-write"])
+    def test_emit_agent_args_mixed_and_sorted(self):
+        from actor.agents.codex import CodexAgent
+        args = CodexAgent().emit_agent_args({
+            "m": "o3",
+            "sandbox": "danger-full-access",
+            "a": "never",
+        })
+        # Sorted: a < m < sandbox
+        self.assertEqual(
+            args,
+            ["-a", "never", "-m", "o3", "--sandbox", "danger-full-access"],
+        )
+
+    def test_emit_agent_args_empty_string_is_bare_flag(self):
+        from actor.agents.codex import CodexAgent
+        self.assertEqual(CodexAgent().emit_agent_args({"x": ""}), ["-x"])
+        self.assertEqual(
+            CodexAgent().emit_agent_args({"verbose": ""}), ["--verbose"]
+        )
+
+    def test_emit_agent_args_skips_none_values(self):
+        from actor.agents.codex import CodexAgent
+        self.assertEqual(
+            CodexAgent().emit_agent_args({"m": "o3", "a": None}),
+            ["-m", "o3"],
+        )
+
+    def test_apply_actor_keys_strips_openai_key_by_default(self):
+        from actor.agents.codex import CodexAgent
+        env = {"OPENAI_API_KEY": "x", "PATH": "/bin"}
+        out = CodexAgent().apply_actor_keys({}, env)
+        self.assertNotIn("OPENAI_API_KEY", out)
+        self.assertEqual(out["PATH"], "/bin")
+
+    def test_apply_actor_keys_keeps_openai_key_when_false(self):
+        from actor.agents.codex import CodexAgent
+        env = {"OPENAI_API_KEY": "x"}
+        out = CodexAgent().apply_actor_keys({"use-subscription": "false"}, env)
+        self.assertEqual(out["OPENAI_API_KEY"], "x")
+
+    def test_codex_class_constants(self):
+        from actor.agents.codex import CodexAgent
+        self.assertEqual(CodexAgent.ACTOR_DEFAULTS, {"use-subscription": "true"})
+        self.assertEqual(
+            CodexAgent.AGENT_DEFAULTS,
+            {"sandbox": "danger-full-access", "a": "never"},
+        )
 
     def test_parse_thread_started(self):
         line = '{"type":"thread.started","thread_id":"019d685b-6ed6-7f72-bdaa-19533aad1f43"}'

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -12,7 +12,7 @@ from actor import (
     ActorError, AlreadyExistsError, NotFoundError, IsRunningError, NotRunningError,
     InvalidNameError, AgentNotFoundError, GitError, ConfigError,
     # Types
-    AgentKind, Status, Actor, Run, LogEntry, LogEntryKind,
+    AgentKind, Status, Actor, Run, ActorConfig, LogEntry, LogEntryKind,
     validate_name, parse_config,
     # ABCs
     Agent, GitOps, ProcessManager,
@@ -24,6 +24,19 @@ from actor import (
     # Helpers
     truncate, format_duration,
 )
+
+
+def _cli(*pairs: str, actor_keys: dict | None = None) -> ActorConfig:
+    """Test helper: build an ActorConfig as if the CLI had produced it.
+
+    Positional `pairs` are treated as `--config` inputs (agent_args only);
+    the optional `actor_keys` kwarg carries dedicated-flag inputs (e.g.
+    use-subscription). Keeps test call sites compact now that the CLI
+    layer splits these before calling cmd_new / cmd_run."""
+    return ActorConfig(
+        actor_keys=dict(actor_keys or {}),
+        agent_args=parse_config(list(pairs)),
+    )
 
 # Aliases for brevity (tests use short names)
 AlreadyExists = AlreadyExistsError
@@ -39,7 +52,7 @@ AgentNotFound = AgentNotFoundError
 # ──────────────────────────────────────────────────────────────────────
 
 class FakeAgentCall:
-    def __init__(self, dir: str, prompt: str, config: dict, session_id: str | None):
+    def __init__(self, dir: str, prompt: str, config: ActorConfig, session_id: str | None):
         self.dir = dir
         self.prompt = prompt
         self.config = config
@@ -72,7 +85,7 @@ class FakeAgent(Agent):
 
     # -- Agent interface --
 
-    def start(self, dir: str, prompt: str, config: dict) -> tuple[int, str | None]:
+    def start(self, dir: str, prompt: str, config: ActorConfig) -> tuple[int, str | None]:
         if self.next_start_error is not None:
             err = self.next_start_error
             self.next_start_error = None
@@ -80,13 +93,13 @@ class FakeAgent(Agent):
         pid = self.next_pid
         self.next_pid += 1
         session_id = self.next_session_id
-        self.calls.append(FakeAgentCall(dir, prompt, dict(config), session_id=None))
+        self.calls.append(FakeAgentCall(dir, prompt, config, session_id=None))
         return pid, session_id
 
-    def resume(self, dir: str, session_id: str, prompt: str, config: dict) -> int:
+    def resume(self, dir: str, session_id: str, prompt: str, config: ActorConfig) -> int:
         pid = self.next_pid
         self.next_pid += 1
-        self.calls.append(FakeAgentCall(dir, prompt, dict(config), session_id=session_id))
+        self.calls.append(FakeAgentCall(dir, prompt, config, session_id=session_id))
         return pid
 
     def wait(self, pid: int) -> tuple[int, str]:
@@ -191,7 +204,19 @@ class FakeProcessManager(ProcessManager):
 #  Shared helpers
 # ──────────────────────────────────────────────────────────────────────
 
+def _coerce_config(c) -> ActorConfig:
+    """Accept ActorConfig directly, or a flat dict (treated as agent_args
+    for back-compat — every pre-refactor fixture passed things like
+    `{"model": "sonnet"}`, which are agent-bound flags)."""
+    if isinstance(c, ActorConfig):
+        return c
+    if isinstance(c, dict):
+        return ActorConfig(agent_args=dict(c))
+    raise TypeError(f"unexpected config type: {type(c).__name__}")
+
+
 def make_actor(name: str, **overrides) -> Actor:
+    overrides["config"] = _coerce_config(overrides.get("config", ActorConfig()))
     kwargs = dict(
         name=name,
         agent=AgentKind.CLAUDE,
@@ -201,7 +226,7 @@ def make_actor(name: str, **overrides) -> Actor:
         base_branch=None,
         worktree=False,
         parent=None,
-        config={},
+        config=ActorConfig(),
         created_at="2026-01-01T00:00:00Z",
         updated_at="2026-01-01T00:00:00Z",
     )
@@ -228,7 +253,7 @@ def make_run(actor_name: str, prompt: str, status: Status,
         status=status,
         exit_code=exit_code,
         pid=pid,
-        config={},
+        config=ActorConfig(),
         started_at=started_at,
         finished_at=finished_at,
     )
@@ -244,7 +269,7 @@ def create_actor(db: Database, name: str, config: list[str] | None = None):
         no_worktree=True,
         base=None,
         agent_name="claude",
-        config_pairs=config or ["model=sonnet"],
+        cli_overrides=_cli(*(config or ["model=sonnet"])),
     )
 
 
@@ -257,7 +282,7 @@ def create_actor_with_worktree(db: Database, git: FakeGit, name: str):
         no_worktree=False,
         base=None,
         agent_name="claude",
-        config_pairs=[],
+        cli_overrides=ActorConfig(),
     )
 
 
@@ -359,7 +384,7 @@ class TestDatabase(unittest.TestCase):
             status=Status.RUNNING,
             exit_code=None,
             pid=1234,
-            config={},
+            config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z",
             finished_at=None,
         )
@@ -381,7 +406,7 @@ class TestDatabase(unittest.TestCase):
         db.insert_actor(make_actor("test"))
         run1 = Run(
             id=0, actor_name="test", prompt="first", status=Status.DONE,
-            exit_code=0, pid=1, config={},
+            exit_code=0, pid=1, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z",
             finished_at="2026-01-01T00:01:00Z",
         )
@@ -391,7 +416,7 @@ class TestDatabase(unittest.TestCase):
 
         run2 = Run(
             id=0, actor_name="test", prompt="second", status=Status.ERROR,
-            exit_code=1, pid=2, config={},
+            exit_code=1, pid=2, config=ActorConfig(),
             started_at="2026-01-01T00:02:00Z",
             finished_at="2026-01-01T00:03:00Z",
         )
@@ -404,7 +429,7 @@ class TestDatabase(unittest.TestCase):
         db.insert_actor(make_actor("test"))
         run = Run(
             id=0, actor_name="test", prompt="go", status=Status.RUNNING,
-            exit_code=None, pid=99, config={},
+            exit_code=None, pid=99, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z", finished_at=None,
         )
         run_id = db.insert_run(run)
@@ -419,7 +444,7 @@ class TestDatabase(unittest.TestCase):
         db.insert_actor(make_actor("test"))
         run = Run(
             id=0, actor_name="test", prompt="go", status=Status.DONE,
-            exit_code=0, pid=1, config={},
+            exit_code=0, pid=1, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z",
             finished_at="2026-01-01T00:01:00Z",
         )
@@ -433,7 +458,7 @@ class TestDatabase(unittest.TestCase):
         for i in range(10):
             r = Run(
                 id=0, actor_name="test", prompt=f"prompt {i}",
-                status=Status.DONE, exit_code=0, pid=i, config={},
+                status=Status.DONE, exit_code=0, pid=i, config=ActorConfig(),
                 started_at=f"2026-01-01T00:{i:02d}:00Z",
                 finished_at=f"2026-01-01T00:{i:02d}:30Z",
             )
@@ -452,7 +477,7 @@ class TestDatabase(unittest.TestCase):
     def test_update_actor_config_missing_actor_errors(self):
         db = self._db()
         with self.assertRaises(NotFound):
-            db.update_actor_config("nonexistent", {})
+            db.update_actor_config("nonexistent", ActorConfig())
 
     def test_update_run_status_missing_run_errors(self):
         db = self._db()
@@ -464,8 +489,8 @@ class TestDatabase(unittest.TestCase):
         actor = make_actor("test", config={"model": "sonnet", "max-budget-usd": "5"})
         db.insert_actor(actor)
         fetched = db.get_actor("test")
-        self.assertEqual(fetched.config["model"], "sonnet")
-        self.assertEqual(fetched.config["max-budget-usd"], "5")
+        self.assertEqual(fetched.config.agent_args["model"], "sonnet")
+        self.assertEqual(fetched.config.agent_args["max-budget-usd"], "5")
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -487,13 +512,13 @@ class TestCmdNew(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="claude",
-            config_pairs=["model=sonnet"],
+            cli_overrides=_cli('model=sonnet'),
         )
         self.assertEqual(actor.name, "test-actor")
         self.assertFalse(actor.worktree)
         self.assertIsNone(actor.source_repo)
         self.assertIsNone(actor.base_branch)
-        self.assertEqual(actor.config["model"], "sonnet")
+        self.assertEqual(actor.config.agent_args["model"], "sonnet")
         fetched = db.get_actor("test-actor")
         self.assertEqual(fetched.name, "test-actor")
 
@@ -508,7 +533,7 @@ class TestCmdNew(unittest.TestCase):
             no_worktree=False,
             base=None,
             agent_name="claude",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
         )
         self.assertTrue(actor.worktree)
         self.assertEqual(actor.base_branch, "develop")
@@ -525,7 +550,7 @@ class TestCmdNew(unittest.TestCase):
             no_worktree=False,
             base="release-1.0",
             agent_name="claude",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
         )
         self.assertEqual(actor.base_branch, "release-1.0")
 
@@ -540,7 +565,7 @@ class TestCmdNew(unittest.TestCase):
                 no_worktree=True,
                 base=None,
                 agent_name="claude",
-                config_pairs=[],
+                cli_overrides=ActorConfig(),
             )
 
     def test_new_actor_duplicate_name(self):
@@ -548,7 +573,7 @@ class TestCmdNew(unittest.TestCase):
         git = FakeGit()
         kwargs = dict(
             name="dupe", dir="/tmp", no_worktree=True,
-            base=None, agent_name="claude", config_pairs=[],
+            base=None, agent_name="claude", cli_overrides=ActorConfig(),
         )
         cmd_new(db, git, **kwargs)
         with self.assertRaises(AlreadyExists):
@@ -565,7 +590,7 @@ class TestCmdNew(unittest.TestCase):
             no_worktree=False,
             base=None,
             agent_name="claude",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
         )
         self.assertFalse(actor.worktree)
         self.assertIsNone(actor.source_repo)
@@ -583,7 +608,7 @@ class TestCmdNew(unittest.TestCase):
                 no_worktree=False,
                 base=None,
                 agent_name="claude",
-                config_pairs=[],
+                cli_overrides=ActorConfig(),
             )
         with self.assertRaises(NotFound):
             db.get_actor("feature")
@@ -619,13 +644,13 @@ class TestCmdNewTemplate(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name=None,
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
             template_name="qa",
             app_config=self._cfg_with_qa(),
         )
         self.assertEqual(actor.agent, AgentKind.CODEX)
-        self.assertEqual(actor.config["model"], "opus")
-        self.assertEqual(actor.config["effort"], "max")
+        self.assertEqual(actor.config.agent_args["model"], "opus")
+        self.assertEqual(actor.config.agent_args["effort"], "max")
 
     def test_cli_agent_overrides_template_agent(self):
         db = self._db()
@@ -637,7 +662,7 @@ class TestCmdNewTemplate(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="claude",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
             template_name="qa",
             app_config=self._cfg_with_qa(),
         )
@@ -653,12 +678,12 @@ class TestCmdNewTemplate(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name=None,
-            config_pairs=["model=haiku"],
+            cli_overrides=_cli('model=haiku'),
             template_name="qa",
             app_config=self._cfg_with_qa(),
         )
-        self.assertEqual(actor.config["model"], "haiku")
-        self.assertEqual(actor.config["effort"], "max")
+        self.assertEqual(actor.config.agent_args["model"], "haiku")
+        self.assertEqual(actor.config.agent_args["effort"], "max")
 
     def test_unknown_template_raises_config_error(self):
         from actor.errors import ConfigError
@@ -672,7 +697,7 @@ class TestCmdNewTemplate(unittest.TestCase):
                 no_worktree=True,
                 base=None,
                 agent_name=None,
-                config_pairs=[],
+                cli_overrides=ActorConfig(),
                 template_name="does-not-exist",
                 app_config=self._cfg_with_qa(),
             )
@@ -687,10 +712,10 @@ class TestCmdNewTemplate(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="claude",
-            config_pairs=["model=sonnet"],
+            cli_overrides=_cli('model=sonnet'),
         )
         self.assertEqual(actor.agent, AgentKind.CLAUDE)
-        self.assertEqual(actor.config["model"], "sonnet")
+        self.assertEqual(actor.config.agent_args["model"], "sonnet")
 
     def test_agent_name_none_without_template_defaults_to_claude(self):
         db = self._db()
@@ -702,7 +727,7 @@ class TestCmdNewTemplate(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name=None,
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
         )
         self.assertEqual(actor.agent, AgentKind.CLAUDE)
 
@@ -725,12 +750,12 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="claude",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
             template_name=None,
             app_config=AppConfig(),
         )
-        self.assertEqual(actor.config.get("permission-mode"), "auto")
-        self.assertEqual(actor.config.get("use-subscription"), "true")
+        self.assertEqual(actor.config.agent_args.get("permission-mode"), "auto")
+        self.assertEqual(actor.config.actor_keys.get("use-subscription"), "true")
 
     def test_class_defaults_applied_when_app_config_is_none(self):
         # Callers that don't pass app_config (e.g. older integration paths)
@@ -744,10 +769,10 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="claude",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
         )
-        self.assertEqual(actor.config.get("permission-mode"), "auto")
-        self.assertEqual(actor.config.get("use-subscription"), "true")
+        self.assertEqual(actor.config.agent_args.get("permission-mode"), "auto")
+        self.assertEqual(actor.config.actor_keys.get("use-subscription"), "true")
 
     def test_class_defaults_apply_to_codex(self):
         from actor import AppConfig
@@ -760,12 +785,12 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="codex",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
             app_config=AppConfig(),
         )
-        self.assertEqual(actor.config.get("sandbox"), "danger-full-access")
-        self.assertEqual(actor.config.get("a"), "never")
-        self.assertEqual(actor.config.get("use-subscription"), "true")
+        self.assertEqual(actor.config.agent_args.get("sandbox"), "danger-full-access")
+        self.assertEqual(actor.config.agent_args.get("a"), "never")
+        self.assertEqual(actor.config.actor_keys.get("use-subscription"), "true")
 
     def test_kdl_agent_defaults_override_class_defaults(self):
         from actor import AgentDefaults, AppConfig
@@ -786,12 +811,12 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="claude",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
             app_config=app,
         )
-        self.assertEqual(actor.config.get("use-subscription"), "false")
-        self.assertEqual(actor.config.get("permission-mode"), "plan")
-        self.assertEqual(actor.config.get("model"), "opus")
+        self.assertEqual(actor.config.actor_keys.get("use-subscription"), "false")
+        self.assertEqual(actor.config.agent_args.get("permission-mode"), "plan")
+        self.assertEqual(actor.config.agent_args.get("model"), "opus")
 
     def test_kdl_null_cancels_class_default(self):
         from actor import AgentDefaults, AppConfig
@@ -811,12 +836,12 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="claude",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
             app_config=app,
         )
-        self.assertNotIn("permission-mode", actor.config)
+        self.assertNotIn("permission-mode", actor.config.agent_args)
         # Other class defaults still apply.
-        self.assertEqual(actor.config.get("use-subscription"), "true")
+        self.assertEqual(actor.config.actor_keys.get("use-subscription"), "true")
 
     def test_template_overrides_kdl_agent_defaults(self):
         from actor import AgentDefaults, AppConfig, Template
@@ -837,11 +862,11 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="claude",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
             template_name="qa",
             app_config=app,
         )
-        self.assertEqual(actor.config.get("permission-mode"), "plan")
+        self.assertEqual(actor.config.agent_args.get("permission-mode"), "plan")
 
     def test_cli_overrides_template_over_kdl_over_class_defaults(self):
         from actor import AgentDefaults, AppConfig, Template
@@ -868,14 +893,14 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="claude",
-            config_pairs=["model=haiku"],
+            cli_overrides=_cli('model=haiku'),
             template_name="qa",
             app_config=app,
         )
-        self.assertEqual(actor.config.get("model"), "haiku")            # CLI wins
-        self.assertEqual(actor.config.get("extra"), "tpl")              # tpl > kdl
-        self.assertEqual(actor.config.get("permission-mode"), "plan")   # tpl
-        self.assertEqual(actor.config.get("use-subscription"), "false") # kdl > class
+        self.assertEqual(actor.config.agent_args.get("model"), "haiku")            # CLI wins
+        self.assertEqual(actor.config.agent_args.get("extra"), "tpl")              # tpl > kdl
+        self.assertEqual(actor.config.agent_args.get("permission-mode"), "plan")   # tpl
+        self.assertEqual(actor.config.actor_keys.get("use-subscription"), "false") # kdl > class
 
     def test_codex_agent_defaults_do_not_leak_into_claude_actor(self):
         from actor import AgentDefaults, AppConfig
@@ -893,10 +918,10 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
             no_worktree=True,
             base=None,
             agent_name="claude",
-            config_pairs=[],
+            cli_overrides=ActorConfig(),
             app_config=app,
         )
-        self.assertNotIn("m", actor.config)
+        self.assertNotIn("m", actor.config.agent_args)
 
     def test_single_kdl_layer_null_cancels_class_default_end_to_end(self):
         """Regression: a settings.kdl that only contains null-as-cancel must
@@ -924,12 +949,12 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
                 no_worktree=True,
                 base=None,
                 agent_name="claude",
-                config_pairs=[],
+                cli_overrides=ActorConfig(),
                 app_config=cfg,
             )
-        self.assertNotIn("permission-mode", actor.config)
+        self.assertNotIn("permission-mode", actor.config.agent_args)
         # Other class defaults stay in place.
-        self.assertEqual(actor.config.get("use-subscription"), "true")
+        self.assertEqual(actor.config.actor_keys.get("use-subscription"), "true")
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -946,7 +971,7 @@ class TestCmdRun(unittest.TestCase):
         create_actor(db, "test")
         agent = FakeAgent()
         pm = FakeProcessManager()
-        cmd_run(db, agent, pm, name="test", prompt="do the thing", config_pairs=[])
+        cmd_run(db, agent, pm, name="test", prompt="do the thing", cli_overrides=ActorConfig())
         actor = db.get_actor("test")
         self.assertIsNotNone(actor.agent_session)
         latest = db.latest_run("test")
@@ -959,8 +984,8 @@ class TestCmdRun(unittest.TestCase):
         create_actor(db, "test")
         agent = FakeAgent()
         pm = FakeProcessManager()
-        cmd_run(db, agent, pm, name="test", prompt="first", config_pairs=[])
-        cmd_run(db, agent, pm, name="test", prompt="second", config_pairs=[])
+        cmd_run(db, agent, pm, name="test", prompt="first", cli_overrides=ActorConfig())
+        cmd_run(db, agent, pm, name="test", prompt="second", cli_overrides=ActorConfig())
         self.assertEqual(len(agent.calls), 2)
         # Second call should have a session_id (resume)
         self.assertIsNotNone(agent.calls[1].session_id)
@@ -971,14 +996,14 @@ class TestCmdRun(unittest.TestCase):
         pm = FakeProcessManager()
         run = Run(
             id=0, actor_name="test", prompt="go", status=Status.RUNNING,
-            exit_code=None, pid=999, config={},
+            exit_code=None, pid=999, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z", finished_at=None,
         )
         db.insert_run(run)
         pm.mark_alive(999)
         agent = FakeAgent()
         with self.assertRaises(IsRunning):
-            cmd_run(db, agent, pm, name="test", prompt="another", config_pairs=[])
+            cmd_run(db, agent, pm, name="test", prompt="another", cli_overrides=ActorConfig())
 
     def test_run_detects_stale_pid_and_proceeds(self):
         db = self._db()
@@ -986,13 +1011,13 @@ class TestCmdRun(unittest.TestCase):
         pm = FakeProcessManager()
         run = Run(
             id=0, actor_name="test", prompt="stale", status=Status.RUNNING,
-            exit_code=None, pid=888, config={},
+            exit_code=None, pid=888, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z", finished_at=None,
         )
         db.insert_run(run)
         # PID 888 is NOT alive
         agent = FakeAgent()
-        cmd_run(db, agent, pm, name="test", prompt="retry", config_pairs=[])
+        cmd_run(db, agent, pm, name="test", prompt="retry", cli_overrides=ActorConfig())
         runs, _ = db.list_runs("test", limit=10)
         self.assertEqual(len(runs), 2)
         self.assertEqual(runs[0].status, Status.DONE)    # latest
@@ -1004,13 +1029,13 @@ class TestCmdRun(unittest.TestCase):
         agent = FakeAgent()
         pm = FakeProcessManager()
         cmd_run(db, agent, pm, name="test", prompt="go",
-                config_pairs=["model=opus", "max-budget-usd=10"])
+                cli_overrides=_cli('model=opus', 'max-budget-usd=10'))
         latest = db.latest_run("test")
-        self.assertEqual(latest.config["model"], "opus")        # overridden
-        self.assertEqual(latest.config["max-budget-usd"], "10") # added
+        self.assertEqual(latest.config.agent_args["model"], "opus")        # overridden
+        self.assertEqual(latest.config.agent_args["max-budget-usd"], "10") # added
         # Actor config unchanged
         actor = db.get_actor("test")
-        self.assertEqual(actor.config["model"], "sonnet")
+        self.assertEqual(actor.config.agent_args["model"], "sonnet")
 
     def test_run_with_nonzero_exit_sets_error(self):
         db = self._db()
@@ -1018,7 +1043,7 @@ class TestCmdRun(unittest.TestCase):
         agent = FakeAgent()
         agent.set_exit_code(1)
         pm = FakeProcessManager()
-        cmd_run(db, agent, pm, name="test", prompt="fail", config_pairs=[])
+        cmd_run(db, agent, pm, name="test", prompt="fail", cli_overrides=ActorConfig())
         latest = db.latest_run("test")
         self.assertEqual(latest.status, Status.ERROR)
         self.assertEqual(latest.exit_code, 1)
@@ -1028,7 +1053,7 @@ class TestCmdRun(unittest.TestCase):
         agent = FakeAgent()
         pm = FakeProcessManager()
         with self.assertRaises(NotFound):
-            cmd_run(db, agent, pm, name="nope", prompt="go", config_pairs=[])
+            cmd_run(db, agent, pm, name="nope", prompt="go", cli_overrides=ActorConfig())
 
     def test_run_agent_start_failure_marks_run_as_error(self):
         db = self._db()
@@ -1037,7 +1062,7 @@ class TestCmdRun(unittest.TestCase):
         agent.set_start_error(ActorError("agent crashed"))
         pm = FakeProcessManager()
         with self.assertRaises(ActorError):
-            cmd_run(db, agent, pm, name="test", prompt="do the thing", config_pairs=[])
+            cmd_run(db, agent, pm, name="test", prompt="do the thing", cli_overrides=ActorConfig())
         latest = db.latest_run("test")
         self.assertIsNotNone(latest, "run row should exist marked as error")
         self.assertEqual(latest.status, Status.ERROR)
@@ -1115,7 +1140,7 @@ class TestCmdInteractive(unittest.TestCase):
         pm = FakeProcessManager()
         run = Run(
             id=0, actor_name="test", prompt="go", status=Status.RUNNING,
-            exit_code=None, pid=999, config={},
+            exit_code=None, pid=999, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z", finished_at=None,
         )
         db.insert_run(run)
@@ -1750,7 +1775,7 @@ class TestCmdStop(unittest.TestCase):
         run = Run(
             id=0, actor_name=actor_name, prompt="do stuff",
             status=Status.RUNNING, exit_code=None, pid=pid,
-            config={}, started_at="2026-01-01T00:00:00Z", finished_at=None,
+            config=ActorConfig(), started_at="2026-01-01T00:00:00Z", finished_at=None,
         )
         return db.insert_run(run)
 
@@ -1775,7 +1800,7 @@ class TestCmdStop(unittest.TestCase):
         pm = FakeProcessManager()
         run = Run(
             id=0, actor_name="test", prompt="done", status=Status.DONE,
-            exit_code=0, pid=100, config={},
+            exit_code=0, pid=100, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z",
             finished_at="2026-01-01T00:01:00Z",
         )
@@ -1819,7 +1844,7 @@ class TestCmdStop(unittest.TestCase):
         pm = FakeProcessManager()
         run = Run(
             id=0, actor_name="test", prompt="weird", status=Status.RUNNING,
-            exit_code=None, pid=None, config={},
+            exit_code=None, pid=None, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z", finished_at=None,
         )
         db.insert_run(run)
@@ -1848,7 +1873,7 @@ class TestCmdStop(unittest.TestCase):
         pm = FakeProcessManager()
         run1 = Run(
             id=0, actor_name="test", prompt="first", status=Status.DONE,
-            exit_code=0, pid=100, config={},
+            exit_code=0, pid=100, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z",
             finished_at="2026-01-01T00:01:00Z",
         )
@@ -1915,8 +1940,8 @@ class TestCmdConfig(unittest.TestCase):
         db.insert_actor(make_actor("test"))
         cmd_config(db, name="test", config_pairs=["model=sonnet", "max-turns=10"])
         actor = db.get_actor("test")
-        self.assertEqual(actor.config["model"], "sonnet")
-        self.assertEqual(actor.config["max-turns"], "10")
+        self.assertEqual(actor.config.agent_args["model"], "sonnet")
+        self.assertEqual(actor.config.agent_args["max-turns"], "10")
 
     def test_merge_config_preserves_existing(self):
         db = self._db()
@@ -1924,9 +1949,9 @@ class TestCmdConfig(unittest.TestCase):
         db.insert_actor(actor)
         cmd_config(db, name="test", config_pairs=["timeout=30"])
         actor = db.get_actor("test")
-        self.assertEqual(actor.config["model"], "sonnet")
-        self.assertEqual(actor.config["max-turns"], "10")
-        self.assertEqual(actor.config["timeout"], "30")
+        self.assertEqual(actor.config.agent_args["model"], "sonnet")
+        self.assertEqual(actor.config.agent_args["max-turns"], "10")
+        self.assertEqual(actor.config.agent_args["timeout"], "30")
 
     def test_merge_config_overwrites_existing_key(self):
         db = self._db()
@@ -1934,14 +1959,14 @@ class TestCmdConfig(unittest.TestCase):
         db.insert_actor(actor)
         cmd_config(db, name="test", config_pairs=["model=opus"])
         actor = db.get_actor("test")
-        self.assertEqual(actor.config["model"], "opus")
+        self.assertEqual(actor.config.agent_args["model"], "opus")
 
     def test_config_value_with_equals_sign(self):
         db = self._db()
         db.insert_actor(make_actor("test"))
         cmd_config(db, name="test", config_pairs=["prompt=a=b=c"])
         actor = db.get_actor("test")
-        self.assertEqual(actor.config["prompt"], "a=b=c")
+        self.assertEqual(actor.config.agent_args["prompt"], "a=b=c")
 
     def test_actor_not_found(self):
         db = self._db()
@@ -1953,17 +1978,17 @@ class TestCmdConfig(unittest.TestCase):
         db.insert_actor(make_actor("test"))
         cmd_config(db, name="test", config_pairs=["verbose"])
         actor = db.get_actor("test")
-        self.assertEqual(actor.config["verbose"], "")
+        self.assertEqual(actor.config.agent_args["verbose"], "")
 
     def test_set_multiple_config_pairs_at_once(self):
         db = self._db()
         db.insert_actor(make_actor("test"))
         cmd_config(db, name="test", config_pairs=["model=sonnet", "max-turns=10", "timeout=30"])
         actor = db.get_actor("test")
-        self.assertEqual(len(actor.config), 3)
-        self.assertEqual(actor.config["model"], "sonnet")
-        self.assertEqual(actor.config["max-turns"], "10")
-        self.assertEqual(actor.config["timeout"], "30")
+        self.assertEqual((len(actor.config.actor_keys) + len(actor.config.agent_args)), 3)
+        self.assertEqual(actor.config.agent_args["model"], "sonnet")
+        self.assertEqual(actor.config.agent_args["max-turns"], "10")
+        self.assertEqual(actor.config.agent_args["timeout"], "30")
 
     def test_successive_config_updates(self):
         db = self._db()
@@ -1972,9 +1997,9 @@ class TestCmdConfig(unittest.TestCase):
         cmd_config(db, name="test", config_pairs=["max-turns=10"])
         cmd_config(db, name="test", config_pairs=["model=opus"])
         actor = db.get_actor("test")
-        self.assertEqual(len(actor.config), 2)
-        self.assertEqual(actor.config["model"], "opus")
-        self.assertEqual(actor.config["max-turns"], "10")
+        self.assertEqual((len(actor.config.actor_keys) + len(actor.config.agent_args)), 2)
+        self.assertEqual(actor.config.agent_args["model"], "opus")
+        self.assertEqual(actor.config.agent_args["max-turns"], "10")
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -2161,7 +2186,7 @@ class TestCmdDiscard(unittest.TestCase):
         pm = FakeProcessManager()
         run = Run(
             id=0, actor_name="test", prompt="go", status=Status.RUNNING,
-            exit_code=None, pid=999, config={},
+            exit_code=None, pid=999, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z", finished_at=None,
         )
         db.insert_run(run)
@@ -2177,7 +2202,7 @@ class TestCmdDiscard(unittest.TestCase):
         pm = FakeProcessManager()
         run = Run(
             id=0, actor_name="test", prompt="go", status=Status.RUNNING,
-            exit_code=None, pid=888, config={},
+            exit_code=None, pid=888, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z", finished_at=None,
         )
         db.insert_run(run)
@@ -2197,7 +2222,7 @@ class TestCmdDiscard(unittest.TestCase):
         create_actor(db, "test", config=[])
         run = Run(
             id=0, actor_name="test", prompt="go", status=Status.DONE,
-            exit_code=0, pid=1, config={},
+            exit_code=0, pid=1, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z",
             finished_at="2026-01-01T00:01:00Z",
         )
@@ -2249,7 +2274,7 @@ class TestCmdDiscard(unittest.TestCase):
         db.insert_actor(child)
         run = Run(
             id=0, actor_name="child", prompt="go", status=Status.RUNNING,
-            exit_code=None, pid=777, config={},
+            exit_code=None, pid=777, config=ActorConfig(),
             started_at="2026-01-01T00:00:00Z", finished_at=None,
         )
         db.insert_run(run)

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -898,6 +898,39 @@ class TestCmdNewAgentDefaults(unittest.TestCase):
         )
         self.assertNotIn("m", actor.config)
 
+    def test_single_kdl_layer_null_cancels_class_default_end_to_end(self):
+        """Regression: a settings.kdl that only contains null-as-cancel must
+        cancel a class-level default, even without a peer value in another
+        kdl layer to overwrite."""
+        import tempfile
+        from actor.config import load_config
+        db = self._db()
+        git = FakeGit()
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            kdl = Path(cwd) / ".actor" / "settings.kdl"
+            kdl.parent.mkdir()
+            kdl.write_text(
+                'agent "claude" {\n'
+                '    defaults {\n'
+                '        permission-mode null\n'
+                '    }\n'
+                '}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            actor = cmd_new(
+                db, git,
+                name="n",
+                dir="/tmp",
+                no_worktree=True,
+                base=None,
+                agent_name="claude",
+                config_pairs=[],
+                app_config=cfg,
+            )
+        self.assertNotIn("permission-mode", actor.config)
+        # Other class defaults stay in place.
+        self.assertEqual(actor.config.get("use-subscription"), "true")
+
 
 # ──────────────────────────────────────────────────────────────────────
 #  Test: cmd_run  (8 tests from run.rs)
@@ -2236,7 +2269,8 @@ class TestCmdDiscard(unittest.TestCase):
 
 class TestClaudeAgent(unittest.TestCase):
     """Tests for Claude-specific logic: encode_dir, session_file_path,
-    config_args, and JSONL read_logs parsing."""
+    argv emission via emit_agent_args / apply_actor_keys, and JSONL
+    read_logs parsing."""
 
     # -- encode_dir tests (2) --
 
@@ -2308,9 +2342,11 @@ class TestClaudeAgent(unittest.TestCase):
         from actor.agents.claude import ClaudeAgent
         env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "secret"}
         out = ClaudeAgent().apply_actor_keys({}, env)
-        # Mutating the result must not touch the original.
+        # Mutating the returned dict must not touch the caller's env.
         out["ANTHROPIC_API_KEY"] = "restored"
-        self.assertNotIn("ANTHROPIC_API_KEY", {k: v for k, v in env.items() if k != "ANTHROPIC_API_KEY"})
+        out["NEW_KEY"] = "added"
+        self.assertEqual(env["ANTHROPIC_API_KEY"], "secret")
+        self.assertNotIn("NEW_KEY", env)
 
     def test_claude_class_constants(self):
         from actor.agents.claude import ClaudeAgent

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -11,7 +11,7 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
-from actor import __version__
+from actor import ActorConfig, __version__
 from actor.cli import main
 from actor.errors import ActorError
 
@@ -89,7 +89,7 @@ class NewCommandTests(unittest.TestCase):
         kwargs = cmd_run.call_args.kwargs
         self.assertEqual(kwargs["name"], "foo")
         self.assertEqual(kwargs["prompt"], "do x")
-        self.assertEqual(kwargs["config_pairs"], [])  # saved as defaults already
+        self.assertEqual(kwargs["cli_overrides"], ActorConfig())  # saved as defaults already
         self.assertEqual(code, 0)
 
     def test_new_with_stdin_prompt_creates_and_runs(self):
@@ -105,30 +105,30 @@ class NewCommandTests(unittest.TestCase):
         cmd_run.assert_not_called()
         self.assertEqual(code, 1)
 
-    def test_new_translates_model_and_use_subscription_to_config_pairs(self):
+    def test_new_translates_model_and_use_subscription_to_cli_overrides(self):
         cmd_new, _cmd_run, _code = self._run([
             "new", "foo", "--model", "sonnet", "--no-use-subscription",
         ])
-        pairs = cmd_new.call_args.kwargs["config_pairs"]
-        self.assertIn("model=sonnet", pairs)
-        self.assertIn("use-subscription=false", pairs)
+        overrides = cmd_new.call_args.kwargs["cli_overrides"]
+        self.assertEqual(overrides.agent_args.get("model"), "sonnet")
+        self.assertEqual(overrides.actor_keys.get("use-subscription"), "false")
 
     def test_new_without_use_subscription_flag_does_not_emit_override(self):
         """Tri-state check: omitting both --use-subscription and --no-use-subscription
-        must NOT push a use-subscription pair, so a template's value wins."""
+        must NOT push a use-subscription value, so a template's value wins."""
         cmd_new, _cmd_run, _code = self._run(["new", "foo"])
-        pairs = cmd_new.call_args.kwargs["config_pairs"]
-        self.assertFalse(
-            any(p.startswith("use-subscription=") for p in pairs),
-            f"expected no use-subscription override, got {pairs}",
+        overrides = cmd_new.call_args.kwargs["cli_overrides"]
+        self.assertNotIn(
+            "use-subscription", overrides.actor_keys,
+            f"expected no use-subscription override, got {overrides.actor_keys}",
         )
 
     def test_new_explicit_use_subscription_flag_emits_true_override(self):
         """Explicit --use-subscription must push use-subscription=true so it
         can override a template's use-subscription "false"."""
         cmd_new, _cmd_run, _code = self._run(["new", "foo", "--use-subscription"])
-        pairs = cmd_new.call_args.kwargs["config_pairs"]
-        self.assertIn("use-subscription=true", pairs)
+        overrides = cmd_new.call_args.kwargs["cli_overrides"]
+        self.assertEqual(overrides.actor_keys.get("use-subscription"), "true")
 
     def test_new_passes_template_arg_to_cmd_new_and_uses_template_prompt(self):
         fake_db = MagicMock()
@@ -281,8 +281,12 @@ class NewCommandTests(unittest.TestCase):
 
 class RunCommandTests(unittest.TestCase):
     def test_run_passes_config_overrides(self):
+        from actor.types import AgentKind
         cmd_run = MagicMock(return_value="ok")
         fake_db = MagicMock()
+        # cli.main resolves the actor's agent kind before building cli_overrides;
+        # pin it so _agent_class sees a valid kind (not a MagicMock attribute).
+        fake_db.get_actor.return_value.agent = AgentKind.CLAUDE
         with patch("actor.cli.cmd_run", cmd_run), \
              patch("actor.cli.Database") as db_cls, \
              patch("actor.cli._create_agent", return_value=MagicMock()):
@@ -292,7 +296,9 @@ class RunCommandTests(unittest.TestCase):
             with patch("sys.stdin", stdin):
                 main(["run", "foo", "--config", "model=opus", "do x"])
         cmd_run.assert_called_once()
-        self.assertEqual(cmd_run.call_args.kwargs["config_pairs"], ["model=opus"])
+        overrides = cmd_run.call_args.kwargs["cli_overrides"]
+        self.assertEqual(overrides.agent_args.get("model"), "opus")
+        self.assertEqual(overrides.actor_keys, {})
 
     def test_run_dash_i_dispatches_to_cmd_interactive(self):
         """`actor run foo -i` must route through cmd_interactive, not cmd_run."""
@@ -390,7 +396,7 @@ class SubClaudeChannelTests(unittest.TestCase):
             return 12345
 
         with patch.object(ClaudeAgent, "_spawn_and_track", fake_spawn):
-            agent.start(Path("/tmp"), "hi", {})
+            agent.start(Path("/tmp"), "hi", ActorConfig())
 
         self.assertIn("--dangerously-load-development-channels", captured["args"])
         idx = captured["args"].index("--dangerously-load-development-channels")
@@ -408,7 +414,7 @@ class SubClaudeChannelTests(unittest.TestCase):
             return 12345
 
         with patch.object(ClaudeAgent, "_spawn_and_track", fake_spawn):
-            agent.resume(Path("/tmp"), "some-session", "continue", {})
+            agent.resume(Path("/tmp"), "some-session", "continue", ActorConfig())
 
         self.assertIn("--dangerously-load-development-channels", captured["args"])
 
@@ -470,10 +476,17 @@ class McpToolTests(unittest.TestCase):
 
     def test_run_actor_forwards_config(self):
         from actor import server
-        with patch("actor.server._spawn_background_run") as spawn:
+        from actor.types import AgentKind
+        # server.run_actor reads the actor's agent kind to validate --config;
+        # pin it to a real kind so _agent_class doesn't reject a MagicMock.
+        with patch("actor.server._db") as db_fn, \
+             patch("actor.server._spawn_background_run") as spawn:
+            db_fn.return_value.get_actor.return_value.agent = AgentKind.CLAUDE
             server.run_actor(name="foo", prompt="do x", config=["model=opus"])
         args, kwargs = spawn.call_args
-        self.assertEqual(kwargs["config_pairs"], ["model=opus"])
+        overrides = kwargs["cli_overrides"]
+        self.assertEqual(overrides.agent_args.get("model"), "opus")
+        self.assertEqual(overrides.actor_keys, {})
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -105,30 +105,30 @@ class NewCommandTests(unittest.TestCase):
         cmd_run.assert_not_called()
         self.assertEqual(code, 1)
 
-    def test_new_translates_model_and_strip_api_keys_to_config_pairs(self):
+    def test_new_translates_model_and_use_subscription_to_config_pairs(self):
         cmd_new, _cmd_run, _code = self._run([
-            "new", "foo", "--model", "sonnet", "--no-strip-api-keys",
+            "new", "foo", "--model", "sonnet", "--no-use-subscription",
         ])
         pairs = cmd_new.call_args.kwargs["config_pairs"]
         self.assertIn("model=sonnet", pairs)
-        self.assertIn("strip-api-keys=false", pairs)
+        self.assertIn("use-subscription=false", pairs)
 
-    def test_new_without_strip_api_keys_flag_does_not_emit_override(self):
-        """Tri-state check: omitting both --strip-api-keys and --no-strip-api-keys
-        must NOT push a strip-api-keys pair, so a template's value wins."""
+    def test_new_without_use_subscription_flag_does_not_emit_override(self):
+        """Tri-state check: omitting both --use-subscription and --no-use-subscription
+        must NOT push a use-subscription pair, so a template's value wins."""
         cmd_new, _cmd_run, _code = self._run(["new", "foo"])
         pairs = cmd_new.call_args.kwargs["config_pairs"]
         self.assertFalse(
-            any(p.startswith("strip-api-keys=") for p in pairs),
-            f"expected no strip-api-keys override, got {pairs}",
+            any(p.startswith("use-subscription=") for p in pairs),
+            f"expected no use-subscription override, got {pairs}",
         )
 
-    def test_new_explicit_strip_api_keys_flag_emits_true_override(self):
-        """Explicit --strip-api-keys must push strip-api-keys=true so it
-        can override a template's strip-api-keys "false"."""
-        cmd_new, _cmd_run, _code = self._run(["new", "foo", "--strip-api-keys"])
+    def test_new_explicit_use_subscription_flag_emits_true_override(self):
+        """Explicit --use-subscription must push use-subscription=true so it
+        can override a template's use-subscription "false"."""
+        cmd_new, _cmd_run, _code = self._run(["new", "foo", "--use-subscription"])
         pairs = cmd_new.call_args.kwargs["config_pairs"]
-        self.assertIn("strip-api-keys=true", pairs)
+        self.assertIn("use-subscription=true", pairs)
 
     def test_new_passes_template_arg_to_cmd_new_and_uses_template_prompt(self):
         fake_db = MagicMock()

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 
 from actor import ActorConfig, __version__
 from actor.cli import main
-from actor.errors import ActorError
+from actor.errors import ActorError, ConfigError
 
 
 class VersionFlagTests(unittest.TestCase):
@@ -487,6 +487,80 @@ class McpToolTests(unittest.TestCase):
         overrides = kwargs["cli_overrides"]
         self.assertEqual(overrides.agent_args.get("model"), "opus")
         self.assertEqual(overrides.actor_keys, {})
+
+    # -- use_subscription param on new_actor ----------------------------------
+
+    def _capture_new_actor_overrides(self, **kwargs) -> ActorConfig:
+        """Invoke server.new_actor with no prompt, return cli_overrides cmd_new saw."""
+        from actor import server
+        with patch("actor.server.cmd_new") as cmd_new, \
+             patch("actor.server._spawn_background_run") as spawn:
+            fake_actor = MagicMock()
+            fake_actor.dir = "/tmp/foo"
+            cmd_new.return_value = fake_actor
+            server.new_actor(name="foo", **kwargs)
+        spawn.assert_not_called()
+        return cmd_new.call_args.kwargs["cli_overrides"]
+
+    def test_new_actor_use_subscription_true_sets_actor_key(self):
+        overrides = self._capture_new_actor_overrides(use_subscription=True)
+        self.assertEqual(overrides.actor_keys, {"use-subscription": "true"})
+        self.assertEqual(overrides.agent_args, {})
+
+    def test_new_actor_use_subscription_false_sets_actor_key(self):
+        overrides = self._capture_new_actor_overrides(use_subscription=False)
+        self.assertEqual(overrides.actor_keys, {"use-subscription": "false"})
+        self.assertEqual(overrides.agent_args, {})
+
+    def test_new_actor_use_subscription_default_none_emits_nothing(self):
+        """Tri-state: omitting the param leaves actor_keys empty so lower
+        layers (template / kdl / class default) supply the value."""
+        overrides = self._capture_new_actor_overrides()
+        self.assertEqual(overrides.actor_keys, {})
+
+    def test_new_actor_rejects_use_subscription_via_config(self):
+        from actor import server
+        with patch("actor.server.cmd_new") as cmd_new:
+            with self.assertRaises(ConfigError):
+                server.new_actor(name="foo", config=["use-subscription=true"])
+        cmd_new.assert_not_called()
+
+    # -- use_subscription param on run_actor ----------------------------------
+
+    def _capture_run_actor_overrides(self, **kwargs) -> ActorConfig:
+        from actor import server
+        from actor.types import AgentKind
+        with patch("actor.server._db") as db_fn, \
+             patch("actor.server._spawn_background_run") as spawn:
+            db_fn.return_value.get_actor.return_value.agent = AgentKind.CLAUDE
+            server.run_actor(name="foo", prompt="do x", **kwargs)
+        return spawn.call_args.kwargs["cli_overrides"]
+
+    def test_run_actor_use_subscription_true_sets_actor_key(self):
+        overrides = self._capture_run_actor_overrides(use_subscription=True)
+        self.assertEqual(overrides.actor_keys, {"use-subscription": "true"})
+        self.assertEqual(overrides.agent_args, {})
+
+    def test_run_actor_use_subscription_false_sets_actor_key(self):
+        overrides = self._capture_run_actor_overrides(use_subscription=False)
+        self.assertEqual(overrides.actor_keys, {"use-subscription": "false"})
+        self.assertEqual(overrides.agent_args, {})
+
+    def test_run_actor_use_subscription_default_none_emits_nothing(self):
+        overrides = self._capture_run_actor_overrides()
+        self.assertEqual(overrides.actor_keys, {})
+
+    def test_run_actor_rejects_use_subscription_via_config(self):
+        from actor import server
+        from actor.types import AgentKind
+        with patch("actor.server._db") as db_fn, \
+             patch("actor.server._spawn_background_run") as spawn:
+            db_fn.return_value.get_actor.return_value.agent = AgentKind.CLAUDE
+            with self.assertRaises(ConfigError):
+                server.run_actor(
+                    name="foo", prompt="do x", config=["use-subscription=true"],
+                )
+        spawn.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -132,9 +132,9 @@ class TestLoadConfigParseShapes(unittest.TestCase):
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
             p = Path(cwd) / ".actor" / "settings.kdl"
             p.parent.mkdir()
-            p.write_text('template "x" {\n    strip-api-keys true\n}\n')
+            p.write_text('template "x" {\n    use-subscription true\n}\n')
             cfg = load_config(cwd=Path(cwd), home=Path(home))
-            self.assertEqual(cfg.templates["x"].config["strip-api-keys"], "true")
+            self.assertEqual(cfg.templates["x"].config["use-subscription"], "true")
 
     def test_int_value_coerced_without_trailing_zero(self):
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from actor.config import AppConfig, Template, load_config
+from actor.config import AgentDefaults, AppConfig, Template, load_config
 from actor.errors import ConfigError
 
 
@@ -289,6 +289,195 @@ class TestLoadConfigCwdUnderHome(unittest.TestCase):
             )
             cfg = load_config(cwd=proj, home=home_p)
             self.assertEqual(cfg.templates["qa"].agent, "codex")
+
+
+class TestLoadConfigAgentBlocks(unittest.TestCase):
+
+    def _write(self, path: Path, body: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    def test_agent_defaults_parsed(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    use-subscription false\n'
+                '    defaults {\n'
+                '        permission-mode "bypassPermissions"\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            d = cfg.agent_defaults["claude"]
+            self.assertEqual(d.actor_keys, {"use-subscription": "false"})
+            self.assertEqual(
+                d.agent_args,
+                {"permission-mode": "bypassPermissions", "model": "opus"},
+            )
+
+    def test_null_in_defaults_is_stripped_by_merge(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    defaults {\n'
+                '        permission-mode null\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            # Null at top level with nothing to cancel leaves an empty
+            # AgentDefaults; the merge step drops empty blocks entirely.
+            self.assertNotIn("claude", cfg.agent_defaults)
+
+    def test_unknown_agent_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'agent "bogus" {\n'
+                '    defaults {\n'
+                '        x "1"\n'
+                '    }\n'
+                '}\n'
+            )
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("bogus", str(ctx.exception))
+
+    def test_unknown_flat_key_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'agent "claude" {\n'
+                '    not-a-real-flat-key "x"\n'
+                '}\n'
+            )
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("not-a-real-flat-key", str(ctx.exception))
+
+    def test_project_agent_defaults_override_user_per_key(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    defaults {\n'
+                '        model "sonnet"\n'
+                '        permission-mode "auto"\n'
+                '    }\n'
+                '}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    defaults {\n'
+                '        permission-mode null\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            d = cfg.agent_defaults["claude"]
+            self.assertEqual(d.agent_args.get("model"), "sonnet")
+            self.assertNotIn("permission-mode", d.agent_args)
+
+    def test_project_agent_defaults_actor_key_override(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    use-subscription true\n'
+                '}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    use-subscription false\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            d = cfg.agent_defaults["claude"]
+            self.assertEqual(d.actor_keys.get("use-subscription"), "false")
+
+    def test_defaults_block_at_template_level_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'template "qa" {\n'
+                '    defaults {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n'
+            )
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("belong under", str(ctx.exception))
+
+    def test_codex_agent_defaults_parsed(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "codex" {\n'
+                '    defaults {\n'
+                '        m "o3"\n'
+                '        sandbox "read-only"\n'
+                '    }\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            d = cfg.agent_defaults["codex"]
+            self.assertEqual(d.agent_args, {"m": "o3", "sandbox": "read-only"})
+
+    def test_duplicate_agent_block_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'agent "claude" {\n'
+                '    use-subscription true\n'
+                '}\n'
+                'agent "claude" {\n'
+                '    use-subscription false\n'
+                '}\n'
+            )
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("claude", str(ctx.exception))
+
+    def test_agent_block_without_name_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(
+                'agent {\n'
+                '    defaults {\n'
+                '        model "opus"\n'
+                '    }\n'
+                '}\n'
+            )
+            with self.assertRaises(ConfigError):
+                load_config(cwd=Path(cwd), home=Path(home))
+
+    def test_null_flat_key_parses_as_none(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    use-subscription true\n'
+                '}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'agent "claude" {\n'
+                '    use-subscription null\n'
+                '}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertNotIn("claude", cfg.agent_defaults)
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,8 +145,9 @@ class TestLoadConfigParseShapes(unittest.TestCase):
             self.assertEqual(cfg.templates["x"].config["max-budget-usd"], "5")
 
     def test_unknown_top_level_nodes_are_ignored(self):
-        # Forward-compat: hooks/agent/alias exist in follow-up tickets but
-        # should parse as no-ops today rather than erroring.
+        # Forward-compat: hooks / alias are reserved for follow-up tickets
+        # #30 / #33 and should parse as no-ops today rather than erroring.
+        # (`agent` is now a first-class node — see TestLoadConfigAgentBlocks.)
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
             p = Path(cwd) / ".actor" / "settings.kdl"
             p.parent.mkdir()
@@ -225,6 +226,24 @@ class TestLoadConfigParseStrict(unittest.TestCase):
         self._expect_error(
             'template "" {\n    agent "claude"\n}\n',
             "non-empty",
+        )
+
+    def test_null_in_template_raises_friendly_error(self):
+        # Null is only meaningful inside `agent { }` blocks (as a cancel
+        # marker). Inside templates it would silently stringify to "None"
+        # or crash with an ugly type error. Reject loudly.
+        self._expect_error(
+            'template "qa" {\n    model null\n}\n',
+            "null",
+        )
+
+    def test_bare_defaults_block_in_agent_raises(self):
+        # A `defaults` block with no children is ambiguous (did the user
+        # mean to unset something? forget to fill it in?). Reject rather
+        # than silently accept a no-op.
+        self._expect_error(
+            'agent "claude" {\n    defaults {\n    }\n}\n',
+            "defaults",
         )
 
 
@@ -317,7 +336,7 @@ class TestLoadConfigAgentBlocks(unittest.TestCase):
                 {"permission-mode": "bypassPermissions", "model": "opus"},
             )
 
-    def test_null_in_defaults_is_stripped_by_merge(self):
+    def test_null_in_defaults_survives_merge_as_cancel_marker(self):
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
             self._write(
                 Path(cwd) / ".actor" / "settings.kdl",
@@ -328,9 +347,12 @@ class TestLoadConfigAgentBlocks(unittest.TestCase):
                 '}\n',
             )
             cfg = load_config(cwd=Path(cwd), home=Path(home))
-            # Null at top level with nothing to cancel leaves an empty
-            # AgentDefaults; the merge step drops empty blocks entirely.
-            self.assertNotIn("claude", cfg.agent_defaults)
+            # Null must survive all the way to cmd_new so it can cancel a
+            # lower-precedence class default.
+            self.assertIn("claude", cfg.agent_defaults)
+            self.assertIsNone(
+                cfg.agent_defaults["claude"].agent_args["permission-mode"]
+            )
 
     def test_unknown_agent_rejected(self):
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
@@ -382,7 +404,10 @@ class TestLoadConfigAgentBlocks(unittest.TestCase):
             cfg = load_config(cwd=Path(cwd), home=Path(home))
             d = cfg.agent_defaults["claude"]
             self.assertEqual(d.agent_args.get("model"), "sonnet")
-            self.assertNotIn("permission-mode", d.agent_args)
+            # project layer null wins over user layer "auto" and is preserved
+            # as a cancel marker for cmd_new's class-default merge.
+            self.assertIn("permission-mode", d.agent_args)
+            self.assertIsNone(d.agent_args["permission-mode"])
 
     def test_project_agent_defaults_actor_key_override(self):
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
@@ -462,7 +487,7 @@ class TestLoadConfigAgentBlocks(unittest.TestCase):
             with self.assertRaises(ConfigError):
                 load_config(cwd=Path(cwd), home=Path(home))
 
-    def test_null_flat_key_parses_as_none(self):
+    def test_null_flat_key_survives_merge(self):
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
             self._write(
                 Path(home) / ".actor" / "settings.kdl",
@@ -477,7 +502,12 @@ class TestLoadConfigAgentBlocks(unittest.TestCase):
                 '}\n',
             )
             cfg = load_config(cwd=Path(cwd), home=Path(home))
-            self.assertNotIn("claude", cfg.agent_defaults)
+            # Project layer null wins over user layer "true" and is preserved
+            # so cmd_new can cancel the class ACTOR_DEFAULTS entry.
+            self.assertIn("claude", cfg.agent_defaults)
+            self.assertIsNone(
+                cfg.agent_defaults["claude"].actor_keys["use-subscription"]
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -246,6 +246,20 @@ class TestLoadConfigParseStrict(unittest.TestCase):
             "defaults",
         )
 
+    def test_actor_key_inside_defaults_block_raises(self):
+        # `use-subscription` is an actor-interpreted flag and must live at
+        # the top of the agent block, not inside `defaults { }` (which is
+        # for agent CLI flags). Let the user fix the shape rather than
+        # silently routing it through the wrong merge lane.
+        self._expect_error(
+            'agent "claude" {\n'
+            '    defaults {\n'
+            '        use-subscription "true"\n'
+            '    }\n'
+            '}\n',
+            "use-subscription",
+        )
+
 
 class TestLoadConfigCoercion(unittest.TestCase):
 
@@ -440,7 +454,7 @@ class TestLoadConfigAgentBlocks(unittest.TestCase):
             )
             with self.assertRaises(ConfigError) as ctx:
                 load_config(cwd=Path(cwd), home=Path(home))
-            self.assertIn("belong under", str(ctx.exception))
+            self.assertIn("reserved", str(ctx.exception))
 
     def test_codex_agent_defaults_parsed(self):
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:

--- a/tests/test_interactive_manager.py
+++ b/tests/test_interactive_manager.py
@@ -19,7 +19,7 @@ if sys.platform == "win32":
 
 from actor import INTERACTIVE_PROMPT
 from actor.db import Database
-from actor.types import Config, Status
+from actor.types import ActorConfig, Status
 from actor.watch.interactive.manager import InteractiveSessionManager
 from actor.watch.interactive.diagnostics import DiagnosticRecorder, EventKind
 
@@ -42,7 +42,7 @@ class _FakeAgent:
     def __init__(self, argv: list[str]) -> None:
         self._argv = argv
 
-    def interactive_argv(self, session_id: str, config: Config) -> list[str]:
+    def interactive_argv(self, session_id: str, config: ActorConfig) -> list[str]:
         return list(self._argv)
 
     def start(self, *a, **k):  # pragma: no cover
@@ -69,7 +69,7 @@ def _ensure_actor(db: Database, name: str, session: str = "sess-1") -> None:
     cmd_new(
         db, git,
         name=name, dir="/tmp", no_worktree=True, base=None,
-        agent_name="claude", config_pairs=[],
+        agent_name="claude", cli_overrides=ActorConfig(),
     )
     db.update_actor_session(name, session)
 
@@ -105,7 +105,7 @@ class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
             agent=_FakeAgent([cat]),
             session_id="sess-1",
             cwd=Path("/tmp"),
-            config={},
+            config=ActorConfig(),
         )
         self.assertTrue(self.manager.has("alice"))
         self.assertIs(self.manager.get("alice"), info)
@@ -120,13 +120,13 @@ class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
         cat = _find_binary("cat")
         first = self.manager.create(
             actor_name="alice", agent=_FakeAgent([cat]),
-            session_id="s", cwd=Path("/tmp"), config={},
+            session_id="s", cwd=Path("/tmp"), config=ActorConfig(),
         )
         try:
             with self.assertRaises(RuntimeError):
                 self.manager.create(
                     actor_name="alice", agent=_FakeAgent([cat]),
-                    session_id="s", cwd=Path("/tmp"), config={},
+                    session_id="s", cwd=Path("/tmp"), config=ActorConfig(),
                 )
             # The original session is still registered and alive.
             self.assertIs(self.manager.get("alice"), first)
@@ -137,7 +137,7 @@ class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
         cat = _find_binary("cat")
         info = self.manager.create(
             actor_name="alice", agent=_FakeAgent([cat]),
-            session_id="s", cwd=Path("/tmp"), config={},
+            session_id="s", cwd=Path("/tmp"), config=ActorConfig(),
         )
         self.manager.close("alice")
         self.assertFalse(self.manager.has("alice"))
@@ -151,7 +151,7 @@ class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
         sh = _find_binary("sh")
         info = self.manager.create(
             actor_name="alice", agent=_FakeAgent([sh, "-c", "exit 3"]),
-            session_id="s", cwd=Path("/tmp"), config={},
+            session_id="s", cwd=Path("/tmp"), config=ActorConfig(),
         )
         # Let child exit and on_exit chain run.
         for _ in range(200):
@@ -172,7 +172,7 @@ class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
         sh = _find_binary("sh")
         info = self.manager.create(
             actor_name="alice", agent=_FakeAgent([sh, "-c", "exit 0"]),
-            session_id="s", cwd=Path("/tmp"), config={},
+            session_id="s", cwd=Path("/tmp"), config=ActorConfig(),
         )
         for _ in range(200):
             run = self.db.get_run(info.run_id)
@@ -191,7 +191,7 @@ class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
         cat = _find_binary("cat")
         info = self.manager.create(
             actor_name="alice", agent=_FakeAgent([cat]),
-            session_id="s", cwd=Path("/tmp"), config={},
+            session_id="s", cwd=Path("/tmp"), config=ActorConfig(),
         )
         try:
             run = self.db.get_run(info.run_id)
@@ -211,7 +211,7 @@ class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
         sleep_bin = _find_binary("sleep")
         info = self.manager.create(
             actor_name="alice", agent=_FakeAgent([sleep_bin, "100"]),
-            session_id="s", cwd=Path("/tmp"), config={},
+            session_id="s", cwd=Path("/tmp"), config=ActorConfig(),
         )
         start = time.monotonic()
         self.manager.shutdown()
@@ -228,11 +228,11 @@ class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
         cat = _find_binary("cat")
         alice = self.manager.create(
             actor_name="alice", agent=_FakeAgent([cat]),
-            session_id="s1", cwd=Path("/tmp"), config={},
+            session_id="s1", cwd=Path("/tmp"), config=ActorConfig(),
         )
         bob = self.manager.create(
             actor_name="bob", agent=_FakeAgent([cat]),
-            session_id="s2", cwd=Path("/tmp"), config={},
+            session_id="s2", cwd=Path("/tmp"), config=ActorConfig(),
         )
         self.manager.close_all()
         self.assertEqual(self.manager.live_names(), [])
@@ -245,7 +245,7 @@ class InteractiveSessionManagerTests(unittest.IsolatedAsyncioTestCase):
         cat = _find_binary("cat")
         info = self.manager.create(
             actor_name="alice", agent=_FakeAgent([cat]),
-            session_id="s", cwd=Path("/tmp"), config={},
+            session_id="s", cwd=Path("/tmp"), config=ActorConfig(),
         )
         # Simulate external stop marking the row DONE before our on_exit.
         self.db.update_run_status(info.run_id, Status.DONE, 0)


### PR DESCRIPTION
## Summary

Redesign the per-agent defaults system introduced in #31 (PR #50 was closed). The new shape:

- `agent "<name>" { ... }` block holds **flat actor-keys** (interpreted by actor-sh, e.g. `use-subscription`) and a nested `defaults { }` sub-block whose children map straight to the agent binary's CLI flags. Claude emits semantic long flags (`permission-mode "auto"` → `--permission-mode auto`); Codex uses its native flag names verbatim (1-char → `-k value`, longer → `--key value`).
- Hardcoded baselines live on each agent class: `ClaudeAgent.AGENT_DEFAULTS = {"permission-mode": "auto"}` / `ACTOR_DEFAULTS = {"use-subscription": "true"}`; `CodexAgent.AGENT_DEFAULTS = {"sandbox": "danger-full-access", "a": "never"}` / `ACTOR_DEFAULTS = {"use-subscription": "true"}`.
- Merge precedence at `actor new`, lowest → highest: class defaults → user kdl → project kdl → template → CLI `--config`. `null` cancels a lower-precedence value at any layer.
- **Config is structured end-to-end.** `ActorConfig` dataclass carries `actor_keys` and `agent_args` as separate dicts, threaded from KDL parser → merge → CLI → DB → agent methods. `Agent._split_config` is gone; the split is preserved by construction. CLI `--config key=value` accepts agent_args only and rejects ACTOR_DEFAULTS keys, pointing users at dedicated flags. DB schema changes to a nested JSON shape (breaking, pre-1.0, no migration).
- Dropped: Claude's `bypassPermissions → --dangerously-skip-permissions` rewrite (users who want it now write `permission-mode "bypassPermissions"` literally), Codex's compound `--dangerously-bypass-approvals-and-sandbox` (now explicit `sandbox=danger-full-access` + `a=never`), and the private `_INTERNAL_KEYS` / `_permission_args` / `_config_args` / `claude_config_args` / `codex_config_args` surface.
- Renames: `strip-api-keys` → `use-subscription` (same polarity), `default-config` → `defaults`.
- Fixes a latent bug where `--permission-mode` could be emitted twice.

## Test plan

- [x] 369 unit tests pass (`uv run python -m unittest discover tests`)
- [x] New tests cover: parsing `agent { ... defaults { ... } }` blocks, null-cancel merge semantics, unknown-flat-key rejection, template-level rejection of `defaults { }`, codex per-agent defaults, precedence ladder across all four layers, structured ActorConfig threading end-to-end.
- [x] CI green on HEAD

Closes #31