### PR TITLE
Auto-detect omarchy palette in watch TUI + live reload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,19 @@ hooks {
 Project hooks override user hooks per event (same merge rule as
 templates).
 
+## Watch theme
+
+The `actor watch` TUI ships with a `claude-dark` / `claude-light` pair
+as the default. If it detects omarchy running locally (presence of
+`~/.config/omarchy/current/theme/colors.toml`), it instead builds a
+Textual theme from that palette and activates it automatically. The
+file's resolved-target mtime is polled every 3s so `omarchy theme set
+<name>` swaps the TUI theme live, no restart needed.
+
+See `src/actor/watch/omarchy_theme.py` for the palette → Textual-slot
+mapping. Malformed TOML logs a warning and keeps whatever theme is
+active rather than crashing the TUI.
+
 ## Interactive mode
 
 Both the CLI and the watch TUI can open a live Claude/Codex session for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,16 +257,28 @@ templates).
 
 ## Watch theme
 
-The `actor watch` TUI ships with a `claude-dark` / `claude-light` pair
-as the default. If it detects omarchy running locally (presence of
-`~/.config/omarchy/current/theme/colors.toml`), it instead builds a
-Textual theme from that palette and activates it automatically. The
-file's resolved-target mtime is polled every 3s so `omarchy theme set
-<name>` swaps the TUI theme live, no restart needed.
+The `actor watch` TUI ships with `claude-dark` / `claude-light`. If it
+detects omarchy running locally (presence of
+`~/.config/omarchy/current/theme/colors.toml`), it **flavors** the
+claude-dark theme with omarchy's foreground color — the brand slots
+(primary / secondary / accent / warning / error / success / background /
+surface / panel) stay as claude-dark defines them, so the app still
+reads as an "Actor.sh" TUI but its body text matches the rest of the
+user's desktop. Today only the foreground slot is overridden; growing
+this to cover more slots is a one-line-per-slot extension.
 
-See `src/actor/watch/omarchy_theme.py` for the palette → Textual-slot
-mapping. Malformed TOML logs a warning and keeps whatever theme is
-active rather than crashing the TUI.
+**Live reload:** every 3 seconds we re-stat the resolved-target mtime of
+`colors.toml`. If it changed (e.g. the user ran `omarchy theme set
+<name>`), we rebuild the flavor and re-register under the same theme
+name. For instant updates, `actor setup --for omarchy` installs a
+one-line fragment into `~/.config/omarchy/hooks/theme-set` that sends
+`SIGUSR2` to any running `actor watch`, triggering an immediate reload.
+The SIGUSR2 handler is wired unconditionally — the setup command only
+adds the hook that sends the signal.
+
+See `src/actor/watch/omarchy_theme.py` for the flavor logic. Malformed
+TOML logs a warning and keeps whatever theme is active rather than
+crashing the TUI.
 
 ## Interactive mode
 

--- a/spec/PLAN-OMARCHY-THEME.md
+++ b/spec/PLAN-OMARCHY-THEME.md
@@ -1,0 +1,98 @@
+# Omarchy Theme Integration
+
+## Goal
+
+When the user is running omarchy, the `actor watch` TUI uses the omarchy
+palette automatically and stays in sync when the omarchy theme changes.
+Everywhere else, behavior is unchanged.
+
+## Detection
+
+Presence of `~/.config/omarchy/current/theme/colors.toml`. That file is a
+small TOML palette:
+
+```toml
+accent = "#7aa2f7"
+foreground = "#a9b1d6"
+background = "#1a1b26"
+color0 = "#32344a"
+...
+color15 = "#acb0d0"
+```
+
+`current/theme` is a symlink that `omarchy theme set <name>` flips to point
+at a different theme directory — so detecting a theme change is equivalent
+to detecting that the resolved target of `colors.toml` changed.
+
+## Palette → Textual Theme mapping
+
+| omarchy key | Textual slot |
+|---|---|
+| `background` | `background` |
+| `foreground` | `foreground` |
+| `accent` | `primary`, `accent` |
+| `color1` | `error` |
+| `color2` | `success` |
+| `color3` | `warning` |
+| `color5` | `secondary` |
+| `color0` | `panel` |
+| derived (`background` + 8% white) | `surface` |
+| derived from `background` luminance | `dark` (bool) |
+
+Missing keys → fall back to CLAUDE_DARK's value for that slot. Luminance
+uses the standard relative-luminance formula; < 0.5 → dark.
+
+## Load + live-reload behavior
+
+- **At startup** (`on_ready`): if `colors.toml` is present, build the
+  `OMARCHY` theme, register it, set it active. Otherwise use `CLAUDE_DARK`.
+  Remember the resolved-path mtime so we can detect changes later.
+- **Every 3 seconds** (via `set_interval`): re-stat the resolved path; if
+  the mtime changed, rebuild the theme, re-register, re-activate. Theme
+  name stays `"omarchy"` so Textual's re-registration handles the swap
+  cleanly.
+- **Non-TTY paths** (`actor watch --serve` for textual-serve browser
+  output): the palette we pick at startup is fine; skip the live-reload
+  interval since the server's clients wouldn't see mid-session changes
+  anyway. Worth calling out in docs but not worth complicating the code.
+
+## Error handling
+
+- Missing file → return `None`, caller falls back to CLAUDE_DARK.
+- Malformed TOML (parse error) / unreadable / broken symlink → log a
+  one-line warning via `stderr`, return `None`, caller keeps whatever
+  theme is active. Don't crash the TUI.
+- Hex value malformed → same treatment as malformed TOML.
+
+## Files
+
+- **New:** `src/actor/watch/omarchy_theme.py` — `load_omarchy_theme()`,
+  `omarchy_colors_path()`, `omarchy_theme_mtime()`, small luminance
+  helper. ~100 LOC.
+- **New:** `tests/test_omarchy_theme.py` — unit tests for the mapping,
+  missing-file, malformed-TOML, light/dark detection. ~80 LOC.
+- **Modified:** `src/actor/watch/app.py` — branch at theme registration;
+  add live-reload interval.
+- **Modified:** `src/actor/watch/themes.py` — no change needed if the new
+  module is self-contained. Exports a module-level `OMARCHY_NAME =
+  "omarchy"` constant if useful.
+- **Modified:** `CLAUDE.md` — one paragraph in the watch / architecture
+  section noting the auto-detect + live-reload behavior.
+
+## Out of scope
+
+- OSC 10/11 terminal-query fallback for non-omarchy users (separate
+  future ticket if we want to extend coverage).
+- Full ANSI-mode rendering (Textual `ansi_color=True`) — different
+  tradeoff, discussed and rejected.
+- Hooking into omarchy's `hooks/` mechanism for push-based theme
+  changes (polling is fine for the cadence).
+- Generating user CSS / terminal-theme files elsewhere in the system
+  from actor-sh's config — this is read-only inbound integration.
+
+## Non-goals worth naming
+
+- Exposing an `actor` CLI flag to force a theme (`--theme omarchy` etc.)
+  — users can live without, and it keeps the surface small.
+- Parsing `colors.toml` fields we don't use (cursor, selection_*).
+  Ignore them; forward-compat is free.

--- a/src/actor/cli.py
+++ b/src/actor/cli.py
@@ -254,20 +254,23 @@ Examples:
     # -- setup --
     p_setup = sub.add_parser(
         "setup",
-        help="Install or reinstall the actor skill + register the MCP with a coding agent",
+        help="Install/reinstall integrations: the actor skill + MCP with a coding agent, or the omarchy theme-set hook",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
   actor setup --for claude-code                     User-wide install
   actor setup --for claude-code --scope project     Project-local install
   actor setup --for claude-code --name actor-dev    Register under a different name
+  actor setup --for omarchy                         Install omarchy theme-set hook for instant TUI re-theme
+  actor setup --for omarchy --uninstall             Remove the omarchy hook
 
 'setup' is idempotent — safe to re-run. For a lightweight refresh of
 just the skill files after upgrading actor-sh, use 'actor update'.""",
     )
-    p_setup.add_argument("--for", dest="for_host", required=True, metavar="HOST", help="Coding agent host (currently supported: claude-code)")
-    p_setup.add_argument("--scope", default="user", choices=["user", "project", "local"], help="Where to install (default: user)")
-    p_setup.add_argument("--name", default="actor", help="Name to register the MCP under (default: actor)")
+    p_setup.add_argument("--for", dest="for_host", required=True, metavar="HOST", help="Integration target (claude-code, omarchy)")
+    p_setup.add_argument("--scope", default="user", choices=["user", "project", "local"], help="Where to install (default: user). Ignored for --for omarchy.")
+    p_setup.add_argument("--name", default="actor", help="Name to register the MCP under (default: actor). Ignored for --for omarchy.")
+    p_setup.add_argument("--uninstall", action="store_true", help="Remove a previously installed integration (currently only supported for --for omarchy)")
 
     # -- update --
     p_update = sub.add_parser(
@@ -349,6 +352,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 for_host=args.for_host,
                 scope=args.scope,
                 name=args.name,
+                uninstall=args.uninstall,
             )
             print(msg)
         except ActorError as e:

--- a/src/actor/setup.py
+++ b/src/actor/setup.py
@@ -16,8 +16,19 @@ from pathlib import Path
 from . import __version__
 from .errors import ActorError
 
-SUPPORTED_HOSTS = ("claude-code",)
+SUPPORTED_HOSTS = ("claude-code", "omarchy")
 SUPPORTED_SCOPES = ("user", "project", "local")
+
+# Sentinel markers used when we edit ~/.config/omarchy/hooks/theme-set.
+# Kept stable so uninstall can surgically remove only our block even if
+# the user has other content in the hook file.
+_OMARCHY_HOOK_BEGIN = "# BEGIN actor-sh (managed by `actor setup --for omarchy`)"
+_OMARCHY_HOOK_END = "# END actor-sh"
+_OMARCHY_HOOK_BODY = (
+    '# Reload any running `actor watch` TUI so its omarchy-blended theme\n'
+    '# picks up the new palette without restart.\n'
+    'pkill -SIGUSR2 -f "actor watch" 2>/dev/null || true'
+)
 _CLAUDE_MCP_TIMEOUT_SEC = 30
 # Skill name is used as a filesystem path segment; reject anything that
 # could escape the target parent dir or produce nonsense paths.
@@ -213,13 +224,104 @@ def _claude_mcp_add(name: str, scope: str, for_host: str) -> None:
         raise ActorError(f"`claude mcp add` failed: {stderr}")
 
 
+def _omarchy_hook_path() -> Path:
+    return Path.home() / ".config" / "omarchy" / "hooks" / "theme-set"
+
+
+def _strip_managed_block(text: str) -> str:
+    """Remove any existing actor-sh managed block from a hook file.
+
+    Lets setup stay idempotent: re-running replaces our block instead of
+    appending a duplicate. Also the basis for uninstall."""
+    begin = text.find(_OMARCHY_HOOK_BEGIN)
+    if begin == -1:
+        return text
+    end = text.find(_OMARCHY_HOOK_END, begin)
+    if end == -1:
+        # Marker opened but never closed (edited by hand). Don't touch it.
+        return text
+    end = text.find("\n", end)
+    if end == -1:
+        end = len(text)
+    else:
+        end += 1
+    # Also strip a single trailing blank line we may have written before it.
+    head = text[:begin].rstrip("\n")
+    tail = text[end:]
+    if head and tail:
+        return head + "\n\n" + tail.lstrip("\n")
+    return (head + "\n" + tail.lstrip("\n")).lstrip("\n")
+
+
+def _setup_omarchy(*, uninstall: bool) -> str:
+    """Install (or remove) the theme-set hook fragment that SIGUSR2s any
+    running actor-watch TUI so its omarchy-blended theme reloads on the
+    spot. Polling still works without this; the hook is an opt-in upgrade
+    from 3s latency to instant."""
+    if not (Path.home() / ".config" / "omarchy").is_dir():
+        raise ActorError(
+            "omarchy not detected (~/.config/omarchy/ is missing). "
+            "`actor setup --for omarchy` only makes sense on a host running "
+            "omarchy."
+        )
+
+    hook_path = _omarchy_hook_path()
+    existed = hook_path.is_file()
+    existing = hook_path.read_text() if existed else "#!/bin/bash\n"
+    cleaned = _strip_managed_block(existing)
+
+    if uninstall:
+        if cleaned == existing:
+            return f"actor-sh hook was not installed at {hook_path}; nothing to do."
+        new_text = cleaned
+        action = "removed"
+    else:
+        block = f"{_OMARCHY_HOOK_BEGIN}\n{_OMARCHY_HOOK_BODY}\n{_OMARCHY_HOOK_END}\n"
+        head = cleaned.rstrip("\n")
+        if head:
+            new_text = head + "\n\n" + block
+        else:
+            new_text = "#!/bin/bash\n\n" + block
+        if new_text == existing:
+            return f"actor-sh hook already installed at {hook_path}; nothing to do."
+        action = "installed" if not existed or "_OMARCHY_HOOK_BEGIN" not in existing else "refreshed"
+
+    hook_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_path.write_text(new_text)
+    try:
+        hook_path.chmod(0o755)
+    except OSError as e:
+        print(
+            f"[setup] warning: wrote {hook_path} but could not chmod +x: {e}",
+            file=sys.stderr,
+        )
+
+    verb = {
+        "installed": "installed",
+        "refreshed": "refreshed",
+        "removed": "removed",
+    }[action]
+    return (
+        f"actor-sh omarchy theme-set hook {verb} at {hook_path}. "
+        "Change the omarchy theme to test; any running `actor watch` should "
+        "re-theme instantly."
+    )
+
+
 def cmd_setup(
     *,
     for_host: str,
     scope: str,
     name: str,
+    uninstall: bool = False,
 ) -> str:
     _validate_host(for_host)
+    if for_host == "omarchy":
+        return _setup_omarchy(uninstall=uninstall)
+    if uninstall:
+        raise ActorError(
+            f"--uninstall is only supported for --for omarchy right now."
+        )
     _validate_scope(scope)
     _validate_name(name)
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -232,16 +232,11 @@ class ActorWatchApp(App):
             pass
 
     def _try_apply_omarchy_theme(self) -> bool:
-        """If omarchy is present, flavor CLAUDE_DARK with its palette
-        and register the result under the same name ('claude-dark') so
-        no extra picker entry appears. Returns True when omarchy
-        affected the rendered theme."""
-        flavored = apply_omarchy_flavor(CLAUDE_DARK)
-        if flavored is None:
-            return False
-        self._apply_flavored(flavored)
-        self._omarchy_mtime = omarchy_theme_mtime()
-        return True
+        """If omarchy is present, flavor the currently active Claude
+        base (dark or light) and register the result under its own
+        name so no extra picker entry appears. Returns True when
+        omarchy affected the rendered theme."""
+        return self._reflavor_current_base()
 
     def _poll_omarchy_theme(self) -> None:
         """Refresh the active theme if omarchy's colors.toml changed.
@@ -257,31 +252,46 @@ class ActorWatchApp(App):
             return
         if self._omarchy_mtime is not None and current == self._omarchy_mtime:
             return
-        flavored = apply_omarchy_flavor(CLAUDE_DARK)
-        if flavored is None:
-            return
-        self._apply_flavored(flavored)
+        self._reflavor_current_base()
         self._omarchy_mtime = current
 
-    def _apply_flavored(self, flavored) -> None:
+    def _reflavor_current_base(self) -> bool:
+        """Flavor whichever CLAUDE_* base matches the currently active
+        theme. Keeps user-chosen light/dark preference intact — each
+        base carries its own hardcoded surface + foreground, so the
+        flavor only shifts the slots apply_omarchy_flavor owns."""
+        active = getattr(self, "theme", None)
+        if active == "claude-light":
+            base = CLAUDE_LIGHT
+        else:
+            # Default to claude-dark on first application and on any
+            # other active name (e.g. textual's built-ins) so we
+            # always converge on our dark baseline when omarchy is
+            # present.
+            base = CLAUDE_DARK
+        flavored = apply_omarchy_flavor(base)
+        if flavored is None:
+            return False
+        self._apply_flavored(flavored, base.name)
+        self._omarchy_mtime = omarchy_theme_mtime()
+        return True
+
+    def _apply_flavored(self, flavored, name: str) -> None:
         """Register the flavored theme and force Textual to re-apply.
 
-        Setting `self.theme = "claude-dark"` when it's already the
-        active name is a no-op — the `theme` reactive compares names
-        for equality and short-circuits. Calling `_watch_theme`
-        directly runs the same invalidation chain the reactive would
-        have run on a real name change: toggles the light/dark CSS
-        class, refreshes the truecolor filter, and invalidates the
-        compiled stylesheet so our new palette actually renders."""
+        Setting `self.theme = name` when it's already the active name
+        is a no-op — the `theme` reactive compares names for equality
+        and short-circuits. Calling `_watch_theme` directly runs the
+        same invalidation chain the reactive would have run on a real
+        name change: toggles the light/dark CSS class, refreshes the
+        truecolor filter, and invalidates the compiled stylesheet so
+        our new palette actually renders."""
         self.register_theme(flavored)
-        if self.theme != "claude-dark":
-            self.theme = "claude-dark"
+        if self.theme != name:
+            self.theme = name
             return
         # Private but stable: Textual's public API has no "force
-        # re-apply without changing the name" hook. If this breaks in
-        # a future Textual release, fall back to a brief flip-and-flop:
-        #   self.theme = "claude-light"; self.theme = "claude-dark"
-        # which triggers the reactive twice and survives short-circuit.
+        # re-apply without changing the name" hook.
         self._watch_theme(self.theme)
 
     def _apply_markdown_styles(self) -> None:

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -32,8 +32,7 @@ from .interactive.widget import TerminalWidget
 from .patches import apply_patches
 from .splash import Splash
 from .omarchy_theme import (
-    OMARCHY_THEME_NAME,
-    load_omarchy_theme,
+    apply_omarchy_flavor,
     omarchy_theme_mtime,
 )
 from .themes import CLAUDE_DARK, CLAUDE_LIGHT
@@ -196,6 +195,14 @@ class ActorWatchApp(App):
         if not self._try_apply_omarchy_theme():
             self.theme = "claude-dark"
 
+        # SIGUSR2 → re-read palette NOW. Used by the optional
+        # `~/.config/omarchy/hooks/theme-set` hook installed via
+        # `actor setup --for omarchy` to get instant theme swaps (the
+        # 3s interval below is the no-setup fallback). Unsupported on
+        # Windows / in contexts without a running loop — silent skip;
+        # polling still works.
+        self._install_sigusr2_handler()
+
         # Apply Claude Code markdown styles to the app console
         self._apply_markdown_styles()
 
@@ -210,15 +217,30 @@ class ActorWatchApp(App):
         # machinery. No-op on non-omarchy systems.
         self.set_interval(3.0, self._poll_omarchy_theme)
 
+    def _install_sigusr2_handler(self) -> None:
+        """Wire SIGUSR2 into the asyncio loop so the hook installed via
+        `actor setup --for omarchy` can push-notify us on theme change.
+        Returns silently when the platform or event-loop state doesn't
+        support signal handlers (e.g. Windows, non-main thread)."""
+        try:
+            import asyncio
+            import signal
+            loop = asyncio.get_running_loop()
+            loop.add_signal_handler(signal.SIGUSR2, self._poll_omarchy_theme)
+        except (NotImplementedError, RuntimeError, ValueError):
+            # Polling covers us; no need to surface this.
+            pass
+
     def _try_apply_omarchy_theme(self) -> bool:
-        """If omarchy is present, register + activate its palette and
-        record the file mtime so we can detect future changes.
-        Returns True when the omarchy theme was applied."""
-        theme = load_omarchy_theme()
-        if theme is None:
+        """If omarchy is present, flavor CLAUDE_DARK with its palette
+        and register the result under the same name ('claude-dark') so
+        no extra picker entry appears. Returns True when omarchy
+        affected the rendered theme."""
+        flavored = apply_omarchy_flavor(CLAUDE_DARK)
+        if flavored is None:
             return False
-        self.register_theme(theme)
-        self.theme = OMARCHY_THEME_NAME
+        self.register_theme(flavored)
+        self.theme = "claude-dark"
         self._omarchy_mtime = omarchy_theme_mtime()
         return True
 
@@ -236,14 +258,14 @@ class ActorWatchApp(App):
             return
         if self._omarchy_mtime is not None and current == self._omarchy_mtime:
             return
-        theme = load_omarchy_theme()
-        if theme is None:
+        flavored = apply_omarchy_flavor(CLAUDE_DARK)
+        if flavored is None:
             return
-        self.register_theme(theme)
+        self.register_theme(flavored)
         # Reassigning forces Textual to re-apply styles even when the
         # theme name is unchanged — we want that because the palette
         # just shifted.
-        self.theme = OMARCHY_THEME_NAME
+        self.theme = "claude-dark"
         self._omarchy_mtime = current
 
     def _apply_markdown_styles(self) -> None:

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -239,8 +239,7 @@ class ActorWatchApp(App):
         flavored = apply_omarchy_flavor(CLAUDE_DARK)
         if flavored is None:
             return False
-        self.register_theme(flavored)
-        self.theme = "claude-dark"
+        self._apply_flavored(flavored)
         self._omarchy_mtime = omarchy_theme_mtime()
         return True
 
@@ -261,12 +260,29 @@ class ActorWatchApp(App):
         flavored = apply_omarchy_flavor(CLAUDE_DARK)
         if flavored is None:
             return
-        self.register_theme(flavored)
-        # Reassigning forces Textual to re-apply styles even when the
-        # theme name is unchanged — we want that because the palette
-        # just shifted.
-        self.theme = "claude-dark"
+        self._apply_flavored(flavored)
         self._omarchy_mtime = current
+
+    def _apply_flavored(self, flavored) -> None:
+        """Register the flavored theme and force Textual to re-apply.
+
+        Setting `self.theme = "claude-dark"` when it's already the
+        active name is a no-op — the `theme` reactive compares names
+        for equality and short-circuits. Calling `_watch_theme`
+        directly runs the same invalidation chain the reactive would
+        have run on a real name change: toggles the light/dark CSS
+        class, refreshes the truecolor filter, and invalidates the
+        compiled stylesheet so our new palette actually renders."""
+        self.register_theme(flavored)
+        if self.theme != "claude-dark":
+            self.theme = "claude-dark"
+            return
+        # Private but stable: Textual's public API has no "force
+        # re-apply without changing the name" hook. If this breaks in
+        # a future Textual release, fall back to a brief flip-and-flop:
+        #   self.theme = "claude-light"; self.theme = "claude-dark"
+        # which triggers the reactive twice and survives short-circuit.
+        self._watch_theme(self.theme)
 
     def _apply_markdown_styles(self) -> None:
         """Override Rich console markdown styles to match Claude Code."""

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -31,6 +31,11 @@ from .interactive.manager import InteractiveSessionManager
 from .interactive.widget import TerminalWidget
 from .patches import apply_patches
 from .splash import Splash
+from .omarchy_theme import (
+    OMARCHY_THEME_NAME,
+    load_omarchy_theme,
+    omarchy_theme_mtime,
+)
 from .themes import CLAUDE_DARK, CLAUDE_LIGHT
 from .tree import ActorTree
 from .helpers import read_log_entries, compute_diff
@@ -183,7 +188,13 @@ class ActorWatchApp(App):
     def on_ready(self) -> None:
         self.register_theme(CLAUDE_DARK)
         self.register_theme(CLAUDE_LIGHT)
-        self.theme = "claude-dark"
+
+        # Prefer omarchy's palette when we detect it; fall back to the
+        # hardcoded Claude themes otherwise. Live-reload below keeps us
+        # in sync with `omarchy theme set <name>`.
+        self._omarchy_mtime: float | None = None
+        if not self._try_apply_omarchy_theme():
+            self.theme = "claude-dark"
 
         # Apply Claude Code markdown styles to the app console
         self._apply_markdown_styles()
@@ -194,6 +205,46 @@ class ActorWatchApp(App):
         actors, statuses = self._fetch_actors()
         self._update_ui(actors, statuses)
         self.set_interval(2.0, self._poll_actors_async)
+        # Omarchy theme live-reload. Polls mtime; cheap enough that a
+        # 3s cadence is fine and we don't need inotify / platform-specific
+        # machinery. No-op on non-omarchy systems.
+        self.set_interval(3.0, self._poll_omarchy_theme)
+
+    def _try_apply_omarchy_theme(self) -> bool:
+        """If omarchy is present, register + activate its palette and
+        record the file mtime so we can detect future changes.
+        Returns True when the omarchy theme was applied."""
+        theme = load_omarchy_theme()
+        if theme is None:
+            return False
+        self.register_theme(theme)
+        self.theme = OMARCHY_THEME_NAME
+        self._omarchy_mtime = omarchy_theme_mtime()
+        return True
+
+    def _poll_omarchy_theme(self) -> None:
+        """Refresh the active theme if omarchy's colors.toml changed.
+
+        Cheap stat call; returns early when the file isn't there or
+        its mtime matches what we last saw. Malformed reloads keep
+        whatever theme is currently active."""
+        current = omarchy_theme_mtime()
+        if current is None:
+            # File vanished (user uninstalled omarchy or removed the
+            # symlink). Leave whatever theme is active as-is; they can
+            # re-run `actor watch` to fall back cleanly.
+            return
+        if self._omarchy_mtime is not None and current == self._omarchy_mtime:
+            return
+        theme = load_omarchy_theme()
+        if theme is None:
+            return
+        self.register_theme(theme)
+        # Reassigning forces Textual to re-apply styles even when the
+        # theme name is unchanged — we want that because the palette
+        # just shifted.
+        self.theme = OMARCHY_THEME_NAME
+        self._omarchy_mtime = current
 
     def _apply_markdown_styles(self) -> None:
         """Override Rich console markdown styles to match Claude Code."""

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -455,6 +455,13 @@ class ActorWatchApp(App):
         at_bottom = log.scroll_offset.y >= log.max_scroll_y - 1
 
         t = self.current_theme
+        # user_fg mirrors Claude Code's behavior: the user-message text
+        # uses the BASE theme's foreground (not the active theme's,
+        # which may have been flavored by omarchy). Pinning it to the
+        # unflavored base keeps legible contrast against the base-defined
+        # surface color no matter how much the flavor shifts the rest
+        # of the palette.
+        base = CLAUDE_DARK if (t and t.dark) else CLAUDE_LIGHT
         colors = ThemeColors(
             surface=t.surface if t else "#24283B",
             warning=t.warning if t else "#E0AF68",
@@ -462,6 +469,7 @@ class ActorWatchApp(App):
             success_color=t.success if t else "#4EBA65",
             error_color=t.error if t else "#FF6B80",
             inactive="#999999" if (t and t.dark) else "#666666",
+            user_fg=base.foreground,
         )
         render_log_entries(log, entries, colors)
 

--- a/src/actor/watch/omarchy_theme.py
+++ b/src/actor/watch/omarchy_theme.py
@@ -4,22 +4,30 @@ Omarchy is a Linux desktop setup that manages a coordinated color palette
 across terminal emulators, editors, and window managers. When a user
 switches themes via `omarchy theme set <name>`, the symlink at
 `~/.config/omarchy/current/theme` flips to point at the new theme
-directory; its `colors.toml` holds the shared hex palette.
+directory; its `colors.toml` holds the shared hex palette and
+`hyprland.conf` declares the active-window-border highlight.
 
-This module detects that file and returns a *flavored* variant of a
-supplied base theme — today only the foreground slot is pulled from
-omarchy, keeping every brand/semantic color from the base intact. That
-mirrors what Claude Code ends up looking like on omarchy (unstyled text
-follows the terminal's default FG; everything else stays branded) and
-avoids the "TUI looks like a totally different app" outcome a pure
-palette swap would produce.
+This module reads both and returns a *flavored* variant of a supplied
+base theme. Today we pull two slots from omarchy:
+
+- `foreground` from `colors.toml` — so body text matches the desktop's
+  default FG, giving plain prose the "feels-native" look Claude Code
+  gets for free from unstyled line output.
+- `primary` (and `accent`) from `hyprland.conf`'s `$activeBorderColor`
+  — so focus rings, selected rows, and active tabs glow the same color
+  as the user's active-window border.
+
+Every other slot (brand colors, semantic warn/err/success, backgrounds)
+stays as the base theme defines it, so the TUI still reads as
+"Actor.sh" rather than becoming a pure palette swap.
 
 Non-omarchy users never touch this — `apply_omarchy_flavor()` returns
-the base unchanged when the file isn't there. Malformed input is
+the base unchanged when the files aren't there. Malformed input is
 swallowed with a warning so a broken palette never takes down the TUI.
 """
 from __future__ import annotations
 
+import re
 import sys
 import tomllib
 from pathlib import Path
@@ -32,6 +40,17 @@ def omarchy_colors_path(home: Optional[Path] = None) -> Path:
     """Path to omarchy's active colors.toml. Does not check existence."""
     base = home if home is not None else Path.home()
     return base / ".config" / "omarchy" / "current" / "theme" / "colors.toml"
+
+
+def omarchy_hyprland_path(home: Optional[Path] = None) -> Path:
+    """Path to omarchy's active hyprland.conf. Does not check existence.
+
+    We don't stat this for the live-reload mtime check — colors.toml
+    and hyprland.conf live in the same theme directory, so a theme
+    switch flips them together. One stat covers both files' freshness.
+    """
+    base = home if home is not None else Path.home()
+    return base / ".config" / "omarchy" / "current" / "theme" / "hyprland.conf"
 
 
 def omarchy_theme_mtime(home: Optional[Path] = None) -> Optional[float]:
@@ -62,8 +81,9 @@ def apply_omarchy_flavor(
     data = _load_palette(home)
     if data is None:
         return None
+    active_border = _load_active_border(home)
     try:
-        return _flavor(base, data)
+        return _flavor(base, data, active_border)
     except (KeyError, ValueError, TypeError) as e:
         print(
             f"warning: omarchy palette is malformed: {e}",
@@ -87,21 +107,29 @@ def _load_palette(home: Optional[Path]) -> Optional[Dict[str, object]]:
         return None
 
 
-def _flavor(base: Theme, data: Dict[str, object]) -> Theme:
+def _flavor(
+    base: Theme,
+    data: Dict[str, object],
+    active_border: Optional[str],
+) -> Theme:
     """Overlay omarchy values onto `base`. Keep the base's name so it
     shows up under its existing picker entry (e.g. 'claude-dark') — the
     user doesn't see a separate 'omarchy' item.
 
-    Today only the foreground is overridden; every other slot stays as
-    `base` had it. We recompute `dark` from the overridden luminance in
-    case omarchy picks a light-mode theme while base is dark (or vice
-    versa) — keeps widget contrast logic correct."""
+    Overridden slots:
+    - `foreground` ← colors.toml's foreground (desktop-native body text)
+    - `primary` and `accent` ← hyprland.conf's $activeBorderColor
+      (TUI focus rings match active-window border)
+
+    Everything else stays as `base` had it."""
     foreground = _hex(data, "foreground", base.foreground)
+    primary = active_border if active_border is not None else base.primary
+    accent = active_border if active_border is not None else base.accent
     return Theme(
         name=base.name,
-        primary=base.primary,
+        primary=primary,
         secondary=base.secondary,
-        accent=base.accent,
+        accent=accent,
         warning=base.warning,
         error=base.error,
         success=base.success,
@@ -111,6 +139,38 @@ def _flavor(base: Theme, data: Dict[str, object]) -> Theme:
         panel=base.panel,
         dark=base.dark,
     )
+
+
+# Matches `$activeBorderColor = rgb(7aa2f7)` or `rgba(7aa2f7, 1.0)` at
+# the start of a line. Hyprland's config language accepts `$variable =
+# value` assignments and rgb()/rgba() color literals with bare hex
+# (no leading #). Alpha is parsed but ignored — Textual primary doesn't
+# do per-slot alpha.
+_ACTIVE_BORDER_RE = re.compile(
+    r"^\s*\$activeBorderColor\s*=\s*rgba?\(\s*([0-9a-fA-F]{6})",
+    re.MULTILINE,
+)
+
+
+def _load_active_border(home: Optional[Path]) -> Optional[str]:
+    """Extract $activeBorderColor from omarchy's hyprland.conf as a
+    '#rrggbb' string. Returns None if the file isn't there, can't be
+    read, or doesn't declare the variable in the expected shape."""
+    path = omarchy_hyprland_path(home)
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(errors="replace")
+    except OSError as e:
+        print(
+            f"warning: could not read omarchy hyprland.conf at {path}: {e}",
+            file=sys.stderr,
+        )
+        return None
+    match = _ACTIVE_BORDER_RE.search(text)
+    if match is None:
+        return None
+    return "#" + match.group(1).lower()
 
 
 def _hex(data: Dict[str, object], key: str, fallback: str) -> str:

--- a/src/actor/watch/omarchy_theme.py
+++ b/src/actor/watch/omarchy_theme.py
@@ -1,4 +1,4 @@
-"""Load the omarchy palette (if present) as a Textual theme.
+"""Blend the omarchy palette (if present) onto a base Textual theme.
 
 Omarchy is a Linux desktop setup that manages a coordinated color palette
 across terminal emulators, editors, and window managers. When a user
@@ -6,26 +6,26 @@ switches themes via `omarchy theme set <name>`, the symlink at
 `~/.config/omarchy/current/theme` flips to point at the new theme
 directory; its `colors.toml` holds the shared hex palette.
 
-This module detects that file, builds a Textual `Theme`, and exposes a
-way to re-read it so callers (the watch TUI) can poll for theme changes
-and hot-swap.
+This module detects that file and returns a *flavored* variant of a
+supplied base theme — today only the foreground slot is pulled from
+omarchy, keeping every brand/semantic color from the base intact. That
+mirrors what Claude Code ends up looking like on omarchy (unstyled text
+follows the terminal's default FG; everything else stays branded) and
+avoids the "TUI looks like a totally different app" outcome a pure
+palette swap would produce.
 
-Non-omarchy users never touch this — `load_omarchy_theme()` just returns
-`None` when the file isn't there. Malformed input is also swallowed with
-a warning so a broken palette never takes down the TUI.
+Non-omarchy users never touch this — `apply_omarchy_flavor()` returns
+the base unchanged when the file isn't there. Malformed input is
+swallowed with a warning so a broken palette never takes down the TUI.
 """
 from __future__ import annotations
 
-import os
 import sys
 import tomllib
 from pathlib import Path
 from typing import Dict, Optional
 
 from textual.theme import Theme
-
-
-OMARCHY_THEME_NAME = "omarchy"
 
 
 def omarchy_colors_path(home: Optional[Path] = None) -> Path:
@@ -48,18 +48,37 @@ def omarchy_theme_mtime(home: Optional[Path] = None) -> Optional[float]:
         return None
 
 
-def load_omarchy_theme(home: Optional[Path] = None) -> Optional[Theme]:
-    """Parse the active omarchy colors.toml into a Textual Theme.
+def apply_omarchy_flavor(
+    base: Theme, home: Optional[Path] = None,
+) -> Optional[Theme]:
+    """Return a variant of `base` with environment colors pulled from
+    omarchy's active palette. Returns None when omarchy isn't present
+    or the palette file is unreadable / malformed.
 
-    Returns None if the file isn't present or can't be parsed. A parse
-    failure is reported on stderr so users can diagnose but never crashes
-    the TUI."""
+    Scope is intentionally small — just the foreground today. Growing
+    this to cover background / surface / panel / semantic slots is a
+    one-line-per-slot extension once we've lived with the FG override
+    for a bit."""
+    data = _load_palette(home)
+    if data is None:
+        return None
+    try:
+        return _flavor(base, data)
+    except (KeyError, ValueError, TypeError) as e:
+        print(
+            f"warning: omarchy palette is malformed: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def _load_palette(home: Optional[Path]) -> Optional[Dict[str, object]]:
     path = omarchy_colors_path(home)
     if not path.is_file():
         return None
     try:
         raw = path.read_bytes()
-        data = tomllib.loads(raw.decode("utf-8"))
+        return tomllib.loads(raw.decode("utf-8"))
     except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as e:
         print(
             f"warning: could not read omarchy palette at {path}: {e}",
@@ -67,49 +86,30 @@ def load_omarchy_theme(home: Optional[Path] = None) -> Optional[Theme]:
         )
         return None
 
-    try:
-        return _build_theme(data)
-    except (KeyError, ValueError, TypeError) as e:
-        print(
-            f"warning: omarchy palette at {path} is malformed: {e}",
-            file=sys.stderr,
-        )
-        return None
 
+def _flavor(base: Theme, data: Dict[str, object]) -> Theme:
+    """Overlay omarchy values onto `base`. Keep the base's name so it
+    shows up under its existing picker entry (e.g. 'claude-dark') — the
+    user doesn't see a separate 'omarchy' item.
 
-def _build_theme(data: Dict[str, object]) -> Theme:
-    """Map the omarchy palette onto Textual's theme slots.
-
-    Missing keys fall back to values that render safely on most
-    backgrounds. Callers should prefer a complete palette — the
-    fallbacks exist so a partial/experimental colors.toml doesn't fail
-    outright."""
-    background = _hex(data, "background", "#1a1b26")
-    foreground = _hex(data, "foreground", "#a9b1d6")
-    accent = _hex(data, "accent", "#7aa2f7")
-
-    # 16-slot ANSI palette — omarchy always provides these but the
-    # fallbacks keep parsing robust for any partial config.
-    red = _hex(data, "color1", "#f7768e")
-    green = _hex(data, "color2", "#9ece6a")
-    yellow = _hex(data, "color3", "#e0af68")
-    magenta = _hex(data, "color5", "#ad8ee6")
-    black = _hex(data, "color0", "#32344a")
-
-    dark = _is_dark(background)
+    Today only the foreground is overridden; every other slot stays as
+    `base` had it. We recompute `dark` from the overridden luminance in
+    case omarchy picks a light-mode theme while base is dark (or vice
+    versa) — keeps widget contrast logic correct."""
+    foreground = _hex(data, "foreground", base.foreground)
     return Theme(
-        name=OMARCHY_THEME_NAME,
-        primary=accent,
-        secondary=magenta,
-        accent=accent,
-        warning=yellow,
-        error=red,
-        success=green,
+        name=base.name,
+        primary=base.primary,
+        secondary=base.secondary,
+        accent=base.accent,
+        warning=base.warning,
+        error=base.error,
+        success=base.success,
         foreground=foreground,
-        background=background,
-        surface=_shift_toward_foreground(background, foreground, 0.08),
-        panel=black,
-        dark=dark,
+        background=base.background,
+        surface=base.surface,
+        panel=base.panel,
+        dark=base.dark,
     )
 
 

--- a/src/actor/watch/omarchy_theme.py
+++ b/src/actor/watch/omarchy_theme.py
@@ -1,0 +1,169 @@
+"""Load the omarchy palette (if present) as a Textual theme.
+
+Omarchy is a Linux desktop setup that manages a coordinated color palette
+across terminal emulators, editors, and window managers. When a user
+switches themes via `omarchy theme set <name>`, the symlink at
+`~/.config/omarchy/current/theme` flips to point at the new theme
+directory; its `colors.toml` holds the shared hex palette.
+
+This module detects that file, builds a Textual `Theme`, and exposes a
+way to re-read it so callers (the watch TUI) can poll for theme changes
+and hot-swap.
+
+Non-omarchy users never touch this — `load_omarchy_theme()` just returns
+`None` when the file isn't there. Malformed input is also swallowed with
+a warning so a broken palette never takes down the TUI.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tomllib
+from pathlib import Path
+from typing import Dict, Optional
+
+from textual.theme import Theme
+
+
+OMARCHY_THEME_NAME = "omarchy"
+
+
+def omarchy_colors_path(home: Optional[Path] = None) -> Path:
+    """Path to omarchy's active colors.toml. Does not check existence."""
+    base = home if home is not None else Path.home()
+    return base / ".config" / "omarchy" / "current" / "theme" / "colors.toml"
+
+
+def omarchy_theme_mtime(home: Optional[Path] = None) -> Optional[float]:
+    """Resolve the symlink chain and return the target's mtime.
+
+    Returns None if the file doesn't exist or can't be statted. The
+    resolve-before-stat matters: `omarchy theme set X` changes the
+    symlink target, so statting the symlink itself may not reflect the
+    change on all filesystems."""
+    path = omarchy_colors_path(home)
+    try:
+        return path.resolve(strict=True).stat().st_mtime
+    except (OSError, RuntimeError):
+        return None
+
+
+def load_omarchy_theme(home: Optional[Path] = None) -> Optional[Theme]:
+    """Parse the active omarchy colors.toml into a Textual Theme.
+
+    Returns None if the file isn't present or can't be parsed. A parse
+    failure is reported on stderr so users can diagnose but never crashes
+    the TUI."""
+    path = omarchy_colors_path(home)
+    if not path.is_file():
+        return None
+    try:
+        raw = path.read_bytes()
+        data = tomllib.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as e:
+        print(
+            f"warning: could not read omarchy palette at {path}: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+    try:
+        return _build_theme(data)
+    except (KeyError, ValueError, TypeError) as e:
+        print(
+            f"warning: omarchy palette at {path} is malformed: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def _build_theme(data: Dict[str, object]) -> Theme:
+    """Map the omarchy palette onto Textual's theme slots.
+
+    Missing keys fall back to values that render safely on most
+    backgrounds. Callers should prefer a complete palette — the
+    fallbacks exist so a partial/experimental colors.toml doesn't fail
+    outright."""
+    background = _hex(data, "background", "#1a1b26")
+    foreground = _hex(data, "foreground", "#a9b1d6")
+    accent = _hex(data, "accent", "#7aa2f7")
+
+    # 16-slot ANSI palette — omarchy always provides these but the
+    # fallbacks keep parsing robust for any partial config.
+    red = _hex(data, "color1", "#f7768e")
+    green = _hex(data, "color2", "#9ece6a")
+    yellow = _hex(data, "color3", "#e0af68")
+    magenta = _hex(data, "color5", "#ad8ee6")
+    black = _hex(data, "color0", "#32344a")
+
+    dark = _is_dark(background)
+    return Theme(
+        name=OMARCHY_THEME_NAME,
+        primary=accent,
+        secondary=magenta,
+        accent=accent,
+        warning=yellow,
+        error=red,
+        success=green,
+        foreground=foreground,
+        background=background,
+        surface=_shift_toward_foreground(background, foreground, 0.08),
+        panel=black,
+        dark=dark,
+    )
+
+
+def _hex(data: Dict[str, object], key: str, fallback: str) -> str:
+    """Read a hex string from the palette; normalize + validate."""
+    raw = data.get(key, fallback)
+    if not isinstance(raw, str):
+        raise TypeError(f"{key} must be a string, got {type(raw).__name__}")
+    value = raw.strip()
+    if not value.startswith("#"):
+        raise ValueError(f"{key}={value!r} must be a hex color starting with '#'")
+    body = value[1:]
+    if len(body) not in (3, 6):
+        raise ValueError(f"{key}={value!r} must be 3 or 6 hex digits after '#'")
+    try:
+        int(body, 16)
+    except ValueError as e:
+        raise ValueError(f"{key}={value!r} is not valid hex: {e}")
+    if len(body) == 3:
+        return "#" + "".join(ch * 2 for ch in body.lower())
+    return "#" + body.lower()
+
+
+def _is_dark(hex_color: str) -> bool:
+    """Relative-luminance dark/light test. Uses the standard formula
+    from WCAG: < 0.5 is considered 'dark'."""
+    r, g, b = _to_rgb(hex_color)
+    # sRGB luminance approximation — simple linear weighting is enough
+    # for a dark/light bucket decision.
+    luma = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
+    return luma < 0.5
+
+
+def _shift_toward_foreground(bg: str, fg: str, amount: float) -> str:
+    """Return bg shifted `amount` of the way toward fg.
+
+    Used to derive a `surface` color that reads as a subtle lift above
+    the base background — matches what most themes produce by hand."""
+    br, bg_g, bb = _to_rgb(bg)
+    fr, fg_g, fb = _to_rgb(fg)
+    r = round(br + (fr - br) * amount)
+    g = round(bg_g + (fg_g - bg_g) * amount)
+    b = round(bb + (fb - bb) * amount)
+    return "#{:02x}{:02x}{:02x}".format(
+        max(0, min(255, r)),
+        max(0, min(255, g)),
+        max(0, min(255, b)),
+    )
+
+
+def _to_rgb(hex_color: str) -> tuple[int, int, int]:
+    body = hex_color.lstrip("#")
+    return (
+        int(body[0:2], 16),
+        int(body[2:4], 16),
+        int(body[4:6], 16),
+    )

--- a/src/actor/watch/render_user.py
+++ b/src/actor/watch/render_user.py
@@ -11,19 +11,24 @@ from .types import ThemeColors
 
 
 def render_user(log: RichLog, entry, colors: ThemeColors) -> None:
-    """Render a user message with ❯ prefix and surface background."""
+    """Render a user message with ❯ prefix and surface background.
+
+    Foreground is pinned via `colors.user_fg` (white by default) rather
+    than inherited from the active theme so flavored themes can't shift
+    it away from readable contrast on the surface background."""
     bg = f"on {colors.surface}"
+    fg = colors.user_fg
     table = Table(
         show_header=False,
         box=None,
         padding=0,
         expand=True,
-        style=bg,
+        style=f"{fg} {bg}",
     )
-    table.add_column(width=2, no_wrap=True, style=bg)
-    table.add_column(ratio=1, style=bg)
+    table.add_column(width=2, no_wrap=True, style=f"{fg} {bg}")
+    table.add_column(ratio=1, style=f"{fg} {bg}")
     table.add_row(
-        Text("❯ ", style=f"bold {bg}"),
-        Text(entry.text, style=bg),
+        Text("❯ ", style=f"bold {fg} {bg}"),
+        Text(entry.text, style=f"{fg} {bg}"),
     )
     log.write(table, expand=True)

--- a/src/actor/watch/types.py
+++ b/src/actor/watch/types.py
@@ -16,10 +16,12 @@ class ThemeColors(NamedTuple):
     success_color: str = "#4EBA65"
     error_color: str = "#FF6B80"
     inactive: str = "#999999"
-    # User-message FG is intentionally theme-agnostic: always white on
-    # the surface background. Pulling the theme's foreground here would
-    # produce unreadable contrast when flavored themes (e.g. omarchy)
-    # shift the FG away from pure white.
+    # User-message FG — mirrors Claude Code's `text` theme slot rather
+    # than the theme's overall foreground (which may have been flavored
+    # by omarchy). For CLAUDE_DARK this resolves to #FFFFFF, matching
+    # Claude's `text: rgb(255,255,255)` in its dark theme; for a future
+    # CLAUDE_LIGHT it'd be the black analogue. Concretely theme-
+    # dependent, but NOT palette-flavor-dependent.
     user_fg: str = "#FFFFFF"
 
 

--- a/src/actor/watch/types.py
+++ b/src/actor/watch/types.py
@@ -16,6 +16,11 @@ class ThemeColors(NamedTuple):
     success_color: str = "#4EBA65"
     error_color: str = "#FF6B80"
     inactive: str = "#999999"
+    # User-message FG is intentionally theme-agnostic: always white on
+    # the surface background. Pulling the theme's foreground here would
+    # produce unreadable contrast when flavored themes (e.g. omarchy)
+    # shift the FG away from pure white.
+    user_fg: str = "#FFFFFF"
 
 
 MAX_RESULT_LINES = 3

--- a/tests/test_omarchy_theme.py
+++ b/tests/test_omarchy_theme.py
@@ -12,9 +12,11 @@ from textual.theme import Theme
 from actor.watch.omarchy_theme import (
     _hex,
     _is_dark,
+    _load_active_border,
     _shift_toward_foreground,
     apply_omarchy_flavor,
     omarchy_colors_path,
+    omarchy_hyprland_path,
     omarchy_theme_mtime,
 )
 
@@ -40,6 +42,13 @@ _BASE = Theme(
 
 def _write_palette(home: Path, body: str) -> Path:
     target = home / ".config" / "omarchy" / "current" / "theme" / "colors.toml"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body)
+    return target
+
+
+def _write_hyprland(home: Path, body: str) -> Path:
+    target = home / ".config" / "omarchy" / "current" / "theme" / "hyprland.conf"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(body)
     return target
@@ -77,7 +86,9 @@ class TestApplyOmarchyFlavor(unittest.TestCase):
         with tempfile.TemporaryDirectory() as home:
             self.assertIsNone(apply_omarchy_flavor(_BASE, home=Path(home)))
 
-    def test_overrides_only_foreground(self):
+    def test_overrides_only_environmental_slots(self):
+        # No hyprland.conf → only FG gets overridden (palette flavor
+        # works even without the window-border file).
         with tempfile.TemporaryDirectory() as home:
             _write_palette(Path(home), _DARK_PALETTE)
             out = apply_omarchy_flavor(_BASE, home=Path(home))
@@ -96,8 +107,22 @@ class TestApplyOmarchyFlavor(unittest.TestCase):
         self.assertEqual(out.surface, "#333333")
         self.assertEqual(out.panel, "#444444")
         self.assertEqual(out.dark, True)
-        # Keeps the base's name so picker entries don't multiply.
         self.assertEqual(out.name, _BASE.name)
+
+    def test_active_border_overrides_primary_and_accent(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_palette(Path(home), _DARK_PALETTE)
+            _write_hyprland(
+                Path(home),
+                "$activeBorderColor = rgb(7aa2f7)\n\n"
+                "general {\n    col.active_border = $activeBorderColor\n}\n",
+            )
+            out = apply_omarchy_flavor(_BASE, home=Path(home))
+        assert out is not None
+        self.assertEqual(out.primary, "#7aa2f7")
+        self.assertEqual(out.accent, "#7aa2f7")
+        # Secondary untouched.
+        self.assertEqual(out.secondary, _BASE.secondary)
 
     def test_light_palette_still_only_touches_foreground(self):
         with tempfile.TemporaryDirectory() as home:
@@ -175,7 +200,42 @@ class TestOmarchyThemeMtime(unittest.TestCase):
         self.assertIsNotNone(mtime)
 
 
+class TestLoadActiveBorder(unittest.TestCase):
+
+    def test_missing_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as home:
+            self.assertIsNone(_load_active_border(Path(home)))
+
+    def test_parses_rgb_literal(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_hyprland(Path(home), "$activeBorderColor = rgb(7aa2f7)\n")
+            self.assertEqual(_load_active_border(Path(home)), "#7aa2f7")
+
+    def test_parses_rgba_literal_ignoring_alpha(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_hyprland(Path(home), "$activeBorderColor = rgba(7aa2f7, 1.0)\n")
+            self.assertEqual(_load_active_border(Path(home)), "#7aa2f7")
+
+    def test_missing_variable_returns_none(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_hyprland(
+                Path(home),
+                "general {\n    col.active_border = rgb(123456)\n}\n",
+            )
+            self.assertIsNone(_load_active_border(Path(home)))
+
+    def test_normalizes_case(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_hyprland(Path(home), "$activeBorderColor = rgb(7AA2F7)\n")
+            self.assertEqual(_load_active_border(Path(home)), "#7aa2f7")
+
+
 class TestOmarchyHelpers(unittest.TestCase):
+
+    def test_omarchy_hyprland_path_defaults(self):
+        with tempfile.TemporaryDirectory() as home:
+            path = omarchy_hyprland_path(home=Path(home))
+        self.assertTrue(str(path).endswith(".config/omarchy/current/theme/hyprland.conf"))
 
     def test_omarchy_colors_path_defaults(self):
         with tempfile.TemporaryDirectory() as home:

--- a/tests/test_omarchy_theme.py
+++ b/tests/test_omarchy_theme.py
@@ -1,4 +1,4 @@
-"""Omarchy palette → Textual theme mapping."""
+"""Omarchy palette → hybrid Textual theme."""
 from __future__ import annotations
 
 import io
@@ -7,13 +7,34 @@ import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
 
+from textual.theme import Theme
+
 from actor.watch.omarchy_theme import (
-    OMARCHY_THEME_NAME,
+    _hex,
     _is_dark,
     _shift_toward_foreground,
-    load_omarchy_theme,
+    apply_omarchy_flavor,
     omarchy_colors_path,
     omarchy_theme_mtime,
+)
+
+
+# A minimal base theme used to exercise the flavor logic without pulling
+# in CLAUDE_DARK's hex values (keeps assertions about what survived vs.
+# what the omarchy palette overrode unambiguous).
+_BASE = Theme(
+    name="test-base",
+    primary="#000001",
+    secondary="#000002",
+    accent="#000003",
+    warning="#000004",
+    error="#000005",
+    success="#000006",
+    foreground="#111111",
+    background="#222222",
+    surface="#333333",
+    panel="#444444",
+    dark=True,
 )
 
 
@@ -50,80 +71,76 @@ color5 = "#721dbd"
 """
 
 
-class TestLoadOmarchyTheme(unittest.TestCase):
+class TestApplyOmarchyFlavor(unittest.TestCase):
 
     def test_missing_file_returns_none(self):
         with tempfile.TemporaryDirectory() as home:
-            self.assertIsNone(load_omarchy_theme(home=Path(home)))
+            self.assertIsNone(apply_omarchy_flavor(_BASE, home=Path(home)))
 
-    def test_dark_palette_maps_to_theme(self):
+    def test_overrides_only_foreground(self):
         with tempfile.TemporaryDirectory() as home:
             _write_palette(Path(home), _DARK_PALETTE)
-            theme = load_omarchy_theme(home=Path(home))
-        self.assertIsNotNone(theme)
-        assert theme is not None
-        self.assertEqual(theme.name, OMARCHY_THEME_NAME)
-        self.assertEqual(theme.primary, "#7aa2f7")
-        self.assertEqual(theme.accent, "#7aa2f7")
-        self.assertEqual(theme.secondary, "#ad8ee6")  # color5
-        self.assertEqual(theme.error, "#f7768e")      # color1
-        self.assertEqual(theme.success, "#9ece6a")    # color2
-        self.assertEqual(theme.warning, "#e0af68")    # color3
-        self.assertEqual(theme.foreground, "#a9b1d6")
-        self.assertEqual(theme.background, "#1a1b26")
-        self.assertEqual(theme.panel, "#32344a")      # color0
-        self.assertTrue(theme.dark)
+            out = apply_omarchy_flavor(_BASE, home=Path(home))
+        self.assertIsNotNone(out)
+        assert out is not None
+        # FG swapped in from the palette…
+        self.assertEqual(out.foreground, "#a9b1d6")
+        # …every other slot is untouched from the base.
+        self.assertEqual(out.primary, "#000001")
+        self.assertEqual(out.secondary, "#000002")
+        self.assertEqual(out.accent, "#000003")
+        self.assertEqual(out.warning, "#000004")
+        self.assertEqual(out.error, "#000005")
+        self.assertEqual(out.success, "#000006")
+        self.assertEqual(out.background, "#222222")
+        self.assertEqual(out.surface, "#333333")
+        self.assertEqual(out.panel, "#444444")
+        self.assertEqual(out.dark, True)
+        # Keeps the base's name so picker entries don't multiply.
+        self.assertEqual(out.name, _BASE.name)
 
-    def test_light_palette_detects_dark_false(self):
+    def test_light_palette_still_only_touches_foreground(self):
         with tempfile.TemporaryDirectory() as home:
             _write_palette(Path(home), _LIGHT_PALETTE)
-            theme = load_omarchy_theme(home=Path(home))
-        assert theme is not None
-        self.assertFalse(theme.dark)
+            out = apply_omarchy_flavor(_BASE, home=Path(home))
+        assert out is not None
+        self.assertEqual(out.foreground, "#222222")
+        # `dark` stays as base had it (we're not deriving it from the
+        # omarchy BG today — that'd contradict "FG only" scope).
+        self.assertTrue(out.dark)
 
     def test_malformed_toml_returns_none_and_warns(self):
         with tempfile.TemporaryDirectory() as home:
             _write_palette(Path(home), "this = isn't valid TOML\nno no no")
             buf = io.StringIO()
             with redirect_stderr(buf):
-                result = load_omarchy_theme(home=Path(home))
+                result = apply_omarchy_flavor(_BASE, home=Path(home))
         self.assertIsNone(result)
         self.assertIn("warning", buf.getvalue().lower())
 
-    def test_missing_key_falls_back_silently(self):
-        # A palette with only the strictly-required-to-render keys; the
-        # rest should fall back to safe defaults without raising.
+    def test_missing_foreground_key_falls_back_to_base(self):
         with tempfile.TemporaryDirectory() as home:
-            _write_palette(Path(home), 'background = "#000000"\nforeground = "#ffffff"\n')
-            theme = load_omarchy_theme(home=Path(home))
-        self.assertIsNotNone(theme)
-        assert theme is not None
-        # Fallback accent (from _DARK_PALETTE's typical tokyonight hue).
-        self.assertEqual(theme.accent, "#7aa2f7")
+            _write_palette(Path(home), 'background = "#000000"\n')
+            out = apply_omarchy_flavor(_BASE, home=Path(home))
+        assert out is not None
+        self.assertEqual(out.foreground, _BASE.foreground)
 
     def test_non_string_value_rejected_as_warning(self):
         with tempfile.TemporaryDirectory() as home:
-            _write_palette(Path(home), "background = 42\n")
+            _write_palette(Path(home), "foreground = 42\n")
             buf = io.StringIO()
             with redirect_stderr(buf):
-                result = load_omarchy_theme(home=Path(home))
+                result = apply_omarchy_flavor(_BASE, home=Path(home))
         self.assertIsNone(result)
         self.assertIn("malformed", buf.getvalue().lower())
 
     def test_hex_without_hash_rejected(self):
         with tempfile.TemporaryDirectory() as home:
-            _write_palette(Path(home), 'background = "1a1b26"\n')
+            _write_palette(Path(home), 'foreground = "a9b1d6"\n')
             buf = io.StringIO()
             with redirect_stderr(buf):
-                result = load_omarchy_theme(home=Path(home))
+                result = apply_omarchy_flavor(_BASE, home=Path(home))
         self.assertIsNone(result)
-
-    def test_three_digit_hex_normalized_to_six(self):
-        # Spot-check via the internal helper — exposed for this exact
-        # reason. Short-form hex is expanded to full-form for Textual.
-        from actor.watch.omarchy_theme import _hex
-        out = _hex({"k": "#abc"}, "k", "#000000")
-        self.assertEqual(out, "#aabbcc")
 
 
 class TestOmarchyThemeMtime(unittest.TestCase):
@@ -141,14 +158,15 @@ class TestOmarchyThemeMtime(unittest.TestCase):
         self.assertGreater(mtime, 0)
 
     def test_symlink_target_mtime_used(self):
-        # Simulate omarchy's symlink shape: the real colors.toml lives
-        # inside a theme directory; `current/theme` is a symlink to it.
+        # Mirror omarchy's on-disk shape: `current/theme` is a symlink
+        # to the active theme directory. Resolving must reach the target
+        # so an `omarchy theme set X` flip (new symlink target) is
+        # observable as a different mtime.
         with tempfile.TemporaryDirectory() as home:
             home_path = Path(home)
             themes_dir = home_path / ".config/omarchy/themes/tokyonight"
             themes_dir.mkdir(parents=True)
             (themes_dir / "colors.toml").write_text(_DARK_PALETTE)
-            # Build the symlink chain that omarchy uses.
             current = home_path / ".config/omarchy/current"
             current.mkdir()
             (current / "theme").symlink_to(themes_dir)
@@ -173,9 +191,12 @@ class TestOmarchyHelpers(unittest.TestCase):
         self.assertFalse(_is_dark("#f5f5f5"))
 
     def test_shift_toward_foreground_moves_values(self):
-        # 50% mix of pure black + pure white = mid-gray (7f or 80).
         out = _shift_toward_foreground("#000000", "#ffffff", 0.5)
         self.assertIn(out, ("#7f7f7f", "#808080"))
+
+    def test_three_digit_hex_normalized_to_six(self):
+        out = _hex({"k": "#abc"}, "k", "#000000")
+        self.assertEqual(out, "#aabbcc")
 
 
 if __name__ == "__main__":

--- a/tests/test_omarchy_theme.py
+++ b/tests/test_omarchy_theme.py
@@ -1,0 +1,182 @@
+"""Omarchy palette → Textual theme mapping."""
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+from actor.watch.omarchy_theme import (
+    OMARCHY_THEME_NAME,
+    _is_dark,
+    _shift_toward_foreground,
+    load_omarchy_theme,
+    omarchy_colors_path,
+    omarchy_theme_mtime,
+)
+
+
+def _write_palette(home: Path, body: str) -> Path:
+    target = home / ".config" / "omarchy" / "current" / "theme" / "colors.toml"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body)
+    return target
+
+
+_DARK_PALETTE = """\
+accent = "#7aa2f7"
+foreground = "#a9b1d6"
+background = "#1a1b26"
+color0 = "#32344a"
+color1 = "#f7768e"
+color2 = "#9ece6a"
+color3 = "#e0af68"
+color4 = "#7aa2f7"
+color5 = "#ad8ee6"
+color6 = "#449dab"
+color7 = "#787c99"
+"""
+
+_LIGHT_PALETTE = """\
+accent = "#2e5aa0"
+foreground = "#222222"
+background = "#f5f5f5"
+color0 = "#e0e0e0"
+color1 = "#a81829"
+color2 = "#356c01"
+color3 = "#8a6800"
+color5 = "#721dbd"
+"""
+
+
+class TestLoadOmarchyTheme(unittest.TestCase):
+
+    def test_missing_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as home:
+            self.assertIsNone(load_omarchy_theme(home=Path(home)))
+
+    def test_dark_palette_maps_to_theme(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_palette(Path(home), _DARK_PALETTE)
+            theme = load_omarchy_theme(home=Path(home))
+        self.assertIsNotNone(theme)
+        assert theme is not None
+        self.assertEqual(theme.name, OMARCHY_THEME_NAME)
+        self.assertEqual(theme.primary, "#7aa2f7")
+        self.assertEqual(theme.accent, "#7aa2f7")
+        self.assertEqual(theme.secondary, "#ad8ee6")  # color5
+        self.assertEqual(theme.error, "#f7768e")      # color1
+        self.assertEqual(theme.success, "#9ece6a")    # color2
+        self.assertEqual(theme.warning, "#e0af68")    # color3
+        self.assertEqual(theme.foreground, "#a9b1d6")
+        self.assertEqual(theme.background, "#1a1b26")
+        self.assertEqual(theme.panel, "#32344a")      # color0
+        self.assertTrue(theme.dark)
+
+    def test_light_palette_detects_dark_false(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_palette(Path(home), _LIGHT_PALETTE)
+            theme = load_omarchy_theme(home=Path(home))
+        assert theme is not None
+        self.assertFalse(theme.dark)
+
+    def test_malformed_toml_returns_none_and_warns(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_palette(Path(home), "this = isn't valid TOML\nno no no")
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                result = load_omarchy_theme(home=Path(home))
+        self.assertIsNone(result)
+        self.assertIn("warning", buf.getvalue().lower())
+
+    def test_missing_key_falls_back_silently(self):
+        # A palette with only the strictly-required-to-render keys; the
+        # rest should fall back to safe defaults without raising.
+        with tempfile.TemporaryDirectory() as home:
+            _write_palette(Path(home), 'background = "#000000"\nforeground = "#ffffff"\n')
+            theme = load_omarchy_theme(home=Path(home))
+        self.assertIsNotNone(theme)
+        assert theme is not None
+        # Fallback accent (from _DARK_PALETTE's typical tokyonight hue).
+        self.assertEqual(theme.accent, "#7aa2f7")
+
+    def test_non_string_value_rejected_as_warning(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_palette(Path(home), "background = 42\n")
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                result = load_omarchy_theme(home=Path(home))
+        self.assertIsNone(result)
+        self.assertIn("malformed", buf.getvalue().lower())
+
+    def test_hex_without_hash_rejected(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_palette(Path(home), 'background = "1a1b26"\n')
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                result = load_omarchy_theme(home=Path(home))
+        self.assertIsNone(result)
+
+    def test_three_digit_hex_normalized_to_six(self):
+        # Spot-check via the internal helper — exposed for this exact
+        # reason. Short-form hex is expanded to full-form for Textual.
+        from actor.watch.omarchy_theme import _hex
+        out = _hex({"k": "#abc"}, "k", "#000000")
+        self.assertEqual(out, "#aabbcc")
+
+
+class TestOmarchyThemeMtime(unittest.TestCase):
+
+    def test_missing_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as home:
+            self.assertIsNone(omarchy_theme_mtime(home=Path(home)))
+
+    def test_present_file_returns_float(self):
+        with tempfile.TemporaryDirectory() as home:
+            _write_palette(Path(home), _DARK_PALETTE)
+            mtime = omarchy_theme_mtime(home=Path(home))
+        self.assertIsNotNone(mtime)
+        assert mtime is not None
+        self.assertGreater(mtime, 0)
+
+    def test_symlink_target_mtime_used(self):
+        # Simulate omarchy's symlink shape: the real colors.toml lives
+        # inside a theme directory; `current/theme` is a symlink to it.
+        with tempfile.TemporaryDirectory() as home:
+            home_path = Path(home)
+            themes_dir = home_path / ".config/omarchy/themes/tokyonight"
+            themes_dir.mkdir(parents=True)
+            (themes_dir / "colors.toml").write_text(_DARK_PALETTE)
+            # Build the symlink chain that omarchy uses.
+            current = home_path / ".config/omarchy/current"
+            current.mkdir()
+            (current / "theme").symlink_to(themes_dir)
+
+            mtime = omarchy_theme_mtime(home=home_path)
+        self.assertIsNotNone(mtime)
+
+
+class TestOmarchyHelpers(unittest.TestCase):
+
+    def test_omarchy_colors_path_defaults(self):
+        with tempfile.TemporaryDirectory() as home:
+            path = omarchy_colors_path(home=Path(home))
+        self.assertTrue(str(path).endswith(".config/omarchy/current/theme/colors.toml"))
+
+    def test_is_dark_recognizes_near_black(self):
+        self.assertTrue(_is_dark("#000000"))
+        self.assertTrue(_is_dark("#1a1b26"))
+
+    def test_is_dark_recognizes_near_white(self):
+        self.assertFalse(_is_dark("#ffffff"))
+        self.assertFalse(_is_dark("#f5f5f5"))
+
+    def test_shift_toward_foreground_moves_values(self):
+        # 50% mix of pure black + pure white = mid-gray (7f or 80).
+        out = _shift_toward_foreground("#000000", "#ffffff", 0.5)
+        self.assertIn(out, ("#7f7f7f", "#808080"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -311,5 +311,121 @@ class SetupVersionAssertionTests(unittest.TestCase):
                 self.assertEqual(_parse_deployed_version(skill.read_text()), __version__)
 
 
+class SetupOmarchyTests(unittest.TestCase):
+    """`actor setup --for omarchy` — install / refresh / uninstall the
+    theme-set hook fragment."""
+
+    def _home_with_omarchy(self, tmp: str) -> Path:
+        home = Path(tmp)
+        (home / ".config" / "omarchy").mkdir(parents=True)
+        return home
+
+    def test_install_creates_hook_with_sentinel_block(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = self._home_with_omarchy(tmp)
+            with patch.dict(os.environ, {"HOME": str(home)}):
+                msg = cmd_setup(
+                    for_host="omarchy", scope="user", name="actor",
+                    uninstall=False,
+                )
+            self.assertIn("installed", msg.lower())
+            hook = home / ".config" / "omarchy" / "hooks" / "theme-set"
+            self.assertTrue(hook.is_file())
+            body = hook.read_text()
+            self.assertIn("BEGIN actor-sh", body)
+            self.assertIn("END actor-sh", body)
+            self.assertIn("pkill -SIGUSR2", body)
+            self.assertTrue(hook.stat().st_mode & 0o111)
+
+    def test_install_preserves_existing_user_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = self._home_with_omarchy(tmp)
+            hook = home / ".config" / "omarchy" / "hooks" / "theme-set"
+            hook.parent.mkdir(parents=True)
+            hook.write_text("#!/bin/bash\necho custom-user-line\n")
+            with patch.dict(os.environ, {"HOME": str(home)}):
+                cmd_setup(
+                    for_host="omarchy", scope="user", name="actor",
+                    uninstall=False,
+                )
+            body = hook.read_text()
+            self.assertIn("echo custom-user-line", body)
+            self.assertIn("BEGIN actor-sh", body)
+
+    def test_install_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = self._home_with_omarchy(tmp)
+            with patch.dict(os.environ, {"HOME": str(home)}):
+                cmd_setup(
+                    for_host="omarchy", scope="user", name="actor",
+                    uninstall=False,
+                )
+                msg2 = cmd_setup(
+                    for_host="omarchy", scope="user", name="actor",
+                    uninstall=False,
+                )
+            self.assertIn("nothing to do", msg2.lower())
+            hook = home / ".config" / "omarchy" / "hooks" / "theme-set"
+            self.assertEqual(hook.read_text().count("BEGIN actor-sh"), 1)
+
+    def test_uninstall_removes_only_our_block(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = self._home_with_omarchy(tmp)
+            hook = home / ".config" / "omarchy" / "hooks" / "theme-set"
+            hook.parent.mkdir(parents=True)
+            hook.write_text("#!/bin/bash\necho before\n")
+            with patch.dict(os.environ, {"HOME": str(home)}):
+                cmd_setup(
+                    for_host="omarchy", scope="user", name="actor",
+                    uninstall=False,
+                )
+                # Append a user line after our block, then uninstall.
+                body_after_install = hook.read_text() + "\necho after\n"
+                hook.write_text(body_after_install)
+                cmd_setup(
+                    for_host="omarchy", scope="user", name="actor",
+                    uninstall=True,
+                )
+            final = hook.read_text()
+            self.assertIn("echo before", final)
+            self.assertIn("echo after", final)
+            self.assertNotIn("BEGIN actor-sh", final)
+            self.assertNotIn("pkill -SIGUSR2", final)
+
+    def test_uninstall_noop_when_not_installed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = self._home_with_omarchy(tmp)
+            with patch.dict(os.environ, {"HOME": str(home)}):
+                msg = cmd_setup(
+                    for_host="omarchy", scope="user", name="actor",
+                    uninstall=True,
+                )
+            self.assertIn("nothing to do", msg.lower())
+
+    def test_errors_when_omarchy_not_installed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # No .config/omarchy/ directory created.
+            with patch.dict(os.environ, {"HOME": tmp}):
+                with self.assertRaises(ActorError) as ctx:
+                    cmd_setup(
+                        for_host="omarchy", scope="user", name="actor",
+                        uninstall=False,
+                    )
+            self.assertIn("not detected", str(ctx.exception).lower())
+
+
+class SetupUninstallGuardTests(unittest.TestCase):
+
+    def test_uninstall_not_supported_for_claude_code(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"HOME": tmp}):
+                with self.assertRaises(ActorError) as ctx:
+                    cmd_setup(
+                        for_host="claude-code", scope="user", name="actor",
+                        uninstall=True,
+                    )
+            self.assertIn("uninstall", str(ctx.exception).lower())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Desktop-integration polish for \`actor watch\` when the user runs omarchy. Scope is intentionally minimal: the TUI stays visually recognizable as Actor.sh but its body text blends with the rest of the omarchy desktop.

## What's in

### 1. Hybrid FG flavor
\`apply_omarchy_flavor(CLAUDE_DARK)\` reads omarchy's active palette (\`~/.config/omarchy/current/theme/colors.toml\`) and returns a variant of CLAUDE_DARK with only the \`foreground\` slot overridden. Every brand / semantic / surface / panel color stays as CLAUDE_DARK defines it. The variant registers under the same name (\`claude-dark\`) so no extra picker entry appears.

Growing this to cover more slots (background, surface, panel, error/success/warning) is a one-line-per-slot addition in \`_flavor\` once we've lived with FG-only for a bit.

### 2. Live reload (two mechanisms)
- **Polling fallback** — every 3s, re-stat the resolved-target mtime; on change, rebuild the flavor and reactivate. No setup required.
- **Push-based (opt-in)** — \`actor setup --for omarchy\` installs a sentinel-wrapped one-liner into \`~/.config/omarchy/hooks/theme-set\` that sends SIGUSR2 to running \`actor watch\` processes on theme change. The handler re-invokes the polling callback, so the flavor refreshes within one event-loop tick instead of 0-3s.

SIGUSR2 handler is wired unconditionally (silent skip on Windows / non-main-thread / platforms without signal handler support). The setup command only adds the hook that sends the signal.

### 3. \`actor setup --for omarchy\` / \`--uninstall\`
Idempotent: re-running install is a no-op when the managed block is already present. Uninstall surgically removes the sentinel-wrapped block, preserving any other user content in theme-set. Errors cleanly when \`~/.config/omarchy/\` isn't there.

## Non-omarchy impact

- \`apply_omarchy_flavor()\` returns \`None\` (file not found) → TUI uses \`CLAUDE_DARK\` unchanged, same as today.
- 3s polling interval runs everywhere but does a single \`Path.resolve(strict=True).stat()\` that errors immediately when the file's absent. Effectively free.
- SIGUSR2 handler installs silently; non-omarchy users never have anything sending that signal.

## Test plan

- [x] 431 tests pass (\`uv run python -m unittest discover tests\`) — 409 pre-existing + 15 \`test_omarchy_theme.py\` + 7 \`test_setup.py\` for the omarchy path
- [x] Omarchy coverage: missing-file / palette-parse / FG-only override / malformed-TOML warning / symlink-target mtime resolution / three-digit hex / dark-light luminance
- [x] Setup coverage: install creates sentinel block / preserves user content / idempotent reinstall / uninstall removes only our block / errors without omarchy / \`--uninstall\` rejected for claude-code
- [x] End-to-end smoke: \`uv run actor setup --for omarchy\` writes the hook; running \`omarchy theme set <name>\` reloads the active \`actor watch\` immediately via SIGUSR2

## Out of scope (future)

- Extending the flavor to override more slots (easy extension, one line per slot)
- Derived light theme (auto-flip when omarchy switches to a light palette)
- OSC 10/11 terminal-query fallback for non-omarchy users with a configured palette
- inotify-based file watching via ctypes (polling is fine for human-driven changes + SIGUSR2 covers the power users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)