### PR TITLE
Omarchy palette expansion + splash & log fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,12 +257,19 @@ templates).
 The `actor watch` TUI ships with `claude-dark` / `claude-light`. If it
 detects omarchy running locally (presence of
 `~/.config/omarchy/current/theme/colors.toml`), it **flavors** the
-claude-dark theme with omarchy's foreground color — the brand slots
-(primary / secondary / accent / warning / error / success / background /
-surface / panel) stay as claude-dark defines them, so the app still
-reads as an "Actor.sh" TUI but its body text matches the rest of the
-user's desktop. Today only the foreground slot is overridden; growing
-this to cover more slots is a one-line-per-slot extension.
+active claude-dark/light theme with omarchy's palette so the TUI reads
+as part of the user's desktop:
+
+- `foreground` ← `colors.toml`'s `foreground`
+- `background` ← `colors.toml`'s `background`
+- `surface`, `panel` ← `background` lifted ~8% toward `foreground` so
+  panels stay subtly distinct from the desktop bg (still palette-derived)
+- `secondary` ← `colors.toml`'s `accent` (brand/logo slot)
+- `primary`, `accent` ← `hyprland.conf`'s `$activeBorderColor` (focus
+  rings match active-window border)
+
+Semantic slots (`warning` / `error` / `success`) stay as the base
+theme had them — `colors.toml` doesn't carry semantic meaning.
 
 **Live reload:** every 3 seconds we re-stat the resolved-target mtime of
 `colors.toml`. If it changed (e.g. the user ran `omarchy theme set

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -148,9 +148,6 @@ class ActorWatchApp(App):
         scrollbar-background: ansi_default;
         scrollbar-background-hover: ansi_default;
         scrollbar-background-active: ansi_default;
-        /* 1-col right gutter so wrapped text doesn't run flush into
-           the scrollbar thumb (or the panel edge when content fits). */
-        padding-right: 1;
     }
     #info-content {
         padding: 1;

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -148,6 +148,9 @@ class ActorWatchApp(App):
         scrollbar-background: ansi_default;
         scrollbar-background-hover: ansi_default;
         scrollbar-background-active: ansi_default;
+        /* 1-col right gutter so wrapped text doesn't run flush into
+           the scrollbar thumb (or the panel edge when content fits). */
+        padding-right: 1;
     }
     #info-content {
         padding: 1;

--- a/src/actor/watch/log_renderer.py
+++ b/src/actor/watch/log_renderer.py
@@ -90,6 +90,29 @@ def build_log_renderables(
     return buf.calls
 
 
+class _RightPaddedLog:
+    """Wraps a log-like object; pads every written renderable with a
+    1-col right gutter so wrapped text doesn't sit flush against the
+    RichLog scrollbar thumb.
+
+    Doing it via a renderable wrapper rather than CSS `padding-right`
+    on the widget is intentional — Textual's CSS padding insets the
+    scrollbar too, which produces a visible gap on the wrong side
+    (between scrollbar and panel edge). Wrapping at the renderable
+    level keeps the scrollbar at the widget edge and the gap between
+    text and scrollbar."""
+
+    def __init__(self, inner) -> None:
+        self._inner = inner
+
+    def write(self, content, **kwargs):
+        self._inner.write(Padding(content, (0, 1, 0, 0)), **kwargs)
+        return self
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
 def apply_log_renderables(
     log: RichLog, renderables: list[tuple[object, dict]],
 ) -> None:
@@ -97,8 +120,9 @@ def apply_log_renderables(
     real RichLog. Must run on the main thread — `clear` and `write`
     mutate widget state that the compositor reads."""
     log.clear()
+    padded = _RightPaddedLog(log)
     for content, kwargs in renderables:
-        log.write(content, **kwargs)
+        padded.write(content, **kwargs)
 
 
 def append_log_entries(
@@ -120,9 +144,10 @@ def append_log_entries(
     if prior_count >= len(entries):
         return
     tool_results = _pair_tools(entries)
+    already_rendered = len(log.lines) > 0
     _write_range(
-        log, entries, prior_count, tool_results, colors,
-        already_rendered=len(log.lines) > 0,
+        _RightPaddedLog(log), entries, prior_count, tool_results, colors,
+        already_rendered=already_rendered,
     )
 
 

--- a/src/actor/watch/log_renderer.py
+++ b/src/actor/watch/log_renderer.py
@@ -170,6 +170,12 @@ def _write_range(
             continue
         if entry.kind == LogEntryKind.TOOL_USE and entry.name in HIDDEN_TOOLS:
             continue
+        # Claude emits a 0-length thinking block when extended thinking
+        # isn't engaged — skip both the entry AND its leading separator
+        # so the prompt → assistant transition doesn't show phantom
+        # blank rows.
+        if entry.kind == LogEntryKind.THINKING and not entry.text.strip():
+            continue
 
         needs_separator = already_rendered or not first_this_pass
         if needs_separator:

--- a/src/actor/watch/omarchy_theme.py
+++ b/src/actor/watch/omarchy_theme.py
@@ -72,12 +72,7 @@ def apply_omarchy_flavor(
 ) -> Optional[Theme]:
     """Return a variant of `base` with environment colors pulled from
     omarchy's active palette. Returns None when omarchy isn't present
-    or the palette file is unreadable / malformed.
-
-    Scope is intentionally small — just the foreground today. Growing
-    this to cover background / surface / panel / semantic slots is a
-    one-line-per-slot extension once we've lived with the FG override
-    for a bit."""
+    or the palette file is unreadable / malformed."""
     data = _load_palette(home)
     if data is None:
         return None
@@ -118,27 +113,91 @@ def _flavor(
 
     Overridden slots:
     - `foreground` ← colors.toml's foreground (desktop-native body text)
+    - `background` ← colors.toml's background
+    - `surface` and `panel` ← background lifted toward foreground
+      (subtle lift so widgets/panels still read as distinct from the
+      desktop bg without introducing a non-palette color)
+    - `secondary` ← whichever of `accent` / `color3` / `color5` /
+      `color1` is most distant in RGB from the active-border color,
+      so the brand/logo slot doesn't collapse into `primary` (e.g.
+      tokyo night sets accent == active-border)
     - `primary` and `accent` ← hyprland.conf's $activeBorderColor
       (TUI focus rings match active-window border)
 
-    Everything else stays as `base` had it."""
+    Semantic slots (`warning`, `error`, `success`) stay as `base` had
+    them — colors.toml doesn't carry semantic meaning per slot, and
+    swapping them out arbitrarily from numbered colorN entries would
+    risk red-as-success collisions."""
     foreground = _hex(data, "foreground", base.foreground)
+    background = _hex(data, "background", base.background)
+    surface = _shift_toward_foreground(background, foreground, 0.08)
     primary = active_border if active_border is not None else base.primary
     accent = active_border if active_border is not None else base.accent
+    secondary = _pick_distinct(
+        data,
+        exclude=primary,
+        candidates=("accent", "color3", "color5", "color1"),
+        fallback=base.secondary,
+    )
     return Theme(
         name=base.name,
         primary=primary,
-        secondary=base.secondary,
+        secondary=secondary,
         accent=accent,
         warning=base.warning,
         error=base.error,
         success=base.success,
         foreground=foreground,
-        background=base.background,
-        surface=base.surface,
-        panel=base.panel,
+        background=background,
+        surface=surface,
+        panel=surface,
         dark=base.dark,
     )
+
+
+# Two palette colors are "distinguishable" if their RGB-space distance
+# exceeds this threshold. ~85 in 0-255 RGB = a perceptible hue/value
+# shift that's not just dithered noise. Tuned by eye against tokyo
+# night (accent == active-border) where we want secondary to skip past
+# `accent` to a real second color; against gruvbox where accent and
+# color3 are both yellow-orange but visibly distinct.
+_DISTINCT_THRESHOLD = 85.0
+
+
+def _pick_distinct(
+    data: Dict[str, object],
+    exclude: Optional[str],
+    candidates: tuple[str, ...],
+    fallback: str,
+) -> str:
+    """Walk `candidates` in order; return the first hex value far
+    enough from `exclude` to read as a different color. If `exclude`
+    is None (no active-border file) the first valid candidate wins."""
+    farthest: tuple[Optional[str], float] = (None, 0.0)
+    for key in candidates:
+        try:
+            color = _hex(data, key, "")
+        except (TypeError, ValueError):
+            continue
+        if not color:
+            continue
+        if exclude is None:
+            return color
+        dist = _rgb_distance(color, exclude)
+        if dist >= _DISTINCT_THRESHOLD:
+            return color
+        if dist > farthest[1]:
+            farthest = (color, dist)
+    # Nothing met the threshold — return the most-distant candidate we
+    # found (if any), else the base fallback. Better to drift toward
+    # similar than to pull a totally off-palette color.
+    return farthest[0] if farthest[0] is not None else fallback
+
+
+def _rgb_distance(a: str, b: str) -> float:
+    ar, ag, ab = _to_rgb(a)
+    br, bg, bb = _to_rgb(b)
+    return ((ar - br) ** 2 + (ag - bg) ** 2 + (ab - bb) ** 2) ** 0.5
 
 
 # Matches `$activeBorderColor = rgb(7aa2f7)` or `rgba(7aa2f7, 1.0)` at

--- a/src/actor/watch/splash.py
+++ b/src/actor/watch/splash.py
@@ -95,10 +95,10 @@ class Splash(Widget):
         self._grids: list[list[list[float]]] | None = None
         self._style_cache: dict[str, Style] = {}
         # Three caches with different invalidation axes: _frame per tick,
-        # _styles per theme change, _geometry per resize.
+        # _styles per resolved-palette change, _geometry per resize.
         self._frame_dirty = True
         self._frame: dict | None = None
-        self._theme_key: str | None = None
+        self._theme_key: tuple[str, str, str, str] | None = None
         self._styles: dict[str, Style] | None = None
         self._geometry: dict | None = None
         self._geometry_size: tuple[int, int] | None = None
@@ -149,11 +149,14 @@ class Splash(Widget):
         return "#D77757", "#B1B9F9", "#FFFFFF", "#2C323E"
 
     def _ensure_styles(self) -> None:
-        t = self.app.current_theme
-        key = t.name if t is not None else "_default"
+        # Key on the resolved color tuple, not the theme name — omarchy
+        # re-registers themes under the same name when the palette
+        # changes, so a name-only key would freeze the splash on the
+        # first-rendered palette.
+        key = self._theme_colors()
         if self._styles is not None and self._theme_key == key:
             return
-        logo_color, anim_color, border_color, panel_color = self._theme_colors()
+        logo_color, anim_color, border_color, panel_color = key
         self._styles = {
             "anim": self._get_style(anim_color),
             "border": self._get_style(f"{border_color} on {panel_color}"),

--- a/src/actor/watch/splash.py
+++ b/src/actor/watch/splash.py
@@ -310,13 +310,20 @@ class Splash(Widget):
         return Segment("".join(chars), style)
 
     def render_line(self, y: int) -> Strip:
-        if self._frame_dirty:
+        rows = self.size.height
+        cols = self.size.width
+        if (
+            self._frame_dirty
+            or self._frame is None
+            or self._frame["rows"] != rows
+            or self._frame["cols"] != cols
+        ):
             self._prepare_frame()
             self._frame_dirty = False
 
         frame = self._frame
-        if frame is None:
-            return Strip.blank(self.size.width)
+        if frame is None or y >= frame["rows"]:
+            return Strip.blank(cols)
 
         cols = frame["cols"]
         a_row = frame["a_grid"][y]

--- a/tests/test_log_append_render.py
+++ b/tests/test_log_append_render.py
@@ -7,11 +7,22 @@ from __future__ import annotations
 import unittest
 from unittest.mock import MagicMock, patch
 
+from rich.padding import Padding
+from rich.text import Text
+
 from actor.interfaces import LogEntry, LogEntryKind
 from actor.watch.log_renderer import (
     append_log_entries,
     render_log_entries,
 )
+
+
+def _unwrap(content: object) -> object:
+    """Peel the 1-col right Padding that apply/append wrap each
+    renderable in. Tests assert against the inner content."""
+    if isinstance(content, Padding):
+        return content.renderable
+    return content
 from actor.watch.types import ThemeColors
 
 
@@ -70,9 +81,10 @@ class TestAppendLogEntries(unittest.TestCase):
         with patch("actor.watch.log_renderer.render_user"):
             append_log_entries(log, entries, prior_count=1, colors=_colors())
 
-        # First log.write is the blank separator before the new entry.
+        # First log.write is the blank separator before the new entry,
+        # wrapped in a 1-col right Padding by _RightPaddedLog.
         first_write = log.write.call_args_list[0]
-        self.assertEqual(str(first_write.args[0]), "")
+        self.assertEqual(str(_unwrap(first_write.args[0])), "")
 
     def test_append_no_leading_separator_when_log_empty(self):
         log = MagicMock()

--- a/tests/test_omarchy_theme.py
+++ b/tests/test_omarchy_theme.py
@@ -86,28 +86,39 @@ class TestApplyOmarchyFlavor(unittest.TestCase):
         with tempfile.TemporaryDirectory() as home:
             self.assertIsNone(apply_omarchy_flavor(_BASE, home=Path(home)))
 
-    def test_overrides_only_environmental_slots(self):
-        # No hyprland.conf → only FG gets overridden (palette flavor
-        # works even without the window-border file).
+    def test_palette_overrides_environmental_slots(self):
+        # No hyprland.conf → palette-only overrides still apply (the
+        # window-border file is optional).
         with tempfile.TemporaryDirectory() as home:
             _write_palette(Path(home), _DARK_PALETTE)
             out = apply_omarchy_flavor(_BASE, home=Path(home))
         self.assertIsNotNone(out)
         assert out is not None
-        # FG swapped in from the palette…
+        # Palette-driven slots…
         self.assertEqual(out.foreground, "#a9b1d6")
-        # …every other slot is untouched from the base.
+        self.assertEqual(out.background, "#1a1b26")
+        self.assertEqual(out.panel, out.surface)  # both lifted from bg
+        # No active-border to dodge → first candidate (accent) wins.
+        self.assertEqual(out.secondary, "#7aa2f7")
+        # No active-border file → primary/accent stay on base.
         self.assertEqual(out.primary, "#000001")
-        self.assertEqual(out.secondary, "#000002")
         self.assertEqual(out.accent, "#000003")
+        # Semantic slots untouched.
         self.assertEqual(out.warning, "#000004")
         self.assertEqual(out.error, "#000005")
         self.assertEqual(out.success, "#000006")
-        self.assertEqual(out.background, "#222222")
-        self.assertEqual(out.surface, "#333333")
-        self.assertEqual(out.panel, "#444444")
         self.assertEqual(out.dark, True)
         self.assertEqual(out.name, _BASE.name)
+
+    def test_surface_is_lifted_from_background(self):
+        # surface = bg shifted ~8% toward fg, so it sits between them
+        # rather than mirroring either slot.
+        with tempfile.TemporaryDirectory() as home:
+            _write_palette(Path(home), _DARK_PALETTE)
+            out = apply_omarchy_flavor(_BASE, home=Path(home))
+        assert out is not None
+        self.assertNotEqual(out.surface, out.background)
+        self.assertNotEqual(out.surface, out.foreground)
 
     def test_active_border_overrides_primary_and_accent(self):
         with tempfile.TemporaryDirectory() as home:
@@ -121,17 +132,22 @@ class TestApplyOmarchyFlavor(unittest.TestCase):
         assert out is not None
         self.assertEqual(out.primary, "#7aa2f7")
         self.assertEqual(out.accent, "#7aa2f7")
-        # Secondary untouched.
-        self.assertEqual(out.secondary, _BASE.secondary)
+        # accent equals active-border in tokyo night, so secondary skips
+        # it and lands on color3 — a perceptibly different palette slot.
+        self.assertNotEqual(out.secondary, out.primary)
+        self.assertEqual(out.secondary, "#e0af68")  # color3 (warm yellow)
 
-    def test_light_palette_still_only_touches_foreground(self):
+    def test_light_palette_overrides_environmental_slots(self):
         with tempfile.TemporaryDirectory() as home:
             _write_palette(Path(home), _LIGHT_PALETTE)
             out = apply_omarchy_flavor(_BASE, home=Path(home))
         assert out is not None
         self.assertEqual(out.foreground, "#222222")
-        # `dark` stays as base had it (we're not deriving it from the
-        # omarchy BG today — that'd contradict "FG only" scope).
+        self.assertEqual(out.background, "#f5f5f5")
+        self.assertEqual(out.secondary, "#2e5aa0")
+        # `dark` stays as base had it — we don't derive it from
+        # background luminance, so the user's chosen base controls the
+        # CSS class regardless of the palette.
         self.assertTrue(out.dark)
 
     def test_malformed_toml_returns_none_and_warns(self):


### PR DESCRIPTION
## Summary
- **Splash resize/theme fixes**: rebuild the QHO frame when the cached `(rows, cols)` no longer match the widget (Textual can dispatch render before `on_resize`); re-key `_styles` on the resolved color tuple instead of theme name so omarchy reloads under the same name actually invalidate (the box content was freezing on first-rendered palette).
- **Omarchy palette flavoring**: `apply_omarchy_flavor` now also overrides `background`, `surface`, `panel`, and `secondary` from `colors.toml`. Surface/panel use a derived ~8% lift toward foreground; `secondary` walks `accent → color3 → color5 → color1` and picks the slot most distant in RGB from the active-border `primary` so the splash logo doesn't collapse onto the animation in themes (e.g. tokyo night) where `accent == active-border`.
- **Watch log**: drop empty thinking blocks instead of rendering them as 2-3 phantom blank rows between prompt and assistant response (Claude attaches a 0-length thinking block when extended thinking isn't engaged).

## Test plan
- [x] `uv run python -m unittest discover tests` (462/462 OK)
- [x] `actor watch` → splash; switch omarchy theme via `omarchy theme set <name>`; logo, animation, border, panel all retrack with the new palette
- [x] Resize terminal during splash; no IndexError from stale frame
- [x] Hello-world actor with text + thinking-empty + inline code renders without phantom blanks