### PR TITLE
Remove .mcp.json and .claude-plugin/ — actor setup handles both

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,3 +1,0 @@
-{
-  "skills": ["./src/actor/_skill"]
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 .DS_Store
+.claude/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "actor": {
-      "command": "actor",
-      "args": ["mcp"]
-    }
-  }
-}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,6 @@ src/actor/               # Python package
     cli.md               # CLI fallback reference
     claude-config.md     # Claude agent config reference
     codex-config.md      # Codex agent config reference
-.claude-plugin/
-  plugin.json            # Declares src/actor/_skill as a skill location for
-                         # tooling like npx skills
 tests/
   test_*.py              # unittest suites
 spec/


### PR DESCRIPTION
## Summary
- Delete \`.mcp.json\` and \`.claude-plugin/plugin.json\` — both duplicated what \`actor setup\` already does for any user with actor installed. The committed \`.mcp.json\` was even disabled locally, signaling it added noise (a permission prompt on every fresh checkout) rather than value.
- Add \`.claude/\` to project \`.gitignore\` so contributors without it in their global ignore don't accidentally commit local Claude Code settings.
- Drop the \`.claude-plugin/\` block from CLAUDE.md's project-structure tree.

Spec docs in \`spec/\` still mention these files historically — left untouched, those are frozen design artifacts (the \`actor daemon\` architecture they describe never landed either).

## Test plan
- [ ] \`actor setup --for claude-code\` still registers the MCP + skill end-to-end
- [ ] Fresh checkout no longer triggers a Claude Code MCP-enable prompt