### PR TITLE
Lifecycle hooks: on-start, before-run, after-run, on-discard (#30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,13 +213,47 @@ Built-in class defaults today:
   "never"}` and `CodexAgent.ACTOR_DEFAULTS = {"use-subscription":
   "true"}`.
 
-Unknown top-level nodes (e.g. `hooks`, `alias`) are silently ignored
-for forward-compat with follow-up tickets. A `defaults { ... }` block
+Unknown top-level nodes (e.g. `alias`) are silently ignored for
+forward-compat with follow-up tickets. A `defaults { ... }` block
 inside a template is rejected with a helpful error pointing users at
 the per-agent `agent "..." { defaults { ... } }` shape.
 
 Load programmatically via `actor.config.load_config(cwd=..., home=...)` —
 both args default to `Path.cwd()` / `$HOME` so tests can inject temp dirs.
+
+### Lifecycle hooks
+
+A top-level `hooks { }` block declares shell commands that fire around
+actor lifecycle events. Each value runs via `/bin/sh -c`, inheriting the
+caller's env plus `ACTOR_NAME`, `ACTOR_DIR`, `ACTOR_AGENT`, and (when
+set) `ACTOR_SESSION_ID`. Cwd is the actor's worktree.
+
+```kdl
+hooks {
+    on-start   "kubectl config use-context dev"
+    before-run "git fetch --quiet"
+    after-run  "./scripts/notify.sh"
+    on-discard "git diff --quiet && git diff --quiet --staged"
+}
+```
+
+- `on-start` — fires once during `actor new`, after the actor row is
+  recorded, before returning. Non-zero rolls back the row + worktree.
+- `before-run` — fires before every `actor run` (incl. interactive),
+  before the Run row is inserted. Non-zero aborts the run.
+- `after-run` — fires after the run completes and the DB row has been
+  updated with final status. Receives three extra env vars:
+  `ACTOR_RUN_ID`, `ACTOR_EXIT_CODE`, `ACTOR_DURATION_MS`. Non-zero
+  logs a warning but does NOT fail the completed run — there's nothing
+  to roll back.
+- `on-discard` — fires during `actor discard`, after cleanup (running
+  agents stopped), before the DB row is deleted. Non-zero aborts
+  discard unless `actor discard --force` / `-f` is passed. If the
+  worktree is gone, the hook runs from `$HOME` instead and `ACTOR_DIR`
+  still reports the missing path so the script can detect it.
+
+Project hooks override user hooks per event (same merge rule as
+templates).
 
 ## Interactive mode
 

--- a/src/actor/__init__.py
+++ b/src/actor/__init__.py
@@ -18,6 +18,7 @@ from .errors import (
     AgentNotFoundError,
     GitError,
     ConfigError,
+    HookFailedError,
 )
 
 # Types
@@ -35,7 +36,10 @@ from .types import (
 )
 
 # Config
-from .config import AgentDefaults, AppConfig, Template, load_config
+from .config import AgentDefaults, AppConfig, Hooks, Template, load_config
+
+# Hooks runtime
+from .hooks import HookResult, HookRunner, hook_env, run_hook
 
 # Interfaces
 from .interfaces import (
@@ -96,6 +100,7 @@ __all__ = [
     "AgentNotFoundError",
     "GitError",
     "ConfigError",
+    "HookFailedError",
     # Types
     "AgentKind",
     "Status",
@@ -107,8 +112,14 @@ __all__ = [
     # Config
     "AgentDefaults",
     "AppConfig",
+    "Hooks",
     "Template",
     "load_config",
+    # Hooks runtime
+    "HookResult",
+    "HookRunner",
+    "hook_env",
+    "run_hook",
     # Interfaces
     "LogEntryKind",
     "LogEntry",

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -119,9 +119,38 @@ template "reviewer" {
   numbers; they're all coerced to strings to match the actor config
   pipeline.
 
-Unknown top-level nodes (`hooks`, `alias`) parse as no-ops today —
-they're reserved for follow-up tickets. Malformed KDL raises an error
-with the file path.
+Unknown top-level nodes (`alias`) parse as no-ops today — they're
+reserved for follow-up tickets. Malformed KDL raises an error with the
+file path.
+
+**Lifecycle hooks** run shell commands around actor events (create,
+run, discard) via an optional top-level `hooks { }` block. Each value
+runs via `/bin/sh -c` with `ACTOR_NAME`, `ACTOR_DIR`, `ACTOR_AGENT`,
+and `ACTOR_SESSION_ID` (when set) in the env; cwd is the actor's
+worktree:
+
+```kdl
+hooks {
+    on-start   "./scripts/setup.sh"
+    before-run "git fetch --quiet"
+    after-run  "./scripts/notify.sh"
+    on-discard "git diff --quiet"
+}
+```
+
+- `on-start` — fires once during `actor new`. Non-zero rolls back
+  the actor.
+- `before-run` — fires before every `actor run` (incl. interactive).
+  Non-zero aborts the run with no DB row written.
+- `after-run` — fires after the run finishes and the DB row has
+  been updated with final status. Receives `ACTOR_RUN_ID`,
+  `ACTOR_EXIT_CODE`, `ACTOR_DURATION_MS`. Observer only — non-zero
+  exit logs a warning but does not fail the completed run.
+- `on-discard` — fires during `actor discard`. Non-zero aborts
+  discard unless the user runs `actor discard --force` (CLI) or
+  passes `force=True` to `discard_actor` (MCP).
+
+Project hooks override user hooks per event.
 
 **Per-agent defaults** live alongside templates and apply automatically
 to every new actor of that agent kind:

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -241,9 +241,15 @@ Examples:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
-  actor discard my-feature                          Remove actor from DB""",
+  actor discard my-feature                          Remove actor from DB
+  actor discard my-feature --force                  Ignore an on-discard hook failure""",
     )
     p_discard.add_argument("name", help="Actor name")
+    p_discard.add_argument(
+        "-f", "--force",
+        action="store_true",
+        help="Bypass on-discard hook failures (actor is discarded even if the hook exits non-zero)",
+    )
 
     # -- setup --
     p_setup = sub.add_parser(
@@ -412,6 +418,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 cli_overrides=cli_overrides,
                 template_name=args.template,
                 app_config=app_config,
+                hook_runner=None,
             )
             print(f"{actor.name} created ({actor.dir})")
 
@@ -438,17 +445,21 @@ def main(argv: Optional[List[str]] = None) -> None:
                         name=args.name,
                         prompt=prompt,
                         cli_overrides=ActorConfig(),  # creation flags already saved as defaults
+                        app_config=app_config,
                     )
                 except Exception as e:
                     print(f"error: actor created but run failed: {e}", file=sys.stderr)
                     sys.exit(2)
 
         elif args.command == "run":
+            from .config import load_config as _load_config_run
+            app_config_run = _load_config_run()
             # Interactive mode
             if args.interactive:
                 agent = agent_for(args.name)
                 exit_code, msg = cmd_interactive(
                     db, agent, proc_mgr, name=args.name,
+                    app_config=app_config_run,
                 )
                 print(msg, file=sys.stderr)
                 # POSIX convention for signal termination: 128 + signum.
@@ -474,6 +485,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 name=args.name,
                 prompt=prompt,
                 cli_overrides=cli_overrides,
+                app_config=app_config_run,
             )
 
         elif args.command == "list":
@@ -506,7 +518,12 @@ def main(argv: Optional[List[str]] = None) -> None:
                 print(output, end="")
 
         elif args.command == "discard":
-            msg = cmd_discard(db, proc_mgr, name=args.name)
+            from .config import load_config as _load_config_discard
+            msg = cmd_discard(
+                db, proc_mgr, name=args.name,
+                app_config=_load_config_discard(),
+                force=args.force,
+            )
             print(msg)
 
     except ActorError as e:

--- a/src/actor/commands.py
+++ b/src/actor/commands.py
@@ -11,12 +11,14 @@ from .errors import (
     ActorError,
     AgentNotFoundError,
     ConfigError,
+    HookFailedError,
     IsRunningError,
     NotRunningError,
 )
 
 if TYPE_CHECKING:
-    from .config import AppConfig
+    from .config import AppConfig, Hooks
+from .hooks import HookRunner, hook_env, run_hook
 from .interfaces import Agent, GitOps, LogEntry, LogEntryKind, ProcessManager, binary_exists
 from .types import (
     Actor,
@@ -126,6 +128,7 @@ def cmd_new(
     cli_overrides: ActorConfig,
     template_name: Optional[str] = None,
     app_config: Optional["AppConfig"] = None,
+    hook_runner: Optional[HookRunner] = None,
 ) -> Actor:
     validate_name(name)
 
@@ -252,6 +255,40 @@ def cmd_new(
                 print(f"warning: failed to clean up worktree at {wt_path}: {cleanup_err}", file=sys.stderr)
         raise
 
+    # on-start hook fires after the actor row + worktree exist so the hook
+    # script can assume both. Non-zero exit rolls everything back.
+    on_start = app_config.hooks.on_start if app_config is not None else None
+    if on_start is not None:
+        env = hook_env(
+            os.environ,
+            actor_name=name,
+            actor_dir=Path(actor_dir),
+            actor_agent=agent_kind.value,
+            actor_session_id=None,
+        )
+        try:
+            run_hook("on-start", on_start, env, Path(actor_dir), runner=hook_runner)
+        except Exception:
+            try:
+                db.delete_actor(name)
+            except Exception as rollback_err:
+                print(
+                    f"warning: failed to roll back actor row for '{name}' "
+                    f"after on-start hook failure: {rollback_err}",
+                    file=sys.stderr,
+                )
+            if worktree:
+                assert source_repo is not None
+                wt_path = _worktree_path(name)
+                try:
+                    git.remove_worktree(Path(source_repo), wt_path)
+                except Exception as cleanup_err:
+                    print(
+                        f"warning: failed to clean up worktree at {wt_path}: {cleanup_err}",
+                        file=sys.stderr,
+                    )
+            raise
+
     return actor
 
 
@@ -264,6 +301,8 @@ def cmd_run(
     name: str,
     prompt: str,
     cli_overrides: ActorConfig,
+    app_config: Optional["AppConfig"] = None,
+    hook_runner: Optional[HookRunner] = None,
 ) -> str:
     actor = db.get_actor(name)
 
@@ -282,6 +321,19 @@ def cmd_run(
         raise ActorError(
             f"actor directory '{actor.dir}' does not exist \u2014 use 'actor discard {name}' to clean up"
         )
+
+    # before-run hook fires before the Run row is inserted so a failing
+    # pre-flight check doesn't leave a phantom run behind.
+    before_run = app_config.hooks.before_run if app_config is not None else None
+    if before_run is not None:
+        env = hook_env(
+            os.environ,
+            actor_name=name,
+            actor_dir=dir_path,
+            actor_agent=actor.agent.value,
+            actor_session_id=actor.agent_session,
+        )
+        run_hook("before-run", before_run, env, dir_path, runner=hook_runner)
 
     # Merge config: actor defaults + run overrides. The split is preserved
     # — actor_keys and agent_args are layered independently. cli_overrides
@@ -351,8 +403,36 @@ def cmd_run(
     if current_run is not None and current_run.id == run_id and current_run.status == Status.STOPPED:
         return output
 
-    status = Status.DONE if exit_code == 0 else Status.ERROR
-    db.update_run_status(run_id, status, exit_code)
+    run_status = Status.DONE if exit_code == 0 else Status.ERROR
+    db.update_run_status(run_id, run_status, exit_code)
+
+    # after-run hook fires AFTER the DB has been updated with the final
+    # status so a hook that runs `actor show` sees the completed run.
+    # Non-zero exit is logged to stderr but does NOT fail the run — the
+    # agent has already finished and there's nothing to roll back.
+    after_run = app_config.hooks.after_run if app_config is not None else None
+    if after_run is not None:
+        # Refetch so ACTOR_SESSION_ID reflects any new_session set above.
+        refreshed = db.get_actor(name)
+        start = _parse_iso(run.started_at)
+        end = _parse_iso(_now_iso())
+        duration_ms = None
+        if start is not None and end is not None:
+            duration_ms = max(0, int((end - start).total_seconds() * 1000))
+        env = hook_env(
+            os.environ,
+            actor_name=name,
+            actor_dir=dir_path,
+            actor_agent=refreshed.agent.value,
+            actor_session_id=refreshed.agent_session,
+            actor_run_id=run_id,
+            actor_exit_code=exit_code,
+            actor_duration_ms=duration_ms,
+        )
+        try:
+            run_hook("after-run", after_run, env, dir_path, runner=hook_runner)
+        except HookFailedError as e:
+            print(f"warning: {e}", file=sys.stderr)
     return output
 
 
@@ -367,6 +447,8 @@ def cmd_interactive(
     proc_mgr: ProcessManager,
     name: str,
     runner: Optional[Callable[[List[str], Path, dict], int]] = None,
+    app_config: Optional["AppConfig"] = None,
+    hook_runner: Optional[HookRunner] = None,
 ) -> Tuple[int, str]:
     """`runner` is injectable so tests can drive without spawning a real
     subprocess. Returns (exit_code, status_message)."""
@@ -390,6 +472,18 @@ def cmd_interactive(
         raise ActorError(
             f"actor directory '{actor.dir}' does not exist \u2014 use 'actor discard {name}' to clean up"
         )
+
+    # before-run hook mirrors cmd_run. Fires before the Run row is inserted.
+    before_run = app_config.hooks.before_run if app_config is not None else None
+    if before_run is not None:
+        env = hook_env(
+            os.environ,
+            actor_name=name,
+            actor_dir=dir_path,
+            actor_agent=actor.agent.value,
+            actor_session_id=actor.agent_session,
+        )
+        run_hook("before-run", before_run, env, dir_path, runner=hook_runner)
 
     argv = agent.interactive_argv(session_id, actor.config)
 
@@ -422,6 +516,32 @@ def cmd_interactive(
 
     final = Status.DONE if exit_code == 0 else Status.ERROR
     db.update_run_status(run_id, final, exit_code)
+
+    # after-run hook (same semantics as cmd_run): fires AFTER the DB
+    # update with final status. Non-zero exit logs a warning but doesn't
+    # fail the completed session.
+    after_run = app_config.hooks.after_run if app_config is not None else None
+    if after_run is not None:
+        refreshed = db.get_actor(name)
+        start = _parse_iso(run.started_at)
+        end_ts = _parse_iso(_now_iso())
+        duration_ms = None
+        if start is not None and end_ts is not None:
+            duration_ms = max(0, int((end_ts - start).total_seconds() * 1000))
+        after_env = hook_env(
+            os.environ,
+            actor_name=name,
+            actor_dir=dir_path,
+            actor_agent=refreshed.agent.value,
+            actor_session_id=refreshed.agent_session,
+            actor_run_id=run_id,
+            actor_exit_code=exit_code,
+            actor_duration_ms=duration_ms,
+        )
+        try:
+            run_hook("after-run", after_run, after_env, dir_path, runner=hook_runner)
+        except HookFailedError as e:
+            print(f"warning: {e}", file=sys.stderr)
     return exit_code, f"Interactive session for '{name}' ended (exit {exit_code})."
 
 
@@ -699,8 +819,11 @@ def cmd_discard(
     proc_mgr: ProcessManager,
     name: str,
     _visited: set[str] | None = None,
+    app_config: Optional["AppConfig"] = None,
+    hook_runner: Optional[HookRunner] = None,
+    force: bool = False,
 ) -> str:
-    db.get_actor(name)
+    actor = db.get_actor(name)
 
     # Track visited to prevent infinite recursion on circular parent chains
     if _visited is None:
@@ -712,13 +835,43 @@ def cmd_discard(
     discarded = []
     for child in children:
         if child.name not in _visited:
-            msg = cmd_discard(db, proc_mgr, name=child.name, _visited=_visited)
+            msg = cmd_discard(
+                db, proc_mgr, name=child.name, _visited=_visited,
+                app_config=app_config, hook_runner=hook_runner, force=force,
+            )
             discarded.append(msg)
 
     # Stop if running
     status = db.resolve_actor_status(name, proc_mgr)
     if status == Status.RUNNING:
         _force_stop(db, proc_mgr, name)
+
+    # on-discard hook fires after resource cleanup, before DB delete.
+    # If the actor's worktree no longer exists on disk we run the hook
+    # from $HOME so subprocess.Popen can still get a valid cwd; the hook
+    # script can detect the missing-worktree case via ACTOR_DIR.
+    on_discard = app_config.hooks.on_discard if app_config is not None else None
+    if on_discard is not None:
+        actor_dir = Path(actor.dir)
+        hook_cwd = actor_dir if actor_dir.is_dir() else Path.home()
+        env = hook_env(
+            os.environ,
+            actor_name=name,
+            actor_dir=actor_dir,
+            actor_agent=actor.agent.value,
+            actor_session_id=actor.agent_session,
+        )
+        try:
+            run_hook("on-discard", on_discard, env, hook_cwd, runner=hook_runner)
+        except HookFailedError as e:
+            if force:
+                print(
+                    f"warning: on-discard hook failed but --force was set; "
+                    f"discarding anyway: {e}",
+                    file=sys.stderr,
+                )
+            else:
+                raise
 
     db.delete_actor(name)
     discarded.append(f"{name} discarded")

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -5,8 +5,9 @@ Loads ~/.actor/settings.kdl (user) and <project>/.actor/settings.kdl
 templates map and per-agent defaults. Project config overrides user
 config per-key.
 
-Out of scope (see tickets #30 / #33): hooks, aliases. Their nodes are
-skipped at parse time without error for forward compatibility.
+Out of scope (see ticket #33): aliases. Unknown top-level nodes are
+skipped at parse time without error for forward compatibility with
+follow-up features like `ask { }` (#52).
 """
 from __future__ import annotations
 
@@ -61,9 +62,26 @@ class AgentDefaults:
 
 
 @dataclass
+class Hooks:
+    on_start: Optional[str] = None
+    before_run: Optional[str] = None
+    after_run: Optional[str] = None
+    on_discard: Optional[str] = None
+
+
+@dataclass
 class AppConfig:
     templates: Dict[str, Template] = field(default_factory=dict)
     agent_defaults: Dict[str, AgentDefaults] = field(default_factory=dict)
+    hooks: Hooks = field(default_factory=Hooks)
+
+
+_HOOK_KEYS = {
+    "on-start": "on_start",
+    "before-run": "before_run",
+    "after-run": "after_run",
+    "on-discard": "on_discard",
+}
 
 
 def _find_project_config(
@@ -343,6 +361,52 @@ def _parse_agent_block(node, source: Path) -> Tuple[str, AgentDefaults]:
     return raw_name, defaults
 
 
+def _parse_hooks(node, source: Path) -> Hooks:
+    if node.args:
+        raise ConfigError(
+            f"hooks block in {source} does not accept positional args"
+        )
+    if getattr(node, "props", None):
+        raise ConfigError(
+            f"hooks block in {source} does not accept properties"
+        )
+    hooks = Hooks()
+    seen: set[str] = set()
+    for child in node.nodes:
+        key = child.name
+        attr = _HOOK_KEYS.get(key)
+        if attr is None:
+            raise ConfigError(
+                f"hooks block in {source}: unknown hook '{key}' "
+                f"(valid: {', '.join(_HOOK_KEYS)})"
+            )
+        if key in seen:
+            raise ConfigError(
+                f"hooks block in {source}: duplicate hook '{key}'"
+            )
+        seen.add(key)
+        if not child.args:
+            raise ConfigError(
+                f"hooks block in {source}: '{key}' needs a value"
+            )
+        if len(child.args) > 1:
+            raise ConfigError(
+                f"hooks block in {source}: '{key}' has extra args "
+                f"(only a single shell command is supported)"
+            )
+        if getattr(child, "props", None):
+            raise ConfigError(
+                f"hooks block in {source}: '{key}' does not accept properties"
+            )
+        raw = child.args[0]
+        if not isinstance(raw, str):
+            raise ConfigError(
+                f"hooks block in {source}: '{key}' must be a string"
+            )
+        setattr(hooks, attr, raw)
+    return hooks
+
+
 def _parse_kdl_file(path: Path) -> AppConfig:
     try:
         text = path.read_text()
@@ -353,6 +417,7 @@ def _parse_kdl_file(path: Path) -> AppConfig:
     except kdl.ParseError as e:
         raise ConfigError(f"parse error in {path}: {e}") from e
     cfg = AppConfig()
+    hooks_seen = False
     for node in doc.nodes:
         if node.name == "template":
             tpl = _parse_template(node, path)
@@ -368,8 +433,16 @@ def _parse_kdl_file(path: Path) -> AppConfig:
                     f"duplicate agent block '{name}' in {path}"
                 )
             cfg.agent_defaults[name] = defaults
-        # Silently ignore hooks / alias — those belong to follow-up
-        # tickets #30 / #33 and are not implemented here.
+        elif node.name == "hooks":
+            if hooks_seen:
+                raise ConfigError(
+                    f"duplicate hooks block in {path}"
+                )
+            hooks_seen = True
+            cfg.hooks = _parse_hooks(node, path)
+        # Silently ignore alias / ask — follow-up tickets (#33 / #52)
+        # add them; keeping the parser lenient here preserves forward
+        # compat for any new top-level blocks.
     return cfg
 
 
@@ -410,9 +483,16 @@ def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
         k: v for k, v in merged_defaults.items()
         if v.actor_keys or v.agent_args
     }
+    merged_hooks = Hooks(
+        on_start=over.hooks.on_start if over.hooks.on_start is not None else base.hooks.on_start,
+        before_run=over.hooks.before_run if over.hooks.before_run is not None else base.hooks.before_run,
+        after_run=over.hooks.after_run if over.hooks.after_run is not None else base.hooks.after_run,
+        on_discard=over.hooks.on_discard if over.hooks.on_discard is not None else base.hooks.on_discard,
+    )
     return AppConfig(
         templates=merged_templates,
         agent_defaults=merged_defaults,
+        hooks=merged_hooks,
     )
 
 

--- a/src/actor/errors.py
+++ b/src/actor/errors.py
@@ -48,3 +48,57 @@ class GitError(ActorError):
 class ConfigError(ActorError):
     def __init__(self, msg: str) -> None:
         super().__init__(f"config error: {msg}")
+
+
+class HookFailedError(ActorError):
+    def __init__(
+        self,
+        event: str,
+        command: str,
+        exit_code: int,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> None:
+        self.event = event
+        self.command = command
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        msg = f"{event} hook failed (exit {exit_code}): {command}"
+        tail = _format_output_tail(stdout, stderr)
+        if tail:
+            msg = f"{msg}\n{tail}"
+        super().__init__(msg)
+
+
+# Cap how much captured hook output we embed in the error message — enough
+# context for debugging, not so much that a chatty hook buries the actual
+# failure when this surfaces in the TUI or MCP response.
+_HOOK_OUTPUT_TAIL_LINES = 10
+_HOOK_OUTPUT_TAIL_CHARS = 800
+
+
+def _format_output_tail(stdout: str, stderr: str) -> str:
+    parts: list[str] = []
+    for label, text in (("stderr", stderr), ("stdout", stdout)):
+        trimmed = _tail(text)
+        if trimmed:
+            parts.append(f"  {label} tail:\n{_indent(trimmed)}")
+    return "\n".join(parts)
+
+
+def _tail(text: str) -> str:
+    text = text.rstrip()
+    if not text:
+        return ""
+    lines = text.splitlines()
+    if len(lines) > _HOOK_OUTPUT_TAIL_LINES:
+        lines = lines[-_HOOK_OUTPUT_TAIL_LINES:]
+    tail = "\n".join(lines)
+    if len(tail) > _HOOK_OUTPUT_TAIL_CHARS:
+        tail = tail[-_HOOK_OUTPUT_TAIL_CHARS:]
+    return tail
+
+
+def _indent(text: str) -> str:
+    return "\n".join(f"    {line}" for line in text.splitlines())

--- a/src/actor/hooks.py
+++ b/src/actor/hooks.py
@@ -1,0 +1,148 @@
+"""Lifecycle hook execution for actor.sh.
+
+Hooks are single shell commands declared in settings.kdl under the
+`hooks {}` block. They run via /bin/sh -c, inherit the caller's env plus
+ACTOR_* variables, and their exit code decides whether the surrounding
+operation (create / run / discard) proceeds.
+
+Kept as a separate module so tests can inject a fake runner via the
+HookRunner type without touching subprocess.
+"""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Mapping, MutableMapping, Optional, Union
+
+from .errors import HookFailedError
+
+
+def merge_env_extra(
+    env: MutableMapping[str, str],
+    env_extra: Optional[Mapping[str, Optional[str]]],
+) -> None:
+    """Merge ``env_extra`` into ``env`` in place. A value of ``None`` means
+    "unset this key" so callers can scrub stale parent-env vars without
+    mutating ``os.environ`` (thread-safe for concurrent Agent calls)."""
+    if env_extra is None:
+        return
+    for key, value in env_extra.items():
+        if value is None:
+            env.pop(key, None)
+        elif isinstance(value, str) and not isinstance(value, bool):
+            env[key] = value
+        else:
+            raise TypeError(
+                f"env_extra[{key!r}] must be str or None, got "
+                f"{type(value).__name__} ({value!r})"
+            )
+
+
+@dataclass(frozen=True)
+class HookResult:
+    """Outcome of a single hook invocation.
+
+    The default runner captures stdio so inherited stdout/stderr can't
+    corrupt the parent (MCP server's JSON, TUI redraws, etc.).
+    """
+
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+# Signature: (command, env, cwd) -> int | HookResult. Test fakes
+# typically return a bare int; the default runner returns HookResult so
+# captured stdio can flow into HookFailedError on failure. ``run_hook``
+# normalizes both.
+HookRunner = Callable[[str, Mapping[str, str], Path], Union[int, HookResult]]
+
+
+def run_hook(
+    event: str,
+    command: Optional[str],
+    env: Mapping[str, str],
+    cwd: Path,
+    runner: Optional[HookRunner] = None,
+) -> None:
+    """Execute a hook. No-op when command is None. Raises HookFailedError
+    on non-zero exit."""
+    if command is None:
+        return
+    exec_runner = runner if runner is not None else _default_hook_runner
+    result = exec_runner(command, env, cwd)
+    if isinstance(result, HookResult):
+        exit_code = result.exit_code
+        stdout = result.stdout
+        stderr = result.stderr
+    elif isinstance(result, int) and not isinstance(result, bool):
+        exit_code = result
+        stdout = ""
+        stderr = ""
+    else:
+        raise TypeError(
+            f"HookRunner for '{event}' returned {type(result).__name__} "
+            f"({result!r}); expected int or HookResult"
+        )
+    if exit_code != 0:
+        raise HookFailedError(
+            event, command, exit_code, stdout=stdout, stderr=stderr,
+        )
+
+
+def _default_hook_runner(
+    command: str, env: Mapping[str, str], cwd: Path
+) -> HookResult:
+    proc = subprocess.run(
+        ["/bin/sh", "-c", command],
+        cwd=str(cwd),
+        env=dict(env),
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+    )
+    return HookResult(
+        exit_code=proc.returncode,
+        stdout=proc.stdout or "",
+        stderr=proc.stderr or "",
+    )
+
+
+def hook_env(
+    base_env: Mapping[str, str],
+    actor_name: str,
+    actor_dir: Path,
+    actor_agent: str,
+    actor_session_id: Optional[str],
+    actor_run_id: Optional[int] = None,
+    actor_exit_code: Optional[int] = None,
+    actor_duration_ms: Optional[int] = None,
+) -> Dict[str, str]:
+    """Return a fresh dict combining base_env with ACTOR_* variables.
+
+    ``actor_run_id``, ``actor_exit_code``, and ``actor_duration_ms`` are
+    run-specific and only populated for hooks that fire around a
+    completed run (currently only ``after-run``)."""
+    env = dict(base_env)
+    env["ACTOR_NAME"] = actor_name
+    env["ACTOR_DIR"] = str(actor_dir)
+    env["ACTOR_AGENT"] = actor_agent
+    if actor_session_id is not None:
+        env["ACTOR_SESSION_ID"] = actor_session_id
+    else:
+        env.pop("ACTOR_SESSION_ID", None)
+    for key, value in (
+        ("ACTOR_RUN_ID", actor_run_id),
+        ("ACTOR_EXIT_CODE", actor_exit_code),
+        ("ACTOR_DURATION_MS", actor_duration_ms),
+    ):
+        if value is None:
+            env.pop(key, None)
+            continue
+        if isinstance(value, bool):
+            raise TypeError(
+                f"{key} expects int, got bool ({value!r})"
+            )
+        env[key] = str(value)
+    return env

--- a/src/actor/server.py
+++ b/src/actor/server.py
@@ -144,13 +144,18 @@ def stop_actor(name: str) -> str:
 
 
 @mcp.tool()
-def discard_actor(name: str) -> str:
+def discard_actor(name: str, force: bool = False) -> str:
     """Remove an actor from the database. Stops it first if running. Worktree stays on disk.
 
     Args:
         name: Actor name.
+        force: If True, ignore on-discard hook failures and discard anyway.
     """
-    return cmd_discard(_db(), RealProcessManager(), name=name)
+    from .config import load_config
+    return cmd_discard(
+        _db(), RealProcessManager(), name=name,
+        app_config=load_config(), force=force,
+    )
 
 
 @mcp.tool()
@@ -185,11 +190,13 @@ def _spawn_background_run(
         thread_db = Database.open(_db_path())
         output = ""
         try:
+            from .config import load_config as _lc
             output = cmd_run(
                 thread_db, agent_impl, pm,
                 name=name,
                 prompt=prompt,
                 cli_overrides=cli_overrides,
+                app_config=_lc(),
             )
         except Exception as e:
             output = str(e)
@@ -254,6 +261,8 @@ def new_actor(
     cli_overrides = _build_cli_overrides(
         agent_cls, config or [], use_subscription=use_subscription,
     )
+    from .config import load_config
+    app_config = load_config()
     actor = cmd_new(
         db, git,
         name=name,
@@ -262,6 +271,7 @@ def new_actor(
         base=base,
         agent_name=agent,
         cli_overrides=cli_overrides,
+        app_config=app_config,
     )
 
     if prompt is not None:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,500 @@
+"""Lifecycle hook tests.
+
+Covers: hooks.py runtime (run_hook, hook_env, merge_env_extra), KDL
+parsing of the `hooks { }` block, and the wiring in cmd_new / cmd_run /
+cmd_interactive / cmd_discard."""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import List, Tuple
+
+from actor import (
+    Database,
+    Status,
+    cmd_discard,
+    cmd_new,
+    cmd_run,
+    cmd_interactive,
+)
+from actor.config import AppConfig, Hooks, load_config
+from actor.errors import ConfigError, HookFailedError
+from actor.hooks import HookResult, hook_env, merge_env_extra, run_hook
+
+# Reuse the fakes from test_actor.py so we don't duplicate a test harness.
+from tests.test_actor import (
+    FakeAgent,
+    FakeGit,
+    FakeProcessManager,
+    _cli,
+    create_actor,
+)
+
+
+def _in_memory_db() -> Database:
+    return Database.open(":memory:")
+
+
+class _RecordingRunner:
+    """Test double for HookRunner. Records calls; returns a scripted outcome."""
+
+    def __init__(self, outcomes: List[int] | List[HookResult] | int = 0) -> None:
+        if isinstance(outcomes, list):
+            self._outcomes: list = list(outcomes)
+        else:
+            self._outcomes = [outcomes]
+        self.calls: List[Tuple[str, dict, Path]] = []
+
+    def __call__(self, command: str, env, cwd: Path):
+        self.calls.append((command, dict(env), cwd))
+        if not self._outcomes:
+            return 0
+        return self._outcomes.pop(0)
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  hooks.py — run_hook
+# ──────────────────────────────────────────────────────────────────────
+
+class TestRunHook(unittest.TestCase):
+
+    def test_none_command_is_noop(self):
+        # No runner invoked; no error.
+        run_hook("on-start", None, {}, Path("/tmp"))
+
+    def test_zero_exit_succeeds(self):
+        runner = _RecordingRunner(0)
+        run_hook("on-start", "echo hi", {"K": "V"}, Path("/tmp"), runner=runner)
+        self.assertEqual(len(runner.calls), 1)
+        cmd, env, cwd = runner.calls[0]
+        self.assertEqual(cmd, "echo hi")
+        self.assertEqual(env["K"], "V")
+        self.assertEqual(cwd, Path("/tmp"))
+
+    def test_nonzero_exit_raises_hook_failed(self):
+        runner = _RecordingRunner(2)
+        with self.assertRaises(HookFailedError) as ctx:
+            run_hook("on-start", "false", {}, Path("/tmp"), runner=runner)
+        self.assertEqual(ctx.exception.event, "on-start")
+        self.assertEqual(ctx.exception.exit_code, 2)
+        self.assertEqual(ctx.exception.command, "false")
+
+    def test_hook_result_stdout_stderr_carried_to_error(self):
+        runner = _RecordingRunner([HookResult(exit_code=7, stdout="out", stderr="boom")])
+        with self.assertRaises(HookFailedError) as ctx:
+            run_hook("on-discard", "x", {}, Path("/tmp"), runner=runner)
+        self.assertEqual(ctx.exception.stdout, "out")
+        self.assertEqual(ctx.exception.stderr, "boom")
+        self.assertIn("boom", str(ctx.exception))
+
+    def test_bool_return_rejected(self):
+        def bool_runner(cmd, env, cwd):
+            return True  # type: ignore[return-value]
+        with self.assertRaises(TypeError):
+            run_hook("on-start", "x", {}, Path("/tmp"), runner=bool_runner)
+
+
+class TestHookEnv(unittest.TestCase):
+
+    def test_sets_actor_vars(self):
+        out = hook_env(
+            {"PATH": "/bin"},
+            actor_name="foo",
+            actor_dir=Path("/tmp/x"),
+            actor_agent="claude",
+            actor_session_id="sess-123",
+        )
+        self.assertEqual(out["ACTOR_NAME"], "foo")
+        self.assertEqual(out["ACTOR_DIR"], "/tmp/x")
+        self.assertEqual(out["ACTOR_AGENT"], "claude")
+        self.assertEqual(out["ACTOR_SESSION_ID"], "sess-123")
+        self.assertEqual(out["PATH"], "/bin")
+        self.assertNotIn("ACTOR_RUN_ID", out)
+
+    def test_session_id_none_pops_existing(self):
+        out = hook_env(
+            {"ACTOR_SESSION_ID": "stale"},
+            actor_name="foo",
+            actor_dir=Path("/tmp"),
+            actor_agent="claude",
+            actor_session_id=None,
+        )
+        self.assertNotIn("ACTOR_SESSION_ID", out)
+
+    def test_run_vars_emitted_for_after_run(self):
+        out = hook_env(
+            {},
+            actor_name="foo",
+            actor_dir=Path("/tmp"),
+            actor_agent="codex",
+            actor_session_id=None,
+            actor_run_id=42,
+            actor_exit_code=0,
+            actor_duration_ms=1234,
+        )
+        self.assertEqual(out["ACTOR_RUN_ID"], "42")
+        self.assertEqual(out["ACTOR_EXIT_CODE"], "0")
+        self.assertEqual(out["ACTOR_DURATION_MS"], "1234")
+
+    def test_bool_for_int_vars_rejected(self):
+        with self.assertRaises(TypeError):
+            hook_env(
+                {},
+                actor_name="foo",
+                actor_dir=Path("/tmp"),
+                actor_agent="claude",
+                actor_session_id=None,
+                actor_exit_code=True,  # type: ignore[arg-type]
+            )
+
+
+class TestMergeEnvExtra(unittest.TestCase):
+
+    def test_string_value_sets(self):
+        env = {"A": "1"}
+        merge_env_extra(env, {"B": "2"})
+        self.assertEqual(env, {"A": "1", "B": "2"})
+
+    def test_none_value_unsets(self):
+        env = {"A": "1", "B": "2"}
+        merge_env_extra(env, {"B": None})
+        self.assertEqual(env, {"A": "1"})
+
+    def test_non_string_rejected(self):
+        env = {}
+        with self.assertRaises(TypeError):
+            merge_env_extra(env, {"K": 42})  # type: ignore[dict-item]
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  KDL parsing for the hooks block
+# ──────────────────────────────────────────────────────────────────────
+
+class TestHooksConfigParse(unittest.TestCase):
+
+    def _load(self, body: str) -> AppConfig:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            p = Path(cwd) / ".actor" / "settings.kdl"
+            p.parent.mkdir()
+            p.write_text(body)
+            return load_config(cwd=Path(cwd), home=Path(home))
+
+    def test_all_four_events(self):
+        cfg = self._load(
+            'hooks {\n'
+            '    on-start "./setup.sh"\n'
+            '    before-run "git fetch"\n'
+            '    after-run "./report.sh"\n'
+            '    on-discard "git diff --quiet"\n'
+            '}\n'
+        )
+        self.assertEqual(cfg.hooks.on_start, "./setup.sh")
+        self.assertEqual(cfg.hooks.before_run, "git fetch")
+        self.assertEqual(cfg.hooks.after_run, "./report.sh")
+        self.assertEqual(cfg.hooks.on_discard, "git diff --quiet")
+
+    def test_empty_block_leaves_defaults(self):
+        cfg = self._load("hooks { }\n")
+        self.assertIsNone(cfg.hooks.on_start)
+
+    def test_unknown_event_rejected(self):
+        with self.assertRaises(ConfigError):
+            self._load('hooks { on-wat "x" }\n')
+
+    def test_duplicate_event_rejected(self):
+        with self.assertRaises(ConfigError):
+            self._load('hooks {\n    on-start "a"\n    on-start "b"\n}\n')
+
+    def test_non_string_value_rejected(self):
+        with self.assertRaises(ConfigError):
+            self._load('hooks { on-start 42 }\n')
+
+    def test_project_overrides_user_per_event(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            (Path(home) / ".actor").mkdir()
+            (Path(home) / ".actor" / "settings.kdl").write_text(
+                'hooks {\n    on-start "user-start"\n    before-run "user-run"\n}\n'
+            )
+            (Path(cwd) / ".actor").mkdir()
+            (Path(cwd) / ".actor" / "settings.kdl").write_text(
+                'hooks {\n    before-run "proj-run"\n}\n'
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+        self.assertEqual(cfg.hooks.on_start, "user-start")  # from user
+        self.assertEqual(cfg.hooks.before_run, "proj-run")  # project wins
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  Wiring: cmd_new on-start
+# ──────────────────────────────────────────────────────────────────────
+
+class TestCmdNewOnStart(unittest.TestCase):
+
+    def test_on_start_fires_with_actor_env(self):
+        db = _in_memory_db()
+        runner = _RecordingRunner(0)
+        cfg = AppConfig(hooks=Hooks(on_start='echo "going"'))
+        cmd_new(
+            db, FakeGit(),
+            name="foo", dir="/tmp", no_worktree=True, base=None,
+            agent_name="claude", cli_overrides=_cli(),
+            app_config=cfg, hook_runner=runner,
+        )
+        self.assertEqual(len(runner.calls), 1)
+        _, env, _ = runner.calls[0]
+        self.assertEqual(env["ACTOR_NAME"], "foo")
+        self.assertEqual(env["ACTOR_AGENT"], "claude")
+
+    def test_on_start_failure_rolls_back_actor(self):
+        db = _in_memory_db()
+        runner = _RecordingRunner(2)
+        cfg = AppConfig(hooks=Hooks(on_start='false'))
+        with self.assertRaises(HookFailedError):
+            cmd_new(
+                db, FakeGit(),
+                name="foo", dir="/tmp", no_worktree=True, base=None,
+                agent_name="claude", cli_overrides=_cli(),
+                app_config=cfg, hook_runner=runner,
+            )
+        # Actor row gone after rollback.
+        self.assertEqual(db.list_actors(), [])
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  Wiring: cmd_run before-run + after-run
+# ──────────────────────────────────────────────────────────────────────
+
+class TestCmdRunBeforeRun(unittest.TestCase):
+
+    def test_before_run_veto_aborts_no_run_row(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        agent = FakeAgent()
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(before_run='false'))
+        runner = _RecordingRunner(1)
+        with self.assertRaises(HookFailedError):
+            cmd_run(
+                db, agent, pm,
+                name="foo", prompt="do x", cli_overrides=_cli(),
+                app_config=cfg, hook_runner=runner,
+            )
+        # No run inserted, no agent started.
+        self.assertEqual(len(agent.calls), 0)
+        self.assertIsNone(db.latest_run("foo"))
+
+    def test_before_run_success_proceeds(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        agent = FakeAgent()
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(before_run='echo ok'))
+        runner = _RecordingRunner(0)
+        cmd_run(
+            db, agent, pm,
+            name="foo", prompt="do x", cli_overrides=_cli(),
+            app_config=cfg, hook_runner=runner,
+        )
+        self.assertEqual(len(agent.calls), 1)
+
+
+class TestCmdRunAfterRun(unittest.TestCase):
+
+    def test_after_run_fires_after_db_update(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        agent = FakeAgent()
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(after_run='./report.sh'))
+        runner = _RecordingRunner(0)
+        cmd_run(
+            db, agent, pm,
+            name="foo", prompt="do x", cli_overrides=_cli(),
+            app_config=cfg, hook_runner=runner,
+        )
+        self.assertEqual(len(runner.calls), 1)
+        _, env, _ = runner.calls[0]
+        # DB was updated first — run row should be DONE by now
+        run = db.latest_run("foo")
+        self.assertIsNotNone(run)
+        self.assertEqual(run.status, Status.DONE)
+        # after-run-specific env vars present
+        self.assertIn("ACTOR_RUN_ID", env)
+        self.assertEqual(env["ACTOR_EXIT_CODE"], "0")
+        self.assertIn("ACTOR_DURATION_MS", env)
+
+    def test_after_run_failure_does_not_abort(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        agent = FakeAgent()
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(after_run='false'))
+        runner = _RecordingRunner(1)
+        # No exception propagated; run still returns.
+        output = cmd_run(
+            db, agent, pm,
+            name="foo", prompt="do x", cli_overrides=_cli(),
+            app_config=cfg, hook_runner=runner,
+        )
+        self.assertEqual(output, "fake output")
+        run = db.latest_run("foo")
+        self.assertEqual(run.status, Status.DONE)
+
+
+class TestCmdInteractiveHooks(unittest.TestCase):
+
+    def _setup(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        # cmd_interactive requires a session, so run once to set it.
+        agent = FakeAgent()
+        pm = FakeProcessManager()
+        cmd_run(
+            db, agent, pm, name="foo", prompt="first", cli_overrides=_cli(),
+        )
+        return db, agent, pm
+
+    def test_interactive_fires_before_and_after(self):
+        db, agent, pm = self._setup()
+        cfg = AppConfig(hooks=Hooks(before_run='a', after_run='b'))
+        runner = _RecordingRunner([0, 0])
+        def fake_runner(argv, cwd, env):
+            return 0
+        cmd_interactive(
+            db, agent, pm, name="foo", runner=fake_runner,
+            app_config=cfg, hook_runner=runner,
+        )
+        events = [c[0] for c in runner.calls]
+        self.assertEqual(events, ["a", "b"])
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  Wiring: cmd_discard on-discard
+# ──────────────────────────────────────────────────────────────────────
+
+class TestAfterRunInvariants(unittest.TestCase):
+    """Cases that are easy to break when refactoring after-run wiring."""
+
+    def test_after_run_skipped_when_before_run_vetoes(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        agent = FakeAgent()
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(before_run='bad', after_run='never'))
+        events: list[str] = []
+        def runner(cmd, env, cwd):
+            events.append(cmd)
+            return 1 if cmd == 'bad' else 0
+        with self.assertRaises(HookFailedError):
+            cmd_run(db, agent, pm, name="foo", prompt="x",
+                    cli_overrides=_cli(), app_config=cfg, hook_runner=runner)
+        # after-run never ran because before-run vetoed.
+        self.assertEqual(events, ['bad'])
+
+    def test_after_run_skipped_when_agent_start_raises(self):
+        from actor.errors import ActorError as AE
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        agent = FakeAgent()
+        agent.set_start_error(AE("boom"))
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(after_run='never'))
+        events: list[str] = []
+        def runner(cmd, env, cwd):
+            events.append(cmd)
+            return 0
+        with self.assertRaises(AE):
+            cmd_run(db, agent, pm, name="foo", prompt="x",
+                    cli_overrides=_cli(), app_config=cfg, hook_runner=runner)
+        self.assertEqual(events, [])
+
+    def test_after_run_receives_nonzero_exit_code_env_var(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        agent = FakeAgent()
+        agent.set_exit_code(2)
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(after_run='report'))
+        runner = _RecordingRunner(0)
+        cmd_run(db, agent, pm, name="foo", prompt="x",
+                cli_overrides=_cli(), app_config=cfg, hook_runner=runner)
+        _, env, _ = runner.calls[0]
+        self.assertEqual(env["ACTOR_EXIT_CODE"], "2")
+
+
+class TestCmdDiscardOnDiscard(unittest.TestCase):
+
+    def test_on_discard_fires_before_delete(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(on_discard='git diff --quiet'))
+        runner = _RecordingRunner(0)
+        cmd_discard(
+            db, pm, name="foo",
+            app_config=cfg, hook_runner=runner,
+        )
+        self.assertEqual(len(runner.calls), 1)
+        self.assertEqual(db.list_actors(), [])
+
+    def test_on_discard_failure_aborts_without_force(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(on_discard='false'))
+        runner = _RecordingRunner(1)
+        with self.assertRaises(HookFailedError):
+            cmd_discard(
+                db, pm, name="foo",
+                app_config=cfg, hook_runner=runner, force=False,
+            )
+        # Actor still in DB — not discarded.
+        self.assertEqual(len(db.list_actors()), 1)
+
+    def test_missing_worktree_falls_back_to_home_cwd(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        # Actor's dir is /tmp/foo (from create_actor no_worktree=True);
+        # to hit the missing-dir branch we override the actor row to
+        # point at a path that doesn't exist.
+        actor = db.get_actor("foo")
+        from actor import Actor
+        db.update_actor_config(
+            "foo", actor.config,
+        )
+        # Monkey-update the actor's dir via a targeted update (no helper
+        # exists for this; use a direct connection). Acceptable because
+        # the test just probes the on-discard branch behavior.
+        import sqlite3
+        # Database.open(":memory:") returns a wrapper; reach under the hood.
+        db._conn.execute(  # type: ignore[attr-defined]
+            "UPDATE actors SET dir=? WHERE name=?",
+            ("/tmp/actor-does-not-exist-xyz", "foo"),
+        )
+        db._conn.commit()  # type: ignore[attr-defined]
+
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(on_discard='pwd'))
+        runner = _RecordingRunner(0)
+        cmd_discard(db, pm, name="foo",
+                    app_config=cfg, hook_runner=runner, force=False)
+        _, _, cwd = runner.calls[0]
+        self.assertEqual(cwd, Path.home())
+
+    def test_force_bypasses_hook_failure(self):
+        db = _in_memory_db()
+        create_actor(db, "foo")
+        pm = FakeProcessManager()
+        cfg = AppConfig(hooks=Hooks(on_discard='false'))
+        runner = _RecordingRunner(1)
+        cmd_discard(
+            db, pm, name="foo",
+            app_config=cfg, hook_runner=runner, force=True,
+        )
+        # Discarded despite the failing hook.
+        self.assertEqual(db.list_actors(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fresh implementation of the lifecycle-hooks feature on top of current main. Replaces PR #49, whose branch had diverged too far for a clean merge after the #31 `ActorConfig` refactor landed.

Declarative shell-command hooks in `settings.kdl` fire around actor lifecycle events. Each hook runs via `/bin/sh -c`, inherits the caller's env plus actor-scoped vars, and its exit code decides whether the surrounding operation proceeds.

## KDL

```kdl
hooks {
    on-start   "./scripts/setup.sh"
    before-run "git fetch --quiet"
    after-run  "./scripts/notify.sh"
    on-discard "git diff --quiet"
}
```

## Semantics

| Event | Fires | Env vars | On non-zero |
|---|---|---|---|
| `on-start` | During `actor new`, after the DB row + worktree exist | Standard 4 | Rolls back actor row + worktree |
| `before-run` | Before `actor run` / `actor run -i`, before Run row is inserted | Standard 4 | Aborts the run with no DB trace |
| `after-run` | After the run completes AND the DB has been updated with final status | Standard 4 + `ACTOR_RUN_ID`, `ACTOR_EXIT_CODE`, `ACTOR_DURATION_MS` | Logs a warning; does NOT fail the completed run (observer only) |
| `on-discard` | During `actor discard`, after cleanup, before DB delete | Standard 4 | Aborts discard unless `--force` / `force=True` |

Standard env vars: `ACTOR_NAME`, `ACTOR_DIR`, `ACTOR_AGENT`, `ACTOR_SESSION_ID` (when set).

If the worktree is gone by discard time, the hook runs from `$HOME` and `ACTOR_DIR` still reports the missing path so the script can detect the case.

Project hooks override user hooks per event (same merge rule as templates).

## CLI / MCP

- `actor discard <name> --force` / `-f` — bypass an `on-discard` failure
- MCP `discard_actor(name, force=True)` — same, via the orchestrator

## Test plan

- [x] 409 tests pass (`uv run python -m unittest discover tests`) — 377 pre-existing + 32 new in `tests/test_hooks.py`
- [x] Tests cover: runtime (run_hook, hook_env, merge_env_extra), KDL parsing (all 4 events, unknown rejection, duplicate rejection, non-string rejection, user/project merge), wiring (on-start fire + rollback, before-run veto, after-run post-DB ordering + observer semantics, cmd_interactive firing both, on-discard gate + force bypass, worktree-gone fallback to `$HOME`, exit code propagation, skip-after-run-when-before-run-vetoes, skip-after-run-when-agent-start-fails)

## Relation to PR #49

Close PR #49 without merge. Its 6 commits implemented the same feature on top of pre-#31 main; the conflicts with the `ActorConfig` refactor were too deep to reconcile cleanly. This PR ports the feature onto the current architecture.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)