### PR TITLE
Watch DIFF tab: full optimization pass (background loading, batched git, streaming, pre-rendered strips, themed label)

### DIFF
--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -43,6 +43,7 @@ from .diff_render import iter_diff_renderables
 from .helpers import (
     compute_diff,
     compute_diff_shortstat,
+    git_index_mtime,
     read_head_oid,
     read_log_entries_since,
 )
@@ -240,6 +241,19 @@ class ActorWatchApp(App):
     _diff_badge_token: int = 0
     _diff_badge_target_actor: str | None = None
 
+    # Live-refresh poll state. While DIFF is active and the selected
+    # actor is RUNNING, a 2s interval ticks
+    # `_poll_diff_for_running`, which captures index mtime + shortstat
+    # and force-refreshes the diff if either flipped vs the last
+    # observation. The first observation after conditions become
+    # true is treated as the baseline (no refresh — the user just
+    # got here, the build is presumably already correct); subsequent
+    # ticks compare. When conditions stop holding, the baseline
+    # resets so a later re-entry baselines cleanly.
+    _diff_poll_initialized: bool = False
+    _diff_poll_last_index_mtime: float | None = None
+    _diff_poll_last_shortstat: tuple[int, int] | None = None
+
     # Base labels for each tab (without the arrow prefix). Kept separate
     # from the rendered tab.label so we can re-apply the "active +
     # focused → arrow" decoration whenever focus moves or the active
@@ -332,6 +346,10 @@ class ActorWatchApp(App):
         # 3s cadence is fine and we don't need inotify / platform-specific
         # machinery. No-op on non-omarchy systems.
         self.set_interval(3.0, self._poll_omarchy_theme)
+        # Live DIFF refresh while the selected actor is RUNNING and
+        # DIFF is active. Same 2s cadence as the actor poller; the
+        # handler early-outs cheaply when conditions don't hold.
+        self.set_interval(2.0, self._poll_diff_for_running)
 
         # Start with focus on the actor tree. call_after_refresh so
         # the focus call runs AFTER any pending focus-changes queued
@@ -1101,6 +1119,99 @@ class ActorWatchApp(App):
         and so a subsequent kick can start a new build cleanly."""
         if token == self._diff_build_token:
             self._diff_build_pending = False
+
+    # -- Live DIFF refresh while a run is in progress ----------------------
+
+    def _poll_diff_for_running(self) -> None:
+        """2s tick (set_interval). Picks up worktree changes for the
+        currently-selected RUNNING actor and force-refreshes the
+        diff so the tab tracks edits without manual interaction.
+
+        Conditions checked synchronously here on the main thread;
+        the subprocess-bound signal capture (`shortstat`) is then
+        delegated to a worker, which calls back via
+        `_evaluate_diff_poll_signals` for the comparison + refresh
+        decision.
+
+        When conditions don't hold (no actor / not RUNNING / DIFF
+        not the active tab), the recorded baseline resets so a
+        later re-entry doesn't think a stale signal "changed"."""
+        actor = self._diff_poll_actor()
+        if actor is None:
+            self._reset_diff_poll_state()
+            return
+        self._poll_diff_signals_worker(actor)
+
+    def _diff_poll_actor(self) -> Actor | None:
+        """The actor whose diff is eligible for live polling, or
+        None if any of (selection, RUNNING status, DIFF tab active)
+        doesn't hold."""
+        try:
+            tree = self.query_one(ActorTree)
+        except Exception:
+            return None
+        actor = tree.selected_actor
+        if actor is None:
+            return None
+        if self._prev_statuses.get(actor.name) != Status.RUNNING:
+            return None
+        try:
+            tabs = self.query_one("#tabs", TabbedContent)
+        except Exception:
+            return None
+        if tabs.active != "diff":
+            return None
+        return actor
+
+    @work(thread=True, exclusive=True, group="diff_poll")
+    def _poll_diff_signals_worker(self, actor: Actor) -> None:
+        """Off-main-thread signal capture: stat the index file +
+        run shortstat. Both are cheap, but a subprocess on the main
+        thread can drop a frame; threading it keeps the TUI smooth."""
+        mtime = git_index_mtime(actor)
+        shortstat = compute_diff_shortstat(actor)
+        self.call_from_thread(
+            self._evaluate_diff_poll_signals,
+            actor.name, mtime, shortstat,
+        )
+
+    def _evaluate_diff_poll_signals(
+        self,
+        actor_name: str,
+        mtime: float | None,
+        shortstat: tuple[int, int] | None,
+    ) -> None:
+        """Main-thread signal comparison + refresh decision.
+
+        Re-checks polling conditions because the worker may have
+        raced with a tab/actor change since the kick: stale signals
+        from a prior selection must not refresh the diff for a
+        different actor."""
+        actor = self._diff_poll_actor()
+        if actor is None or actor.name != actor_name:
+            return
+        if not self._diff_poll_initialized:
+            # First observation since conditions became true. The
+            # user has just landed on DIFF, so the active build /
+            # cache key is presumably already correct — we don't
+            # refresh, just record the baseline for next time.
+            self._diff_poll_initialized = True
+            self._diff_poll_last_index_mtime = mtime
+            self._diff_poll_last_shortstat = shortstat
+            return
+        changed = (
+            mtime != self._diff_poll_last_index_mtime
+            or shortstat != self._diff_poll_last_shortstat
+        )
+        self._diff_poll_last_index_mtime = mtime
+        self._diff_poll_last_shortstat = shortstat
+        if changed:
+            self._maybe_refresh_diff(force=True)
+
+    def _reset_diff_poll_state(self) -> None:
+        self._diff_poll_initialized = False
+        self._diff_poll_last_index_mtime = None
+        self._diff_poll_last_shortstat = None
 
     def _update_diff_tab_label(self, added: int = 0, removed: int = 0) -> None:
         if added or removed:

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -39,7 +39,8 @@ from .omarchy_theme import (
 )
 from .themes import CLAUDE_DARK, CLAUDE_LIGHT
 from .tree import ActorTree
-from .helpers import compute_diff, read_log_entries_since
+from .diff_render import build_diff_renderables
+from .helpers import compute_diff, read_head_oid, read_log_entries_since
 from .log_renderer import (
     append_log_entries,
     apply_log_renderables,
@@ -201,6 +202,23 @@ class ActorWatchApp(App):
     _prev_statuses: dict[str, Status] = {}
     _current_actors: list[Actor] = []
     _diff_loaded_for: str | None = None
+
+    # Two-phase diff build state — mirrors the logs pattern. The kick
+    # path bumps `_diff_build_token` and starts a worker; the worker
+    # checks the token cooperatively and only commits its result when
+    # the token still matches at apply time. `_diff_build_pending`
+    # gates the 300ms placeholder. `_diff_last_applied_key` stores the
+    # `(actor.name, head_oid, content_width)` cache key from the most
+    # recent successful apply — kicks early-out when the request key
+    # matches. `_diff_pending_actor` stashes the actor whose diff was
+    # requested while the DIFF tab was hidden (width 0); the next tab
+    # activation flushes it.
+    _diff_build_token: int = 0
+    _diff_build_pending: bool = False
+    _diff_build_target_actor: str | None = None
+    _diff_build_target_width: int = 0
+    _diff_last_applied_key: tuple | None = None
+    _diff_pending_actor: str | None = None
 
     # Base labels for each tab (without the arrow prefix). Kept separate
     # from the rendered tab.label so we can re-apply the "active +
@@ -532,6 +550,12 @@ class ActorWatchApp(App):
         scroll = self.query_one("#diff-scroll", VerticalScroll)
         scroll.remove_children()
         self._diff_loaded_for = None
+        # Cancel any in-flight diff build by bumping the token; the
+        # worker's apply will see a mismatch and drop its output.
+        self._diff_build_token += 1
+        self._diff_build_pending = False
+        self._diff_last_applied_key = None
+        self._diff_pending_actor = None
         self._update_diff_tab_label()
 
     # -- Logs ----------------------------------------------------------------
@@ -591,6 +615,27 @@ class ActorWatchApp(App):
         if log.size.width != self._last_log_width and self._last_log_entries:
             self._last_log_count = 0
             self._set_logs(self._last_log_actor, self._last_log_entries)
+
+        # Diff: width is part of the cache key, so a real width change
+        # invalidates the last apply. Re-kick for the currently-loaded
+        # actor; the kick's own width-0 guard handles the hidden case.
+        try:
+            scroll = self.query_one("#diff-scroll", VerticalScroll)
+        except Exception:
+            return
+        last_key = self._diff_last_applied_key
+        if last_key is None:
+            return
+        last_actor_name, _last_oid, last_width = last_key
+        if scroll.size.width == last_width:
+            return
+        actor = next(
+            (a for a in self._current_actors if a.name == last_actor_name),
+            None,
+        )
+        if actor is None:
+            return
+        self._kick_diff_build(actor)
 
     def _append_logs(self, actor_name: str, new_entries: list) -> None:
         """Main-thread callback from _refresh_logs worker. The cursor
@@ -803,37 +848,149 @@ class ActorWatchApp(App):
         if not force and self._diff_loaded_for == actor.name:
             return
         self._diff_loaded_for = actor.name
-        self._refresh_diff(actor)
+        self._kick_diff_build(actor)
 
-    @work(thread=True, exclusive=True, group="diff")
-    def _refresh_diff(self, actor: Actor) -> None:
-        from .diff_render import render_edit_diff
+    def _kick_diff_build(self, actor: Actor) -> None:
+        """Start an off-thread diff build with token + 300ms placeholder.
 
-        result = compute_diff(actor)
+        Skips work entirely when `#diff-scroll` has zero width — that
+        means the DIFF tab is hidden (TabbedContent collapses inactive
+        panes). The actor is stashed on `_diff_pending_actor` and
+        replayed by `_flush_pending_diff_if_visible` once the tab is
+        activated.
 
-        if result.files is None:
-            self.call_from_thread(self._set_diff_text, result.reason)
+        Token discipline mirrors the logs path: every kick bumps
+        `_diff_build_token`, every worker captures its own token, and
+        `_apply_diff_build` only commits when the captured token still
+        matches. Stale workers drop their output silently."""
+        try:
+            scroll = self.query_one("#diff-scroll", VerticalScroll)
+        except Exception:
+            return
+        width = scroll.size.width
+        if width == 0:
+            self._diff_pending_actor = actor.name
+            return
+        self._diff_pending_actor = None
+
+        self._diff_build_token += 1
+        self._diff_build_pending = True
+        self._diff_build_target_actor = actor.name
+        self._diff_build_target_width = width
+        token = self._diff_build_token
+
+        def _maybe_show_placeholder() -> None:
+            # Fire only if this build is still the latest one AND
+            # hasn't already applied. Any newer kick-off bumps the
+            # token; a committed apply clears the pending flag.
+            if token != self._diff_build_token or not self._diff_build_pending:
+                return
+            try:
+                scroll = self.query_one("#diff-scroll", VerticalScroll)
+            except Exception:
+                return
+            scroll.remove_children()
+            scroll.mount(Static(Text("Loading diff...", style="dim")))
+
+        self.set_timer(0.3, _maybe_show_placeholder)
+        self._build_diff_worker(token, actor, width)
+
+    @work(thread=True, exclusive=True, group="diff_build")
+    def _build_diff_worker(self, token: int, actor: Actor, width: int) -> None:
+        # Cooperative cancel: when a newer build supersedes this one,
+        # `_diff_build_token` is already the new value on the main
+        # thread. Check at every coarse-grained boundary so we don't
+        # keep burning subprocess + render work on output that will be
+        # discarded anyway.
+        def is_cancelled() -> bool:
+            return self._diff_build_token != token
+
+        if is_cancelled():
             return
 
+        head_oid = read_head_oid(actor)
+        cache_key = (actor.name, head_oid, width)
+        if cache_key == self._diff_last_applied_key:
+            # Nothing relevant changed since the last applied build —
+            # skip the expensive `compute_diff` + render. Hand control
+            # back to the main thread to clear the pending flag.
+            self.call_from_thread(self._mark_diff_build_done, token)
+            return
+
+        if is_cancelled():
+            return
+
+        result = compute_diff(actor)
+        if is_cancelled():
+            return
+
+        if result.files is None:
+            self.call_from_thread(
+                self._apply_diff_text, token, cache_key, result.reason,
+            )
+            return
+
+        is_dark = self.current_theme.dark if self.current_theme else True
         try:
-            is_dark = self.current_theme.dark if self.current_theme else True
-            from rich.console import Group
-            import difflib
-            parts = []
-            total_added = 0
-            total_removed = 0
-            from rich.text import Text as RichText
-            for fd in result.files:
-                parts.append(render_edit_diff(fd.file_path, fd.old_content, fd.new_content, dark=is_dark, style="diff"))
-                parts.append(RichText(""))
-                for line in difflib.unified_diff(fd.old_content.splitlines(), fd.new_content.splitlines(), lineterm=""):
-                    if line.startswith("+") and not line.startswith("+++"):
-                        total_added += 1
-                    elif line.startswith("-") and not line.startswith("---"):
-                        total_removed += 1
-            self.call_from_thread(self._set_diff_widget, Static(Group(*parts)), total_added, total_removed)
+            built = build_diff_renderables(result.files, is_dark, is_cancelled)
         except Exception as e:
-            self.call_from_thread(self._set_diff_text, f"Diff error: {e}")
+            self.call_from_thread(
+                self._apply_diff_text, token, cache_key, f"Diff error: {e}",
+            )
+            return
+        if built is None:
+            # Cancelled mid-build; the newer worker owns the apply.
+            return
+        parts, total_added, total_removed = built
+        self.call_from_thread(
+            self._apply_diff_build,
+            token, cache_key, parts, total_added, total_removed,
+        )
+
+    def _apply_diff_build(
+        self,
+        token: int,
+        cache_key: tuple,
+        parts: list,
+        total_added: int,
+        total_removed: int,
+    ) -> None:
+        if token != self._diff_build_token:
+            return
+        try:
+            scroll = self.query_one("#diff-scroll", VerticalScroll)
+        except Exception:
+            self._diff_build_pending = False
+            return
+        from rich.console import Group
+        scroll.remove_children()
+        scroll.mount(Static(Group(*parts)))
+        self._diff_build_pending = False
+        self._diff_last_applied_key = cache_key
+        self._update_diff_tab_label(total_added, total_removed)
+
+    def _apply_diff_text(
+        self, token: int, cache_key: tuple, text: str,
+    ) -> None:
+        if token != self._diff_build_token:
+            return
+        try:
+            scroll = self.query_one("#diff-scroll", VerticalScroll)
+        except Exception:
+            self._diff_build_pending = False
+            return
+        scroll.remove_children()
+        scroll.mount(Static(text))
+        self._diff_build_pending = False
+        self._diff_last_applied_key = cache_key
+        self._update_diff_tab_label()
+
+    def _mark_diff_build_done(self, token: int) -> None:
+        """Cache-hit early-out path: the worker decided no rebuild was
+        needed. Clear the pending flag so the placeholder doesn't fire
+        and so a subsequent kick can start a new build cleanly."""
+        if token == self._diff_build_token:
+            self._diff_build_pending = False
 
     def _update_diff_tab_label(self, added: int = 0, removed: int = 0) -> None:
         if added or removed:
@@ -884,6 +1041,9 @@ class ActorWatchApp(App):
         # first paint sees real content at the real width instead
         # of a stale/empty cache that then gets corrected.
         self._flush_pending_logs_if_visible()
+        # Same story for DIFF: kicks that happened while the tab was
+        # hidden stash on `_diff_pending_actor`; flush them now.
+        self._flush_pending_diff_if_visible()
 
     def _flush_pending_logs_if_visible(self) -> None:
         """Re-run the logs renderer once LIVE has a non-zero width,
@@ -921,17 +1081,34 @@ class ActorWatchApp(App):
     def on_descendant_blur(self, event) -> None:
         self._refresh_tab_arrows()
 
-    def _set_diff_text(self, text: str) -> None:
-        scroll = self.query_one("#diff-scroll", VerticalScroll)
-        scroll.remove_children()
-        scroll.mount(Static(text))
-        self._update_diff_tab_label()
+    def _flush_pending_diff_if_visible(self) -> None:
+        """Re-kick the stashed diff build once DIFF has a non-zero
+        width, mirroring `_flush_pending_logs_if_visible`. Called from
+        the tab-activated handler.
 
-    def _set_diff_widget(self, dv: object, added: int = 0, removed: int = 0) -> None:
-        scroll = self.query_one("#diff-scroll", VerticalScroll)
-        scroll.remove_children()
-        scroll.mount(dv)
-        self._update_diff_tab_label(added, removed)
+        `_kick_diff_build`'s width-0 guard handles the "still hidden"
+        case (it just re-stashes), and the cache-key comparison in
+        the worker short-circuits the "user toggled tabs but nothing
+        else changed" case so we don't pay for redundant rebuilds."""
+        if self._diff_pending_actor is None:
+            return
+        name = self._diff_pending_actor
+
+        def _attempt() -> None:
+            try:
+                scroll = self.query_one("#diff-scroll", VerticalScroll)
+            except Exception:
+                return
+            if scroll.size.width == 0:
+                return
+            actor = next(
+                (a for a in self._current_actors if a.name == name), None,
+            )
+            if actor is None:
+                return
+            self._kick_diff_build(actor)
+
+        self.call_after_refresh(_attempt)
 
     # -- Runs ----------------------------------------------------------------
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -1225,6 +1225,13 @@ class ActorWatchApp(App):
         scroll.mount(Static(text, markup=False))
         self._diff_build_pending = False
         self._diff_last_applied_key = None
+        # Same badge-race guard as `_apply_diff_build_done` and
+        # `_apply_diff_text`: a badge worker from this same kick
+        # (still in flight with shortstat counts) must not later
+        # land "+5 -3" on top of the error message we just mounted
+        # — that would split the tab label and the scroll pane into
+        # contradictory states.
+        self._diff_badge_token += 1
         self._update_diff_tab_label()
 
     def _mark_diff_build_done(self, token: int) -> None:
@@ -1501,6 +1508,11 @@ class ActorWatchApp(App):
                 (a for a in self._current_actors if a.name == name), None,
             )
             if actor is None:
+                # Actor was discarded between the stash and the
+                # flush. Clear the stash so subsequent tab
+                # activations don't repeatedly try (and fail) to
+                # resolve a stale name.
+                self._diff_pending_actor = None
                 return
             self._kick_diff_build(actor)
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -1029,9 +1029,24 @@ class ActorWatchApp(App):
             return
 
         if result.files is None:
-            self.call_from_thread(
-                self._apply_diff_text, token, cache_key, result.reason,
-            )
+            # `compute_diff` reports two flavors of file-less result:
+            # benign reasons ("working tree clean", "no repository")
+            # which CACHE — repeat kicks at the same key correctly
+            # early-out — and "error" which signals a transient
+            # internal failure that must NOT be cached, otherwise
+            # the user is stuck on the error state until HEAD or
+            # width changes. Route the error reason through
+            # `_apply_diff_error` (cache-invalidating) and benign
+            # reasons through `_apply_diff_text` (cache-promoting).
+            if result.reason == "error":
+                self.call_from_thread(
+                    self._apply_diff_error, token,
+                    "Diff error: compute failed",
+                )
+            else:
+                self.call_from_thread(
+                    self._apply_diff_text, token, cache_key, result.reason,
+                )
             return
 
         # Stream files into `#diff-scroll` one PrerenderedDiff widget
@@ -1146,11 +1161,18 @@ class ActorWatchApp(App):
         label totals, drop the pending flag. Idempotent against
         per-file appends — only the cache key + label promotion need
         to ride this finalizer; the scroll is already populated by
-        the streaming `_diff_append_file` calls."""
+        the streaming `_diff_append_file` calls.
+
+        Bumps `_diff_badge_token` so any in-flight badge worker
+        from the same kick can no longer apply: the build's count
+        includes untracked files (which shortstat misses), so a
+        late-arriving badge would otherwise revise our authoritative
+        number downward and visually flicker."""
         if token != self._diff_build_token:
             return
         self._diff_build_pending = False
         self._diff_last_applied_key = cache_key
+        self._diff_badge_token += 1
         self._update_diff_tab_label(total_added, total_removed)
 
     def _apply_diff_text(
@@ -1175,6 +1197,10 @@ class ActorWatchApp(App):
         scroll.mount(Static(text, markup=False))
         self._diff_build_pending = False
         self._diff_last_applied_key = cache_key
+        # Same badge-race guard as `_apply_diff_build_done`: an
+        # in-flight badge from this kick must not later overwrite
+        # the no-changes / no-repo label we just committed.
+        self._diff_badge_token += 1
         self._update_diff_tab_label()
 
     def _apply_diff_error(self, token: int, text: str) -> None:
@@ -1232,8 +1258,16 @@ class ActorWatchApp(App):
 
     def _diff_poll_actor(self) -> Actor | None:
         """The actor whose diff is eligible for live polling, or
-        None if any of (selection, RUNNING status, DIFF tab active)
-        doesn't hold."""
+        None if any of (selection, RUNNING/INTERACTIVE status,
+        DIFF tab active) doesn't hold.
+
+        `Status.INTERACTIVE` is a display-only overlay applied to
+        actors with a live interactive session — under the hood
+        they're typically still RUNNING, and the user is driving
+        them by hand which can absolutely modify the worktree.
+        Excluding INTERACTIVE here would silently disable live
+        diff refresh for one of the most common use cases (a user
+        running an agent interactively while watching its edits)."""
         try:
             tree = self.query_one(ActorTree)
         except Exception:
@@ -1241,7 +1275,8 @@ class ActorWatchApp(App):
         actor = tree.selected_actor
         if actor is None:
             return None
-        if self._prev_statuses.get(actor.name) != Status.RUNNING:
+        status = self._prev_statuses.get(actor.name)
+        if status not in (Status.RUNNING, Status.INTERACTIVE):
             return None
         try:
             tabs = self.query_one("#tabs", TabbedContent)

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -984,6 +984,20 @@ class ActorWatchApp(App):
             # token; a committed apply clears the pending flag.
             if token != self._diff_build_token or not self._diff_build_pending:
                 return
+            # Skip the placeholder when we already have content for
+            # this actor — wiping fresh content with "Loading diff..."
+            # for a few hundred milliseconds is jarring and recurs
+            # every 2s while the live poll force-refreshes a slow
+            # render. The cache-key actor field tells us whether the
+            # currently mounted scroll content matches the actor of
+            # this kick; if so, leave it alone until the new build
+            # streams or the finalizer commits.
+            last_key = self._diff_last_applied_key
+            if (
+                last_key is not None
+                and last_key[0] == self._diff_build_target_actor
+            ):
+                return
             try:
                 scroll = self.query_one("#diff-scroll", VerticalScroll)
             except Exception:
@@ -1225,6 +1239,14 @@ class ActorWatchApp(App):
         scroll.mount(Static(text, markup=False))
         self._diff_build_pending = False
         self._diff_last_applied_key = None
+        # Reset `_diff_loaded_for` so re-selecting the same actor in
+        # the tree retries the build instead of short-circuiting at
+        # the `_maybe_refresh_diff` actor-already-loaded check. Without
+        # this, the user would be stuck on the error message and have
+        # to switch actors and back (or wait for a live-poll force
+        # refresh) just to retry. With this reset, a simple re-click
+        # in the actor tree fires a fresh build.
+        self._diff_loaded_for = None
         # Same badge-race guard as `_apply_diff_build_done` and
         # `_apply_diff_text`: a badge worker from this same kick
         # (still in flight with shortstat counts) must not later

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -1234,29 +1234,29 @@ class ActorWatchApp(App):
         self._diff_poll_last_shortstat = None
 
     def _update_diff_tab_label(self, added: int = 0, removed: int = 0) -> None:
-        # Classic diff-style ` +N -M` badge with theme `$success` / `$error`
-        # for the colors so omarchy palette flips carry through. We hold a
-        # Rich Text in `_tab_base_labels["diff"]` instead of a plain string
-        # — Tab.label accepts Rich renderables, and `_refresh_tab_arrows`
-        # special-cases Text bases to preserve the styling when it
-        # prepends the focus-arrow.
+        # Pill-style ` +N -M` badge using the same fg/bg the diff body
+        # uses for added/removed lines (`DARK_COLORS` / `LIGHT_COLORS`
+        # in diff_render). Inactive tab → colored pills; active tab →
+        # plain text (Textual's focus-background overrides our colors
+        # there and would produce unreadable contrast). The
+        # active-state stripping happens in `_refresh_tab_arrows`.
         if added or removed:
+            from .diff_render import DARK_COLORS, LIGHT_COLORS
             # `current_theme` raises ReactiveError before super().__init__
-            # runs (some tests construct a bare App without init). Falling
-            # back to brand defaults keeps label generation pure-data-in.
+            # runs (some tests bypass init). Default to dark on failure.
             try:
                 t = self.current_theme
+                is_dark = t.dark if t else True
             except Exception:
-                t = None
-            success = (t.success if t else None) or "#50C850"
-            error = (t.error if t else None) or "#DC5A5A"
+                is_dark = True
+            dc = DARK_COLORS if is_dark else LIGHT_COLORS
+            added_style = f"{dc.added_marker} on {dc.added_bg}"
+            removed_style = f"{dc.removed_marker} on {dc.removed_bg}"
             base: str | Text = Text("DIFF")
             if added:
-                base.append(" +", style=success)
-                base.append(str(added), style=success)
+                base.append(f" +{added}", style=added_style)
             if removed:
-                base.append(" -", style=error)
-                base.append(str(removed), style=error)
+                base.append(f" -{removed}", style=removed_style)
         else:
             base = "DIFF"
         self._tab_base_labels["diff"] = base
@@ -1283,14 +1283,13 @@ class ActorWatchApp(App):
             if tab is None:
                 continue
             if tab_id == active_id and focused:
-                if isinstance(base, Text):
-                    # Preserve segment styles in the Text base when
-                    # prepending the focus arrow. f"→ {text}" would
-                    # stringify it and drop the colors.
-                    label: str | Text = Text("→ ").append_text(base)
-                else:
-                    label = f"→ {base}"
-                tab.label = label
+                # Drop styles when this tab is the focused-active one —
+                # Textual paints its own reverse-video focus background
+                # over the label, and our pill colors fight it (e.g.
+                # green-on-darkgreen badge becomes unreadable on the
+                # active-tab background). Use the plain text form.
+                plain = base.plain if isinstance(base, Text) else base
+                tab.label = f"→ {plain}"
             else:
                 tab.label = base
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -40,7 +40,12 @@ from .omarchy_theme import (
 from .themes import CLAUDE_DARK, CLAUDE_LIGHT
 from .tree import ActorTree
 from .diff_render import build_diff_renderables
-from .helpers import compute_diff, read_head_oid, read_log_entries_since
+from .helpers import (
+    compute_diff,
+    compute_diff_shortstat,
+    read_head_oid,
+    read_log_entries_since,
+)
 from .log_renderer import (
     append_log_entries,
     apply_log_renderables,
@@ -219,6 +224,15 @@ class ActorWatchApp(App):
     _diff_build_target_width: int = 0
     _diff_last_applied_key: tuple | None = None
     _diff_pending_actor: str | None = None
+
+    # Cheap-badge-first state. Independent of the full build path —
+    # the badge worker runs `git diff --shortstat` to produce a
+    # near-instant ±N for the tab label while the heavier full build
+    # is still parsing diffs and rendering Tables. Token discipline
+    # mirrors the build path but uses its own counter so the two
+    # paths cancel independently.
+    _diff_badge_token: int = 0
+    _diff_badge_target_actor: str | None = None
 
     # Base labels for each tab (without the arrow prefix). Kept separate
     # from the rendered tab.label so we can re-apply the "active +
@@ -550,9 +564,11 @@ class ActorWatchApp(App):
         scroll = self.query_one("#diff-scroll", VerticalScroll)
         scroll.remove_children()
         self._diff_loaded_for = None
-        # Cancel any in-flight diff build by bumping the token; the
-        # worker's apply will see a mismatch and drop its output.
+        # Cancel any in-flight diff build / badge worker by bumping
+        # both tokens; their applies will see a mismatch and drop
+        # their output.
         self._diff_build_token += 1
+        self._diff_badge_token += 1
         self._diff_build_pending = False
         self._diff_last_applied_key = None
         self._diff_pending_actor = None
@@ -848,7 +864,50 @@ class ActorWatchApp(App):
         if not force and self._diff_loaded_for == actor.name:
             return
         self._diff_loaded_for = actor.name
+        # Kick both paths together. The badge is independent of the
+        # full build — even if the build is stashed because DIFF is
+        # hidden, the badge still fires and updates the always-visible
+        # tab label.
+        self._kick_diff_badge(actor)
         self._kick_diff_build(actor)
+
+    def _kick_diff_badge(self, actor: Actor) -> None:
+        """Fire a quick `git diff --shortstat` worker just to populate
+        the DIFF (±N) tab label. Independent of the full build path
+        so the label appears in <100ms even when the full render is
+        still parsing diffs and building Tables.
+
+        Fires regardless of whether the DIFF tab is currently active —
+        the label sits in the tabs bar, which is always visible, so a
+        user looking at LIVE still benefits from seeing what's pending
+        on DIFF. (The full build path's hidden-tab stash is about
+        avoiding zero-width RichLog renders; the badge has no widget
+        to render into, so the same constraint doesn't apply.)"""
+        self._diff_badge_token += 1
+        self._diff_badge_target_actor = actor.name
+        self._build_diff_badge_worker(self._diff_badge_token, actor)
+
+    @work(thread=True, exclusive=True, group="diff_badge")
+    def _build_diff_badge_worker(self, token: int, actor: Actor) -> None:
+        # Cooperative cancel — same discipline as the build worker.
+        if self._diff_badge_token != token:
+            return
+        counts = compute_diff_shortstat(actor)
+        if self._diff_badge_token != token or counts is None:
+            return
+        added, removed = counts
+        self.call_from_thread(self._apply_diff_badge, token, added, removed)
+
+    def _apply_diff_badge(self, token: int, added: int, removed: int) -> None:
+        """Main-thread commit of badge counts. Stale tokens drop
+        silently; the build-path apply will land its own (possibly
+        higher, if untracked files contributed) counts later either
+        way. The two paths share `_update_diff_tab_label` — last
+        write wins, which is fine because the build's number is
+        authoritative and arrives last."""
+        if token != self._diff_badge_token:
+            return
+        self._update_diff_tab_label(added, removed)
 
     def _kick_diff_build(self, actor: Actor) -> None:
         """Start an off-thread diff build with token + 300ms placeholder.

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -259,7 +259,10 @@ class ActorWatchApp(App):
     # from the rendered tab.label so we can re-apply the "active +
     # focused → arrow" decoration whenever focus moves or the active
     # tab changes.
-    _tab_base_labels: dict[str, str] = {
+    # `diff` may hold a Rich Text (with green +N / red -M segments) when
+    # there are changes; the others stay strings. `_refresh_tab_arrows`
+    # handles either shape when prepending the focus arrow.
+    _tab_base_labels: dict[str, str | Text] = {
         "logs": "LIVE",
         "diff": "DIFF",
         "info": "OVERVIEW",
@@ -1231,8 +1234,29 @@ class ActorWatchApp(App):
         self._diff_poll_last_shortstat = None
 
     def _update_diff_tab_label(self, added: int = 0, removed: int = 0) -> None:
+        # Classic diff-style ` +N -M` badge with theme `$success` / `$error`
+        # for the colors so omarchy palette flips carry through. We hold a
+        # Rich Text in `_tab_base_labels["diff"]` instead of a plain string
+        # — Tab.label accepts Rich renderables, and `_refresh_tab_arrows`
+        # special-cases Text bases to preserve the styling when it
+        # prepends the focus-arrow.
         if added or removed:
-            base = f"DIFF (±{added + removed})"
+            # `current_theme` raises ReactiveError before super().__init__
+            # runs (some tests construct a bare App without init). Falling
+            # back to brand defaults keeps label generation pure-data-in.
+            try:
+                t = self.current_theme
+            except Exception:
+                t = None
+            success = (t.success if t else None) or "#50C850"
+            error = (t.error if t else None) or "#DC5A5A"
+            base: str | Text = Text("DIFF")
+            if added:
+                base.append(" +", style=success)
+                base.append(str(added), style=success)
+            if removed:
+                base.append(" -", style=error)
+                base.append(str(removed), style=error)
         else:
             base = "DIFF"
         self._tab_base_labels["diff"] = base
@@ -1259,7 +1283,14 @@ class ActorWatchApp(App):
             if tab is None:
                 continue
             if tab_id == active_id and focused:
-                tab.label = f"→ {base}"
+                if isinstance(base, Text):
+                    # Preserve segment styles in the Text base when
+                    # prepending the focus arrow. f"→ {text}" would
+                    # stringify it and drop the colors.
+                    label: str | Text = Text("→ ").append_text(base)
+                else:
+                    label = f"→ {base}"
+                tab.label = label
             else:
                 tab.label = base
 

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -40,6 +40,7 @@ from .omarchy_theme import (
 from .themes import CLAUDE_DARK, CLAUDE_LIGHT
 from .tree import ActorTree
 from .diff_render import iter_diff_renderables
+from .prerendered_diff import PrerenderedDiff, renderable_to_strips
 from .helpers import (
     compute_diff,
     compute_diff_shortstat,
@@ -1013,10 +1014,18 @@ class ActorWatchApp(App):
             )
             return
 
-        # Stream files into `#diff-scroll` one Static per file as
-        # they finish rendering. The first append for this token
-        # clears placeholder/prior content on the main thread (see
-        # `_diff_append_file`); subsequent appends just mount.
+        # Stream files into `#diff-scroll` one PrerenderedDiff widget
+        # per file as they finish rendering. The first append for this
+        # token clears placeholder/prior content on the main thread
+        # (see `_diff_append_file`); subsequent appends just mount.
+        #
+        # Each file's Rich renderable is converted to a list of
+        # textual `Strip`s **here in the worker thread** — that's the
+        # CPU-bound Segment-generation pass that previously happened
+        # on the main thread at paint time and showed up as a UI hang.
+        # By the time we call_from_thread, the strips are pre-baked;
+        # the main thread's mount + paint becomes effectively
+        # constant-time per file.
         is_dark = self.current_theme.dark if self.current_theme else True
         total_added = 0
         total_removed = 0
@@ -1024,8 +1033,13 @@ class ActorWatchApp(App):
             for path, renderable, added, removed in iter_diff_renderables(
                 result.files, is_dark, is_cancelled,
             ):
+                if is_cancelled():
+                    return
+                strips = renderable_to_strips(renderable, width)
+                if is_cancelled():
+                    return
                 self.call_from_thread(
-                    self._diff_append_file, token, path, renderable,
+                    self._diff_append_file, token, path, strips,
                 )
                 total_added += added
                 total_removed += removed
@@ -1053,19 +1067,23 @@ class ActorWatchApp(App):
         self,
         token: int,
         file_path: str,
-        renderable: object,
+        strips: list,
     ) -> None:
-        """Streaming mount of a single rendered file onto
+        """Streaming mount of a single pre-rendered file onto
         `#diff-scroll`. Stale tokens (newer kick already in flight)
         skip the mount.
 
         The first append for a given token clears the scroll —
         wiping the 300ms placeholder if it fired and any leftover
-        Statics from a prior kick. From there, each subsequent
-        append for the same token mounts one more Static at the
-        bottom, so the user sees files appear in order as they
-        render. Pending is flipped off on first append too: real
-        content is on screen, the placeholder must not fire."""
+        widgets from a prior kick. From there, each subsequent
+        append for the same token mounts one more PrerenderedDiff
+        at the bottom, so the user sees files appear in order as
+        they render. Pending is flipped off on first append too:
+        real content is on screen, the placeholder must not fire.
+
+        `strips` is a list of `textual.strip.Strip` produced off-thread
+        by `renderable_to_strips` — mounting + painting the widget is
+        effectively constant-time, no CPU-bound Rich render at paint."""
         if token != self._diff_build_token:
             return
         try:
@@ -1076,8 +1094,7 @@ class ActorWatchApp(App):
             scroll.remove_children()
             self._diff_streamed_token = token
             self._diff_build_pending = False
-        from rich.console import Group
-        scroll.mount(Static(Group(renderable, Text(""))))
+        scroll.mount(PrerenderedDiff(strips))
 
     def _apply_diff_build_done(
         self,

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -39,7 +39,7 @@ from .omarchy_theme import (
 )
 from .themes import CLAUDE_DARK, CLAUDE_LIGHT
 from .tree import ActorTree
-from .diff_render import build_diff_renderables
+from .diff_render import iter_diff_renderables
 from .helpers import (
     compute_diff,
     compute_diff_shortstat,
@@ -224,6 +224,12 @@ class ActorWatchApp(App):
     _diff_build_target_width: int = 0
     _diff_last_applied_key: tuple | None = None
     _diff_pending_actor: str | None = None
+    # Stage-4 streaming: which token's first-file append landed on
+    # `#diff-scroll`. The first append for a given kick clears the
+    # scroll (placeholder + any prior content); subsequent appends
+    # for the same token just mount. -1 is a sentinel that never
+    # matches a live token.
+    _diff_streamed_token: int = -1
 
     # Cheap-badge-first state. Independent of the full build path —
     # the badge worker runs `git diff --shortstat` to produce a
@@ -989,41 +995,86 @@ class ActorWatchApp(App):
             )
             return
 
+        # Stream files into `#diff-scroll` one Static per file as
+        # they finish rendering. The first append for this token
+        # clears placeholder/prior content on the main thread (see
+        # `_diff_append_file`); subsequent appends just mount.
         is_dark = self.current_theme.dark if self.current_theme else True
+        total_added = 0
+        total_removed = 0
         try:
-            built = build_diff_renderables(result.files, is_dark, is_cancelled)
+            for path, renderable, added, removed in iter_diff_renderables(
+                result.files, is_dark, is_cancelled,
+            ):
+                self.call_from_thread(
+                    self._diff_append_file, token, path, renderable,
+                )
+                total_added += added
+                total_removed += removed
         except Exception as e:
+            # Mid-stream render error → wipe whatever's mounted and
+            # surface the error message in its place. `_apply_diff_text`
+            # remove_children's the scroll first, so partial appends
+            # don't linger above the error.
             self.call_from_thread(
                 self._apply_diff_text, token, cache_key, f"Diff error: {e}",
             )
             return
-        if built is None:
-            # Cancelled mid-build; the newer worker owns the apply.
+        if is_cancelled():
+            # Stream stopped mid-flight; the partial mounts already on
+            # screen stay until the newer kick's first append clears
+            # them. We deliberately don't finalize cache_key here so
+            # the next build re-renders rather than seeing a cache hit.
             return
-        parts, total_added, total_removed = built
         self.call_from_thread(
-            self._apply_diff_build,
-            token, cache_key, parts, total_added, total_removed,
+            self._apply_diff_build_done,
+            token, cache_key, total_added, total_removed,
         )
 
-    def _apply_diff_build(
+    def _diff_append_file(
         self,
         token: int,
-        cache_key: tuple,
-        parts: list,
-        total_added: int,
-        total_removed: int,
+        file_path: str,
+        renderable: object,
     ) -> None:
+        """Streaming mount of a single rendered file onto
+        `#diff-scroll`. Stale tokens (newer kick already in flight)
+        skip the mount.
+
+        The first append for a given token clears the scroll —
+        wiping the 300ms placeholder if it fired and any leftover
+        Statics from a prior kick. From there, each subsequent
+        append for the same token mounts one more Static at the
+        bottom, so the user sees files appear in order as they
+        render. Pending is flipped off on first append too: real
+        content is on screen, the placeholder must not fire."""
         if token != self._diff_build_token:
             return
         try:
             scroll = self.query_one("#diff-scroll", VerticalScroll)
         except Exception:
-            self._diff_build_pending = False
             return
+        if self._diff_streamed_token != token:
+            scroll.remove_children()
+            self._diff_streamed_token = token
+            self._diff_build_pending = False
         from rich.console import Group
-        scroll.remove_children()
-        scroll.mount(Static(Group(*parts)))
+        scroll.mount(Static(Group(renderable, Text(""))))
+
+    def _apply_diff_build_done(
+        self,
+        token: int,
+        cache_key: tuple,
+        total_added: int,
+        total_removed: int,
+    ) -> None:
+        """Finalize a streamed build: lock in the cache key + tab
+        label totals, drop the pending flag. Idempotent against
+        per-file appends — only the cache key + label promotion need
+        to ride this finalizer; the scroll is already populated by
+        the streaming `_diff_append_file` calls."""
+        if token != self._diff_build_token:
+            return
         self._diff_build_pending = False
         self._diff_last_applied_key = cache_key
         self._update_diff_tab_label(total_added, total_removed)

--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -45,6 +45,7 @@ from .helpers import (
     compute_diff,
     compute_diff_shortstat,
     git_index_mtime,
+    git_untracked_count,
     read_head_oid,
     read_log_entries_since,
 )
@@ -252,8 +253,10 @@ class ActorWatchApp(App):
     # ticks compare. When conditions stop holding, the baseline
     # resets so a later re-entry baselines cleanly.
     _diff_poll_initialized: bool = False
+    _diff_poll_last_actor: str | None = None
     _diff_poll_last_index_mtime: float | None = None
     _diff_poll_last_shortstat: tuple[int, int] | None = None
+    _diff_poll_last_untracked: int | None = None
 
     # Base labels for each tab (without the arrow prefix). Kept separate
     # from the rendered tab.label so we can re-apply the "active +
@@ -895,9 +898,12 @@ class ActorWatchApp(App):
         # Kick both paths together. The badge is independent of the
         # full build — even if the build is stashed because DIFF is
         # hidden, the badge still fires and updates the always-visible
-        # tab label.
+        # tab label. `force` propagates to the build kick so the
+        # cache-key short-circuit doesn't suppress live-poll-driven
+        # refreshes (HEAD doesn't move during a typical run, so the
+        # cache key matches, but the worktree HAS changed).
         self._kick_diff_badge(actor)
-        self._kick_diff_build(actor)
+        self._kick_diff_build(actor, force=force)
 
     def _kick_diff_badge(self, actor: Actor) -> None:
         """Fire a quick `git diff --shortstat` worker just to populate
@@ -937,7 +943,7 @@ class ActorWatchApp(App):
             return
         self._update_diff_tab_label(added, removed)
 
-    def _kick_diff_build(self, actor: Actor) -> None:
+    def _kick_diff_build(self, actor: Actor, force: bool = False) -> None:
         """Start an off-thread diff build with token + 300ms placeholder.
 
         Skips work entirely when `#diff-scroll` has zero width — that
@@ -949,7 +955,13 @@ class ActorWatchApp(App):
         Token discipline mirrors the logs path: every kick bumps
         `_diff_build_token`, every worker captures its own token, and
         `_apply_diff_build` only commits when the captured token still
-        matches. Stale workers drop their output silently."""
+        matches. Stale workers drop their output silently.
+
+        `force=True` skips the cache-key short-circuit in the worker
+        — used by the live-refresh poller, which kicks precisely
+        BECAUSE the worktree changed even though HEAD didn't move.
+        Without this bypass the cache check would early-out and the
+        diff would stay stale despite the user editing files."""
         try:
             scroll = self.query_one("#diff-scroll", VerticalScroll)
         except Exception:
@@ -980,10 +992,12 @@ class ActorWatchApp(App):
             scroll.mount(Static(Text("Loading diff...", style="dim")))
 
         self.set_timer(0.3, _maybe_show_placeholder)
-        self._build_diff_worker(token, actor, width)
+        self._build_diff_worker(token, actor, width, force)
 
     @work(thread=True, exclusive=True, group="diff_build")
-    def _build_diff_worker(self, token: int, actor: Actor, width: int) -> None:
+    def _build_diff_worker(
+        self, token: int, actor: Actor, width: int, force: bool = False,
+    ) -> None:
         # Cooperative cancel: when a newer build supersedes this one,
         # `_diff_build_token` is already the new value on the main
         # thread. Check at every coarse-grained boundary so we don't
@@ -997,10 +1011,13 @@ class ActorWatchApp(App):
 
         head_oid = read_head_oid(actor)
         cache_key = (actor.name, head_oid, width)
-        if cache_key == self._diff_last_applied_key:
+        if not force and cache_key == self._diff_last_applied_key:
             # Nothing relevant changed since the last applied build —
             # skip the expensive `compute_diff` + render. Hand control
             # back to the main thread to clear the pending flag.
+            # `force=True` (live poll) bypasses this; the worktree
+            # has changed even when HEAD hasn't, so the cache key is
+            # not a reliable "nothing to redo" signal there.
             self.call_from_thread(self._mark_diff_build_done, token)
             return
 
@@ -1037,10 +1054,10 @@ class ActorWatchApp(App):
                 result.files, is_dark, is_cancelled,
             ):
                 if is_cancelled():
-                    return
+                    return self._on_stream_cancelled(token)
                 strips = renderable_to_strips(renderable, width)
                 if is_cancelled():
-                    return
+                    return self._on_stream_cancelled(token)
                 self.call_from_thread(
                     self._diff_append_file, token, path, strips,
                 )
@@ -1048,23 +1065,42 @@ class ActorWatchApp(App):
                 total_removed += removed
         except Exception as e:
             # Mid-stream render error → wipe whatever's mounted and
-            # surface the error message in its place. `_apply_diff_text`
+            # surface the error message in its place. `_apply_diff_error`
             # remove_children's the scroll first, so partial appends
-            # don't linger above the error.
+            # don't linger above the error. The error path does NOT
+            # promote the cache key, so the next kick at the same
+            # (actor, head, width) retries instead of cache-hitting on
+            # a stale error mount.
             self.call_from_thread(
-                self._apply_diff_text, token, cache_key, f"Diff error: {e}",
+                self._apply_diff_error, token, f"Diff error: {e}",
             )
             return
         if is_cancelled():
-            # Stream stopped mid-flight; the partial mounts already on
-            # screen stay until the newer kick's first append clears
-            # them. We deliberately don't finalize cache_key here so
-            # the next build re-renders rather than seeing a cache hit.
-            return
+            return self._on_stream_cancelled(token)
         self.call_from_thread(
             self._apply_diff_build_done,
             token, cache_key, total_added, total_removed,
         )
+
+    def _on_stream_cancelled(self, token: int) -> None:
+        """Worker bailout when cancellation flips True mid-stream.
+
+        Partial mounts already on screen STAY (clearing on cancel
+        would make every fast actor switch flicker). The catch: the
+        scroll no longer reflects `_diff_last_applied_key`, so a
+        subsequent kick at the same (actor, head, width) must NOT
+        cache-hit. We invalidate the key here when this token had
+        actually streamed at least one file (i.e. owns the scroll
+        content); without that, the next kick's worker takes the
+        early-out path and the partial state stays stuck on screen
+        forever."""
+        if self._diff_streamed_token == token:
+            self.call_from_thread(self._invalidate_diff_cache_key)
+
+    def _invalidate_diff_cache_key(self) -> None:
+        """Drop the cached `_diff_last_applied_key` so the next
+        build can't short-circuit. Runs on the main thread."""
+        self._diff_last_applied_key = None
 
     def _diff_append_file(
         self,
@@ -1120,6 +1156,10 @@ class ActorWatchApp(App):
     def _apply_diff_text(
         self, token: int, cache_key: tuple, text: str,
     ) -> None:
+        """Mount a benign reason text (e.g. "working tree clean",
+        "no repository") and CACHE the key. Repeat kicks at the same
+        (actor, head, width) early-out via the cache check — the
+        text mount is still on screen, so that's correct."""
         if token != self._diff_build_token:
             return
         try:
@@ -1128,9 +1168,37 @@ class ActorWatchApp(App):
             self._diff_build_pending = False
             return
         scroll.remove_children()
-        scroll.mount(Static(text))
+        # `markup=False` — exception messages and reason strings can
+        # contain `[brackets]` that Rich would otherwise interpret as
+        # markup (e.g. `[red]` colorizing) and either crash or render
+        # unexpectedly. We want literal text.
+        scroll.mount(Static(text, markup=False))
         self._diff_build_pending = False
         self._diff_last_applied_key = cache_key
+        self._update_diff_tab_label()
+
+    def _apply_diff_error(self, token: int, text: str) -> None:
+        """Mount a render-error message and INVALIDATE the cache key.
+
+        Two reasons the cache must drop here:
+        1. The scroll now shows error text, not the diff a prior
+           successful build's cache_key represented. Leaving the key
+           cached would let the next non-force kick early-out via
+           `_mark_diff_build_done` and never repaint the diff.
+        2. The render error itself may be transient. The user
+           shouldn't have to wait for HEAD or width to change before
+           a retry succeeds."""
+        if token != self._diff_build_token:
+            return
+        try:
+            scroll = self.query_one("#diff-scroll", VerticalScroll)
+        except Exception:
+            self._diff_build_pending = False
+            return
+        scroll.remove_children()
+        scroll.mount(Static(text, markup=False))
+        self._diff_build_pending = False
+        self._diff_last_applied_key = None
         self._update_diff_tab_label()
 
     def _mark_diff_build_done(self, token: int) -> None:
@@ -1185,14 +1253,22 @@ class ActorWatchApp(App):
 
     @work(thread=True, exclusive=True, group="diff_poll")
     def _poll_diff_signals_worker(self, actor: Actor) -> None:
-        """Off-main-thread signal capture: stat the index file +
-        run shortstat. Both are cheap, but a subprocess on the main
-        thread can drop a frame; threading it keeps the TUI smooth."""
+        """Off-main-thread signal capture: stat the index file, run
+        shortstat, and count untracked files. All three are cheap
+        individually, but each is a subprocess and on the main
+        thread that can drop a frame; threading keeps the TUI smooth.
+
+        The untracked count is the third signal because index mtime
+        and shortstat between them miss the most common actor edit:
+        creating a new file. Without this, an actor that runs `Write`
+        on a file the worktree didn't have wouldn't trigger a diff
+        refresh."""
         mtime = git_index_mtime(actor)
         shortstat = compute_diff_shortstat(actor)
+        untracked = git_untracked_count(actor)
         self.call_from_thread(
             self._evaluate_diff_poll_signals,
-            actor.name, mtime, shortstat,
+            actor.name, mtime, shortstat, untracked,
         )
 
     def _evaluate_diff_poll_signals(
@@ -1200,38 +1276,55 @@ class ActorWatchApp(App):
         actor_name: str,
         mtime: float | None,
         shortstat: tuple[int, int] | None,
+        untracked: int | None,
     ) -> None:
         """Main-thread signal comparison + refresh decision.
 
         Re-checks polling conditions because the worker may have
         raced with a tab/actor change since the kick: stale signals
         from a prior selection must not refresh the diff for a
-        different actor."""
+        different actor.
+
+        Re-baselines whenever the actor changes — without that, the
+        baseline from alice's signals would compare against bob's on
+        the next tick after a switch, falsely "detect a change", and
+        fire a redundant force-refresh on top of the actor-switch
+        kick `on_tree_node_highlighted` already triggered."""
         actor = self._diff_poll_actor()
         if actor is None or actor.name != actor_name:
             return
-        if not self._diff_poll_initialized:
-            # First observation since conditions became true. The
-            # user has just landed on DIFF, so the active build /
-            # cache key is presumably already correct — we don't
-            # refresh, just record the baseline for next time.
+        if (
+            not self._diff_poll_initialized
+            or self._diff_poll_last_actor != actor_name
+        ):
+            # First observation since conditions became true OR the
+            # selected actor changed. The user has just landed on
+            # this actor's DIFF, so the active build / cache key is
+            # presumably already correct — we don't refresh, just
+            # record the baseline for next time.
             self._diff_poll_initialized = True
+            self._diff_poll_last_actor = actor_name
             self._diff_poll_last_index_mtime = mtime
             self._diff_poll_last_shortstat = shortstat
+            self._diff_poll_last_untracked = untracked
             return
         changed = (
             mtime != self._diff_poll_last_index_mtime
             or shortstat != self._diff_poll_last_shortstat
+            or untracked != self._diff_poll_last_untracked
         )
         self._diff_poll_last_index_mtime = mtime
         self._diff_poll_last_shortstat = shortstat
+        self._diff_poll_last_untracked = untracked
         if changed:
             self._maybe_refresh_diff(force=True)
 
     def _reset_diff_poll_state(self) -> None:
         self._diff_poll_initialized = False
+        self._diff_poll_last_actor = None
         self._diff_poll_last_index_mtime = None
         self._diff_poll_last_shortstat = None
+        self._diff_poll_last_untracked = None
 
     def _update_diff_tab_label(self, added: int = 0, removed: int = 0) -> None:
         # Pill-style ` +N -M` badge using the same fg/bg the diff body

--- a/src/actor/watch/diff_render.py
+++ b/src/actor/watch/diff_render.py
@@ -76,17 +76,27 @@ def _tokenize(s: str) -> list[str]:
     return re.findall(r'\S+|\s+', s)
 
 
-def _word_diff(old: str, new: str) -> tuple[list[tuple[str, bool]], list[tuple[str, bool]]]:
-    """Compute word-level diff. Returns (old_tokens, new_tokens) with changed flag."""
+def _word_diff(
+    old: str, new: str,
+) -> tuple[list[tuple[str, bool]], list[tuple[str, bool]]] | None:
+    """Compute word-level diff. Returns ``(old_tokens, new_tokens)``
+    with per-token changed flags, or ``None`` when the lines are too
+    dissimilar to make per-word highlighting useful (>40% of tokens
+    changed). Callers should treat None as "skip the word-diff path
+    and render this line with the standard line-bg + syntax
+    highlighting"."""
     old_tokens = _tokenize(old)
     new_tokens = _tokenize(new)
 
     sm = difflib.SequenceMatcher(None, old_tokens, new_tokens)
 
-    # If more than 40% changed, don't do word highlighting
+    # If more than 40% changed, don't do word highlighting — the
+    # whole line ends up smeared with `*_word_bg` which is louder
+    # than the standard line-bg and obscures rather than highlights
+    # the actual change. The caller falls back to the no-pair path.
     ratio = sm.ratio()
     if ratio < 0.6:
-        return [(old, True)], [(new, True)]
+        return None
 
     old_result: list[tuple[str, bool]] = []
     new_result: list[tuple[str, bool]] = []
@@ -231,10 +241,7 @@ def render_edit_diff(
             if match:
                 old_num = int(match.group(1))
                 new_num = int(match.group(2))
-                if entries:
-                    entries.append({"type": "hunk", "header": line})
-                else:
-                    entries.append({"type": "hunk", "header": line})
+                entries.append({"type": "hunk", "header": line})
             continue
         if line.startswith('---') or line.startswith('+++'):
             continue
@@ -258,12 +265,21 @@ def render_edit_diff(
     max_num = max((e.get("num", 0) for e in entries if e["type"] != "ellipsis"), default=0)
     num_width = len(str(max_num))
 
-    # Compute word-diff ranges for adjacent del+add pairs
+    # Compute word-diff ranges for adjacent del+add pairs. Lines
+    # too dissimilar (>40% changed) get a None back — those entries
+    # never enter `word_diffs`, so the per-line render below falls
+    # through to the standard syntax-highlighted line-bg path
+    # instead of smearing the whole line with `*_word_bg`.
     markers = [e.get("marker", "") for e in entries]
     pairs = _find_adjacent_pairs(markers)
     word_diffs: dict[int, list[tuple[str, bool]]] = {}
     for del_idx, add_idx in pairs:
-        old_tokens, new_tokens = _word_diff(entries[del_idx]["code"], entries[add_idx]["code"])
+        result = _word_diff(
+            entries[del_idx]["code"], entries[add_idx]["code"],
+        )
+        if result is None:
+            continue
+        old_tokens, new_tokens = result
         word_diffs[del_idx] = old_tokens
         word_diffs[add_idx] = new_tokens
 

--- a/src/actor/watch/diff_render.py
+++ b/src/actor/watch/diff_render.py
@@ -405,10 +405,11 @@ def build_diff_renderables(
     drop its result and return silently — a newer build is running and
     will own the apply.
 
-    The duplicate `difflib.unified_diff` for ± counts is intentional
-    Stage-1 carry-over from the original `_refresh_diff`. Stage 2
-    folds the count into the parsed diff to drop this redundant work.
-    """
+    Per-file ± counts come straight from ``FileDiff.added /
+    FileDiff.removed``, which are populated by `compute_diff` from
+    parsed `git diff` output. Stage 1 ran a duplicate
+    `difflib.unified_diff` here just for the counts; Stage 2 wires the
+    counts through the FileDiff so this loop only renders."""
     if is_cancelled():
         return None
     parts: list = []
@@ -424,17 +425,10 @@ def build_diff_renderables(
             )
         )
         parts.append(Text(""))
+        total_added += fd.added
+        total_removed += fd.removed
         if is_cancelled():
             return None
-        for line in difflib.unified_diff(
-            fd.old_content.splitlines(),
-            fd.new_content.splitlines(),
-            lineterm="",
-        ):
-            if line.startswith("+") and not line.startswith("+++"):
-                total_added += 1
-            elif line.startswith("-") and not line.startswith("---"):
-                total_removed += 1
     if is_cancelled():
         return None
     return parts, total_added, total_removed

--- a/src/actor/watch/diff_render.py
+++ b/src/actor/watch/diff_render.py
@@ -6,13 +6,27 @@ import difflib
 import json
 import re
 from pathlib import Path
-from typing import NamedTuple
+from typing import Callable, NamedTuple, TYPE_CHECKING
 
 from pygments.lexers import get_lexer_for_filename, TextLexer
 from pygments.token import Token
 from rich.console import Group
 from rich.table import Table
 from rich.text import Text
+
+if TYPE_CHECKING:
+    from .helpers import FileDiff
+
+
+# Callable returning True when the build should abort. Builders check
+# between files and after each per-file render; the default never
+# cancels, so synchronous callers can ignore this entirely. Mirrors
+# the `CancelCheck` contract used by the logs renderer.
+CancelCheck = Callable[[], bool]
+
+
+def _never_cancelled() -> bool:
+    return False
 
 
 
@@ -374,6 +388,56 @@ def render_write_diff(
 ) -> Group:
     """Render a file write as all-added lines."""
     return render_edit_diff(file_path, "", content, dark=dark)
+
+
+def build_diff_renderables(
+    files: list["FileDiff"],
+    dark: bool,
+    is_cancelled: CancelCheck = _never_cancelled,
+) -> tuple[list, int, int] | None:
+    """Render `files` into a list of Rich renderables plus aggregate
+    add/remove counts. Safe to call from a worker thread — no widget
+    state is touched.
+
+    Returns ``(parts, total_added, total_removed)`` on success, or
+    ``None`` when ``is_cancelled()`` flips True between files or after
+    a per-file render. The caller (worker) takes None as a signal to
+    drop its result and return silently — a newer build is running and
+    will own the apply.
+
+    The duplicate `difflib.unified_diff` for ± counts is intentional
+    Stage-1 carry-over from the original `_refresh_diff`. Stage 2
+    folds the count into the parsed diff to drop this redundant work.
+    """
+    if is_cancelled():
+        return None
+    parts: list = []
+    total_added = 0
+    total_removed = 0
+    for fd in files:
+        if is_cancelled():
+            return None
+        parts.append(
+            render_edit_diff(
+                fd.file_path, fd.old_content, fd.new_content,
+                dark=dark, style="diff",
+            )
+        )
+        parts.append(Text(""))
+        if is_cancelled():
+            return None
+        for line in difflib.unified_diff(
+            fd.old_content.splitlines(),
+            fd.new_content.splitlines(),
+            lineterm="",
+        ):
+            if line.startswith("+") and not line.startswith("+++"):
+                total_added += 1
+            elif line.startswith("-") and not line.startswith("---"):
+                total_removed += 1
+    if is_cancelled():
+        return None
+    return parts, total_added, total_removed
 
 
 def try_render_tool_diff(name: str, input_json: str, dark: bool = True) -> Group | None:

--- a/src/actor/watch/diff_render.py
+++ b/src/actor/watch/diff_render.py
@@ -390,45 +390,68 @@ def render_write_diff(
     return render_edit_diff(file_path, "", content, dark=dark)
 
 
+def iter_diff_renderables(
+    files: list["FileDiff"],
+    dark: bool,
+    is_cancelled: CancelCheck = _never_cancelled,
+):
+    """Generator that yields ``(file_path, renderable, added, removed)``
+    per file, suitable for streaming mounts onto the DIFF pane.
+
+    The watch app's build worker iterates this generator and calls
+    ``call_from_thread(_diff_append_file, ...)`` for each yielded
+    tuple, so a 50-file diff appears progressively rather than after
+    one giant final mount. Stays safe to call from a worker thread —
+    no widget state is touched here.
+
+    Cancellation: ``is_cancelled()`` is checked BEFORE rendering each
+    file and AFTER rendering but BEFORE yielding. On cancel, the
+    generator returns silently — the consumer should check
+    ``is_cancelled()`` after the loop to distinguish "drained
+    naturally" from "stopped mid-stream", and skip the
+    finalize/commit step in the latter case.
+
+    Per-file ± counts come straight from `FileDiff.added` /
+    `FileDiff.removed`, which `compute_diff` populates by parsing
+    `git diff` output (Stage 2)."""
+    for fd in files:
+        if is_cancelled():
+            return
+        renderable = render_edit_diff(
+            fd.file_path, fd.old_content, fd.new_content,
+            dark=dark, style="diff",
+        )
+        if is_cancelled():
+            return
+        yield fd.file_path, renderable, fd.added, fd.removed
+
+
 def build_diff_renderables(
     files: list["FileDiff"],
     dark: bool,
     is_cancelled: CancelCheck = _never_cancelled,
 ) -> tuple[list, int, int] | None:
-    """Render `files` into a list of Rich renderables plus aggregate
-    add/remove counts. Safe to call from a worker thread — no widget
-    state is touched.
+    """Synchronous full-build wrapper around `iter_diff_renderables`.
 
-    Returns ``(parts, total_added, total_removed)`` on success, or
-    ``None`` when ``is_cancelled()`` flips True between files or after
-    a per-file render. The caller (worker) takes None as a signal to
-    drop its result and return silently — a newer build is running and
-    will own the apply.
+    Returns ``(parts, total_added, total_removed)`` on success or
+    ``None`` when cancellation aborted the iteration. Each rendered
+    file gets a trailing blank Text separator inside ``parts`` to
+    match the previous mount layout for callers that still want a
+    single `Group(*parts)` mount (e.g. tests, ad-hoc tools).
 
-    Per-file ± counts come straight from ``FileDiff.added /
-    FileDiff.removed``, which are populated by `compute_diff` from
-    parsed `git diff` output. Stage 1 ran a duplicate
-    `difflib.unified_diff` here just for the counts; Stage 2 wires the
-    counts through the FileDiff so this loop only renders."""
-    if is_cancelled():
-        return None
+    The watch app's build worker bypasses this wrapper and consumes
+    the iterator directly so it can mount per-file as renders complete
+    — see `_build_diff_worker` in `actor.watch.app`."""
     parts: list = []
     total_added = 0
     total_removed = 0
-    for fd in files:
-        if is_cancelled():
-            return None
-        parts.append(
-            render_edit_diff(
-                fd.file_path, fd.old_content, fd.new_content,
-                dark=dark, style="diff",
-            )
-        )
+    for _path, renderable, added, removed in iter_diff_renderables(
+        files, dark, is_cancelled,
+    ):
+        parts.append(renderable)
         parts.append(Text(""))
-        total_added += fd.added
-        total_removed += fd.removed
-        if is_cancelled():
-            return None
+        total_added += added
+        total_removed += removed
     if is_cancelled():
         return None
     return parts, total_added, total_removed

--- a/src/actor/watch/helpers.py
+++ b/src/actor/watch/helpers.py
@@ -106,6 +106,25 @@ class DiffResult:
         self.reason = reason
 
 
+def read_head_oid(actor: Actor) -> str | None:
+    """Cheap `git rev-parse HEAD` on the actor's worktree. Used as
+    part of the diff-view cache key — the diff against merge-base
+    only needs recomputing when HEAD moves (or width changes). Returns
+    None when the worktree isn't a git repo or git fails for any
+    reason; callers should treat that as a cache miss."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True, text=True, cwd=actor.dir,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    oid = result.stdout.strip()
+    return oid or None
+
+
 def compute_diff(actor: Actor) -> DiffResult:
     """Compute diff for an actor."""
     worktree_dir = actor.dir

--- a/src/actor/watch/helpers.py
+++ b/src/actor/watch/helpers.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
 from ..types import Actor, Status
+
+
+# Pinning `LC_ALL=C` (and `LC_MESSAGES=C` as a defensive duplicate)
+# guarantees git emits English error messages on stderr regardless
+# of the user's locale. We parse those messages to detect the
+# "fatal: not a git repository" case, so a non-English locale would
+# otherwise silently skip the early-out and produce a confusing
+# fallthrough. Applied to every git invocation in this module that
+# cares about stderr semantics; harmless on the rest.
+_GIT_ENV = {**os.environ, "LC_ALL": "C", "LC_MESSAGES": "C"}
 
 # -- Status icons -----------------------------------------------------------
 
@@ -281,6 +292,7 @@ def compute_diff_shortstat(actor: Actor) -> tuple[int, int] | None:
         mb = subprocess.run(
             ["git", "merge-base", base_branch, "HEAD"],
             capture_output=True, text=True, cwd=actor.dir,
+            env=_GIT_ENV,
         )
     except Exception:
         return None
@@ -295,6 +307,7 @@ def compute_diff_shortstat(actor: Actor) -> tuple[int, int] | None:
         ss = subprocess.run(
             ["git", "diff", "--shortstat", diff_ref],
             capture_output=True, text=True, cwd=actor.dir,
+            env=_GIT_ENV,
         )
     except Exception:
         return None
@@ -503,6 +516,7 @@ def compute_diff(actor: Actor) -> DiffResult:
         mb = subprocess.run(
             ["git", "merge-base", base_branch, "HEAD"],
             capture_output=True, text=True, cwd=worktree_dir,
+            env=_GIT_ENV,
         )
         if mb.returncode != 0:
             stderr = (mb.stderr or "").lower()
@@ -583,7 +597,15 @@ def compute_diff(actor: Actor) -> DiffResult:
                     new = (wt / path).read_text(errors="replace")
                 except (FileNotFoundError, OSError):
                     new = ""
-            if old != new:
+            # A pure rename (similarity=100%, no content change) has
+            # `old == new` but the file moved — we still want it in
+            # the diff view, otherwise a rename-only worktree would
+            # display "working tree clean" and contradict reality.
+            # Identical content with no rename signal is the only
+            # case we filter out.
+            old_path = f.get("old_path")
+            is_rename = old_path is not None and old_path != path
+            if old != new or is_rename:
                 file_diffs.append(FileDiff(
                     file_path=path,
                     old_content=old,

--- a/src/actor/watch/helpers.py
+++ b/src/actor/watch/helpers.py
@@ -208,6 +208,33 @@ def git_index_mtime(actor: Actor) -> float | None:
         return None
 
 
+def git_untracked_count(actor: Actor) -> int | None:
+    """Count untracked, non-ignored files in the actor's worktree.
+
+    Used by the live-refresh poller as a third change signal beside
+    `git_index_mtime` and `compute_diff_shortstat`. The first two
+    miss new untracked files entirely — index mtime only flips on
+    `git add`/etc., and `git diff --shortstat` against the merge base
+    doesn't include `--others`. An actor that creates a new file via
+    `Write` (the most common output shape) needs this signal to
+    trigger a live refresh; otherwise the diff stays stale until a
+    tracked file is also touched.
+
+    Returns the number of untracked, non-ignored entries, or ``None``
+    on git failure (the caller should treat None as "no signal yet"
+    so the next tick can baseline cleanly)."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            capture_output=True, text=True, cwd=actor.dir,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return sum(1 for line in result.stdout.splitlines() if line)
+
+
 def parse_shortstat(line: str) -> tuple[int, int]:
     """Parse `git diff --shortstat` summary line into (added, removed).
 
@@ -279,18 +306,25 @@ def compute_diff_shortstat(actor: Actor) -> tuple[int, int] | None:
 def _parse_diff_files(diff_output: str) -> list[dict]:
     """Parse `git diff --no-color` output into per-file metadata.
 
-    Returns a list of dicts with: ``path``, ``added``, ``removed``,
-    ``is_new``, ``is_deleted``, ``is_binary``. The walk is a flat
-    state machine — no regex on every line — so it stays cheap on
-    large diffs. Multiple hunks per file aggregate into the same
-    counts. Lines like ``\\ No newline at end of file`` are skipped.
+    Returns a list of dicts with: ``path``, ``old_path``, ``added``,
+    ``removed``, ``is_new``, ``is_deleted``, ``is_binary``. The walk
+    is a flat state machine — no regex on every line — so it stays
+    cheap on large diffs. Multiple hunks per file aggregate into the
+    same counts. Lines like ``\\ No newline at end of file`` are
+    skipped.
 
     The file path comes from the ``+++ b/<path>`` line when present
     (authoritative for adds and modifies), falling back to
     ``--- a/<path>`` for deletes (where the +++ side is /dev/null).
-    The ``diff --git a/X b/Y`` header is intentionally not parsed
-    for the path because it's ambiguous when paths contain spaces
-    — git only quotes it for special chars."""
+    For renames, the ``rename from`` / ``rename to`` headers populate
+    ``old_path`` and ``path`` separately so callers can read the
+    pre-image at the *old* name from the merge base — a query at the
+    new name would miss because the rename hasn't happened in that
+    tree. The ``diff --git a/X b/Y`` header is intentionally not
+    parsed for the path because it's ambiguous when paths contain
+    spaces — git only quotes it for special chars (and we pass
+    ``-c core.quotepath=false`` to compute_diff to avoid quoted forms
+    on non-ASCII paths)."""
     files: list[dict] = []
     cur: dict | None = None
     in_hunk = False
@@ -301,6 +335,7 @@ def _parse_diff_files(diff_output: str) -> list[dict]:
                 files.append(cur)
             cur = {
                 "path": None,
+                "old_path": None,
                 "added": 0,
                 "removed": 0,
                 "is_new": False,
@@ -310,6 +345,14 @@ def _parse_diff_files(diff_output: str) -> list[dict]:
             in_hunk = False
             continue
         if cur is None:
+            continue
+        if line.startswith("rename from "):
+            cur["old_path"] = line[len("rename from "):]
+            in_hunk = False
+            continue
+        if line.startswith("rename to "):
+            cur["path"] = line[len("rename to "):]
+            in_hunk = False
             continue
         if line.startswith("--- "):
             rest = line[4:]
@@ -332,7 +375,10 @@ def _parse_diff_files(diff_output: str) -> list[dict]:
                 cur["is_deleted"] = True
             else:
                 slash = rest.find("/")
-                if slash >= 0:
+                if slash >= 0 and cur["path"] is None:
+                    # Only set from `+++ b/...` if not already set —
+                    # `rename to` takes precedence and runs before
+                    # `+++` in git's output ordering, so we honor it.
                     cur["path"] = rest[slash + 1:]
             in_hunk = False
             continue
@@ -374,15 +420,18 @@ def _git_cat_file_batch(refs: list[str], cwd: str) -> dict[str, str]:
     if not refs:
         return {}
     try:
-        proc = subprocess.Popen(
+        # `with` ensures the subprocess and its three pipes get
+        # cleaned up even when `communicate()` raises mid-call. Plain
+        # try/except would leak the child + FDs in that path.
+        with subprocess.Popen(
             ["git", "cat-file", "--batch"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=cwd,
-        )
-        stdin_data = ("\n".join(refs) + "\n").encode("utf-8")
-        stdout, _stderr = proc.communicate(stdin_data)
+        ) as proc:
+            stdin_data = ("\n".join(refs) + "\n").encode("utf-8")
+            stdout, _stderr = proc.communicate(stdin_data)
     except Exception:
         return {ref: "" for ref in refs}
 
@@ -467,8 +516,13 @@ def compute_diff(actor: Actor) -> DiffResult:
         # `--src-prefix`/`--dst-prefix` overrides the user's
         # `diff.mnemonicPrefix` so the parser sees the standard
         # `a/`/`b/` prefixes regardless of local git config.
+        # `core.quotepath=false` keeps non-ASCII paths verbatim
+        # (utf-8) instead of git's default octal-escaped quoted form,
+        # which would otherwise corrupt the parser's slash-strip and
+        # break disk reads of those paths.
         diff_proc = subprocess.run(
-            ["git", "diff", "--no-color",
+            ["git", "-c", "core.quotepath=false",
+             "diff", "--no-color",
              "--src-prefix=a/", "--dst-prefix=b/",
              diff_ref],
             capture_output=True, text=True, cwd=worktree_dir,
@@ -478,9 +532,11 @@ def compute_diff(actor: Actor) -> DiffResult:
             if diff_proc.returncode == 0 else []
         )
 
-        # 3. Untracked files.
+        # 3. Untracked files. Same `core.quotepath=false` pin so
+        # non-ASCII filenames come back unquoted.
         untracked_proc = subprocess.run(
-            ["git", "ls-files", "--others", "--exclude-standard"],
+            ["git", "-c", "core.quotepath=false",
+             "ls-files", "--others", "--exclude-standard"],
             capture_output=True, text=True, cwd=worktree_dir,
         )
         untracked_paths = (
@@ -492,12 +548,15 @@ def compute_diff(actor: Actor) -> DiffResult:
             return DiffResult(reason="working tree clean")
 
         # 4. Batch-read old contents for every tracked, non-binary,
-        # non-new file in a single cat-file invocation.
+        # non-new file in a single cat-file invocation. Renames look
+        # up the OLD path (the file's name at the merge base), since
+        # querying the new name in that tree would miss.
         refs_needed: list[str] = []
         for f in tracked:
             if f["path"] is None or f["is_new"] or f["is_binary"]:
                 continue
-            refs_needed.append(f"{diff_ref}:{f['path']}")
+            old_path = f.get("old_path") or f["path"]
+            refs_needed.append(f"{diff_ref}:{old_path}")
         old_contents = (
             _git_cat_file_batch(refs_needed, worktree_dir)
             if refs_needed else {}
@@ -512,7 +571,11 @@ def compute_diff(actor: Actor) -> DiffResult:
                 # text-oriented view; skip rather than mount blank
                 # rows.
                 continue
-            old = "" if f["is_new"] else old_contents.get(f"{diff_ref}:{path}", "")
+            if f["is_new"]:
+                old = ""
+            else:
+                old_path = f.get("old_path") or path
+                old = old_contents.get(f"{diff_ref}:{old_path}", "")
             if f["is_deleted"]:
                 new = ""
             else:

--- a/src/actor/watch/helpers.py
+++ b/src/actor/watch/helpers.py
@@ -164,6 +164,50 @@ def read_head_oid(actor: Actor) -> str | None:
     return oid or None
 
 
+def git_index_mtime(actor: Actor) -> float | None:
+    """Locate the index file for an actor's worktree and return its
+    mtime as a float, or None if the file isn't there.
+
+    Handles both shapes:
+    - **primary checkout**: ``<wt>/.git`` is a directory; the index
+      lives at ``<wt>/.git/index``.
+    - **`git worktree` checkout** (which is what `actor new` creates
+      for non-primary actors): ``<wt>/.git`` is a small text file
+      with ``gitdir: <path>`` pointing at the per-worktree git dir;
+      the index lives at ``<that-path>/index``.
+
+    Used by the live-refresh poller as a near-zero-cost "did
+    something happen since last tick" signal — beats running
+    `git status` or `git diff` on every poll. Misses unstaged edits
+    (the index only updates on `git add`/`rm`/etc.), so the poller
+    pairs this with a `git diff --shortstat` call to catch worktree
+    changes the index doesn't reflect."""
+    wt = Path(actor.dir)
+    git = wt / ".git"
+    try:
+        if git.is_dir():
+            index = git / "index"
+        elif git.is_file():
+            content = git.read_text(errors="replace")
+            gitdir: Path | None = None
+            for line in content.splitlines():
+                if line.startswith("gitdir: "):
+                    raw = line[len("gitdir: "):].strip()
+                    gd = Path(raw)
+                    if not gd.is_absolute():
+                        gd = (wt / gd).resolve()
+                    gitdir = gd
+                    break
+            if gitdir is None:
+                return None
+            index = gitdir / "index"
+        else:
+            return None
+        return index.stat().st_mtime
+    except (FileNotFoundError, OSError):
+        return None
+
+
 def parse_shortstat(line: str) -> tuple[int, int]:
     """Parse `git diff --shortstat` summary line into (added, removed).
 

--- a/src/actor/watch/helpers.py
+++ b/src/actor/watch/helpers.py
@@ -164,6 +164,74 @@ def read_head_oid(actor: Actor) -> str | None:
     return oid or None
 
 
+def parse_shortstat(line: str) -> tuple[int, int]:
+    """Parse `git diff --shortstat` summary line into (added, removed).
+
+    Output format examples (note the leading space):
+      `` 3 files changed, 7 insertions(+), 2 deletions(-)``
+      `` 1 file changed, 1 insertion(+)``         (no deletions case)
+      `` 1 file changed, 1 deletion(-)``          (no insertions case)
+      ``""``                                      (no changes)
+
+    Returns (0, 0) for empty / unparseable input rather than raising —
+    the badge is best-effort UX, not a correctness gate."""
+    added = 0
+    removed = 0
+    for chunk in line.split(","):
+        chunk = chunk.strip()
+        if "insertion" in chunk:
+            try:
+                added = int(chunk.split()[0])
+            except (ValueError, IndexError):
+                pass
+        elif "deletion" in chunk:
+            try:
+                removed = int(chunk.split()[0])
+            except (ValueError, IndexError):
+                pass
+    return added, removed
+
+
+def compute_diff_shortstat(actor: Actor) -> tuple[int, int] | None:
+    """Quick `git diff --shortstat` against the merge base — used by
+    the watch DIFF tab to populate the (±N) badge label in <100ms
+    while the heavier `compute_diff` + render path is still running.
+
+    Two subprocesses (`merge-base` + `diff --shortstat`); returns the
+    combined (added, removed) line counts. Untracked files are NOT
+    included — shortstat only sees the index. The full build's later
+    `_update_diff_tab_label` call lands the authoritative number when
+    it commits, which may revise the badge upward if untracked files
+    contributed lines.
+
+    Returns None when git fails (no repo, missing base, etc.)."""
+    base_branch = actor.base_branch or "HEAD"
+    try:
+        mb = subprocess.run(
+            ["git", "merge-base", base_branch, "HEAD"],
+            capture_output=True, text=True, cwd=actor.dir,
+        )
+    except Exception:
+        return None
+    if mb.returncode != 0:
+        if "not a git repository" in (mb.stderr or "").lower():
+            return None
+        diff_ref = base_branch
+    else:
+        diff_ref = mb.stdout.strip() or base_branch
+
+    try:
+        ss = subprocess.run(
+            ["git", "diff", "--shortstat", diff_ref],
+            capture_output=True, text=True, cwd=actor.dir,
+        )
+    except Exception:
+        return None
+    if ss.returncode != 0:
+        return None
+    return parse_shortstat(ss.stdout)
+
+
 def _parse_diff_files(diff_output: str) -> list[dict]:
     """Parse `git diff --no-color` output into per-file metadata.
 

--- a/src/actor/watch/helpers.py
+++ b/src/actor/watch/helpers.py
@@ -92,11 +92,50 @@ def read_log_entries_since(actor: Actor, cursor=None):
 # -- Compute git diff --------------------------------------------------------
 
 class FileDiff:
-    """Diff for a single file."""
-    def __init__(self, file_path: str, old_content: str, new_content: str) -> None:
+    """Diff for a single file.
+
+    `added` / `removed` are the per-file ± line counts. When the
+    constructor is called without them they fall back to a synchronous
+    `difflib.unified_diff` over the contents — that fallback only fires
+    in tests/manual callers; the production pipeline (`compute_diff`)
+    parses the counts straight out of `git diff` output and passes
+    them in explicitly so no extra diff work runs at render time."""
+
+    def __init__(
+        self,
+        file_path: str,
+        old_content: str,
+        new_content: str,
+        added: int | None = None,
+        removed: int | None = None,
+    ) -> None:
         self.file_path = file_path
         self.old_content = old_content
         self.new_content = new_content
+        if added is None or removed is None:
+            a, r = _count_diff_lines(old_content, new_content)
+            self.added = a if added is None else added
+            self.removed = r if removed is None else removed
+        else:
+            self.added = added
+            self.removed = removed
+
+
+def _count_diff_lines(old: str, new: str) -> tuple[int, int]:
+    """Fallback ± line counter for FileDiff callers that didn't
+    pre-compute. compute_diff bypasses this by passing counts straight
+    from `git diff`'s parsed output."""
+    import difflib
+    added = 0
+    removed = 0
+    for line in difflib.unified_diff(
+        old.splitlines(), new.splitlines(), lineterm="",
+    ):
+        if line.startswith("+") and not line.startswith("+++"):
+            added += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            removed += 1
+    return added, removed
 
 
 class DiffResult:
@@ -125,71 +164,280 @@ def read_head_oid(actor: Actor) -> str | None:
     return oid or None
 
 
+def _parse_diff_files(diff_output: str) -> list[dict]:
+    """Parse `git diff --no-color` output into per-file metadata.
+
+    Returns a list of dicts with: ``path``, ``added``, ``removed``,
+    ``is_new``, ``is_deleted``, ``is_binary``. The walk is a flat
+    state machine — no regex on every line — so it stays cheap on
+    large diffs. Multiple hunks per file aggregate into the same
+    counts. Lines like ``\\ No newline at end of file`` are skipped.
+
+    The file path comes from the ``+++ b/<path>`` line when present
+    (authoritative for adds and modifies), falling back to
+    ``--- a/<path>`` for deletes (where the +++ side is /dev/null).
+    The ``diff --git a/X b/Y`` header is intentionally not parsed
+    for the path because it's ambiguous when paths contain spaces
+    — git only quotes it for special chars."""
+    files: list[dict] = []
+    cur: dict | None = None
+    in_hunk = False
+
+    for line in diff_output.split("\n"):
+        if line.startswith("diff --git "):
+            if cur is not None:
+                files.append(cur)
+            cur = {
+                "path": None,
+                "added": 0,
+                "removed": 0,
+                "is_new": False,
+                "is_deleted": False,
+                "is_binary": False,
+            }
+            in_hunk = False
+            continue
+        if cur is None:
+            continue
+        if line.startswith("--- "):
+            rest = line[4:]
+            if rest == "/dev/null":
+                cur["is_new"] = True
+            else:
+                # Strip the leading prefix segment. Default git output
+                # uses `a/<path>`, but `diff.mnemonicPrefix=true`
+                # produces `c/`/`w/` instead. Splitting on the first
+                # `/` covers both. Fallback path for deletes —
+                # overridden by the +++ line when present.
+                slash = rest.find("/")
+                if slash >= 0 and cur["path"] is None:
+                    cur["path"] = rest[slash + 1:]
+            in_hunk = False
+            continue
+        if line.startswith("+++ "):
+            rest = line[4:]
+            if rest == "/dev/null":
+                cur["is_deleted"] = True
+            else:
+                slash = rest.find("/")
+                if slash >= 0:
+                    cur["path"] = rest[slash + 1:]
+            in_hunk = False
+            continue
+        if line.startswith("Binary files "):
+            cur["is_binary"] = True
+            in_hunk = False
+            continue
+        if line.startswith("@@"):
+            in_hunk = True
+            continue
+        if not in_hunk:
+            continue
+        if line.startswith("+"):
+            cur["added"] += 1
+        elif line.startswith("-"):
+            cur["removed"] += 1
+        # Context (' ') and `\ No newline at end of file` markers are
+        # intentionally ignored.
+
+    if cur is not None:
+        files.append(cur)
+    return files
+
+
+def _git_cat_file_batch(refs: list[str], cwd: str) -> dict[str, str]:
+    """Batch-read git objects via a single ``git cat-file --batch``.
+
+    `refs` are typically ``<merge-base>:<path>`` strings. Returns a
+    dict mapping each input ref to its decoded content. Refs that
+    don't resolve (e.g. paths added since the merge-base) map to ``""``.
+
+    Decoding uses utf-8 with ``errors="replace"`` so a stray binary
+    blob doesn't crash the whole render — the substituted U+FFFD
+    chars surface as garbled text in the diff view, which is a
+    deliberately mild failure mode. Tracked binary files are
+    detected upstream by `_parse_diff_files` (``is_binary``) and
+    skipped before they reach the FileDiff list, so this path
+    mostly handles utf-8-clean tracked content."""
+    if not refs:
+        return {}
+    try:
+        proc = subprocess.Popen(
+            ["git", "cat-file", "--batch"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=cwd,
+        )
+        stdin_data = ("\n".join(refs) + "\n").encode("utf-8")
+        stdout, _stderr = proc.communicate(stdin_data)
+    except Exception:
+        return {ref: "" for ref in refs}
+
+    contents: dict[str, str] = {}
+    pos = 0
+    n = len(stdout)
+    for ref in refs:
+        if pos >= n:
+            contents[ref] = ""
+            continue
+        nl = stdout.find(b"\n", pos)
+        if nl == -1:
+            contents[ref] = ""
+            break
+        header = stdout[pos:nl].decode("utf-8", errors="replace")
+        pos = nl + 1
+        if header.endswith(" missing"):
+            contents[ref] = ""
+            continue
+        # Format: <sha> <type> <size>. rsplit shields against shas /
+        # types containing spaces (they don't, but it's free safety).
+        parts = header.rsplit(" ", 2)
+        if len(parts) != 3:
+            contents[ref] = ""
+            continue
+        try:
+            size = int(parts[2])
+        except ValueError:
+            contents[ref] = ""
+            continue
+        body = stdout[pos:pos + size]
+        # The protocol emits a trailing LF after each body — skip it
+        # so the next iteration reads the next header cleanly.
+        pos += size + 1
+        contents[ref] = body.decode("utf-8", errors="replace")
+    return contents
+
+
 def compute_diff(actor: Actor) -> DiffResult:
-    """Compute diff for an actor."""
+    """Compute diff for an actor's worktree against the merge base.
+
+    Spawns a constant number of subprocesses regardless of how many
+    files changed — at most four:
+
+    1. ``git merge-base <base> HEAD`` (also detects "not a git repo"
+       via stderr, so the prior ``git rev-parse --git-dir`` probe
+       drops out entirely).
+    2. ``git diff --no-color <merge-base>`` — single unified diff
+       parsed in-process for paths and ± counts.
+    3. ``git ls-files --others --exclude-standard`` — untracked.
+    4. ``git cat-file --batch`` — every tracked file's pre-image read
+       in one round-trip; replaces the per-file ``git show``.
+
+    The 4th call is skipped when there are no tracked changes that
+    need an old-content read (pure adds + untracked-only). New
+    contents come from disk reads, same as before.
+
+    Down from N+5 in the per-file ``git show`` era — a 50-file diff
+    used to spawn 55 subprocesses cold."""
     worktree_dir = actor.dir
-
-    # Check if the directory is a git repo at all
-    check = subprocess.run(
-        ["git", "rev-parse", "--git-dir"],
-        capture_output=True, text=True, cwd=worktree_dir,
-    )
-    if check.returncode != 0:
-        return DiffResult(reason="no repository")
-
-    base_branch = actor.base_branch
-    if not base_branch:
-        base_branch = "HEAD"
+    base_branch = actor.base_branch or "HEAD"
 
     try:
-        # Find the merge base — the point where the actor branched off
-        merge_base_result = subprocess.run(
+        # 1. Merge-base. A non-git cwd surfaces as "fatal: not a git
+        # repository" on stderr; treat that as the legacy
+        # "no repository" reason. Any other failure (e.g. unrelated
+        # histories, missing base ref) falls through to base_branch
+        # so we still produce a diff.
+        mb = subprocess.run(
             ["git", "merge-base", base_branch, "HEAD"],
             capture_output=True, text=True, cwd=worktree_dir,
         )
-        if merge_base_result.returncode == 0 and merge_base_result.stdout.strip():
-            diff_ref = merge_base_result.stdout.strip()
-        else:
+        if mb.returncode != 0:
+            stderr = (mb.stderr or "").lower()
+            if "not a git repository" in stderr:
+                return DiffResult(reason="no repository")
             diff_ref = base_branch
+        else:
+            diff_ref = mb.stdout.strip() or base_branch
 
-        # Get tracked files that changed
-        result = subprocess.run(
-            ["git", "diff", "--name-only", diff_ref],
+        # 2. Tracked changes — one diff with hunks. Pinning
+        # `--src-prefix`/`--dst-prefix` overrides the user's
+        # `diff.mnemonicPrefix` so the parser sees the standard
+        # `a/`/`b/` prefixes regardless of local git config.
+        diff_proc = subprocess.run(
+            ["git", "diff", "--no-color",
+             "--src-prefix=a/", "--dst-prefix=b/",
+             diff_ref],
             capture_output=True, text=True, cwd=worktree_dir,
         )
-        tracked_files = result.stdout.strip().split("\n") if result.returncode == 0 and result.stdout.strip() else []
+        tracked = (
+            _parse_diff_files(diff_proc.stdout)
+            if diff_proc.returncode == 0 else []
+        )
 
-        # Get untracked files (new files the actor created)
-        untracked_result = subprocess.run(
+        # 3. Untracked files.
+        untracked_proc = subprocess.run(
             ["git", "ls-files", "--others", "--exclude-standard"],
             capture_output=True, text=True, cwd=worktree_dir,
         )
-        untracked_files = untracked_result.stdout.strip().split("\n") if untracked_result.returncode == 0 and untracked_result.stdout.strip() else []
+        untracked_paths = (
+            untracked_proc.stdout.splitlines()
+            if untracked_proc.returncode == 0 else []
+        )
 
-        files = tracked_files + untracked_files
-        if not files:
+        if not tracked and not untracked_paths:
             return DiffResult(reason="working tree clean")
 
-        file_diffs = []
-        for f in files:
-            orig_result = subprocess.run(
-                ["git", "show", f"{diff_ref}:{f}"],
-                capture_output=True, text=True, cwd=worktree_dir,
-            )
-            old_content = orig_result.stdout if orig_result.returncode == 0 else ""
+        # 4. Batch-read old contents for every tracked, non-binary,
+        # non-new file in a single cat-file invocation.
+        refs_needed: list[str] = []
+        for f in tracked:
+            if f["path"] is None or f["is_new"] or f["is_binary"]:
+                continue
+            refs_needed.append(f"{diff_ref}:{f['path']}")
+        old_contents = (
+            _git_cat_file_batch(refs_needed, worktree_dir)
+            if refs_needed else {}
+        )
 
-            file_path = Path(worktree_dir) / f
+        wt = Path(worktree_dir)
+        file_diffs: list[FileDiff] = []
+        for f in tracked:
+            path = f["path"]
+            if path is None or f["is_binary"]:
+                # Binary diffs render as nothing useful in our
+                # text-oriented view; skip rather than mount blank
+                # rows.
+                continue
+            old = "" if f["is_new"] else old_contents.get(f"{diff_ref}:{path}", "")
+            if f["is_deleted"]:
+                new = ""
+            else:
+                try:
+                    new = (wt / path).read_text(errors="replace")
+                except (FileNotFoundError, OSError):
+                    new = ""
+            if old != new:
+                file_diffs.append(FileDiff(
+                    file_path=path,
+                    old_content=old,
+                    new_content=new,
+                    added=f["added"],
+                    removed=f["removed"],
+                ))
+
+        for path in untracked_paths:
+            if not path:
+                continue
             try:
-                new_content = file_path.read_text()
+                new = (wt / path).read_text(errors="replace")
             except (FileNotFoundError, OSError):
-                new_content = ""
-
-            if old_content != new_content:
-                file_diffs.append(FileDiff(f, old_content, new_content))
+                new = ""
+            # Untracked files are wholly new — every line counts as
+            # added. This matches what `git diff` would report if
+            # they were staged.
+            added = len(new.splitlines())
+            file_diffs.append(FileDiff(
+                file_path=path,
+                old_content="",
+                new_content=new,
+                added=added,
+                removed=0,
+            ))
 
         if not file_diffs:
             return DiffResult(reason="working tree clean")
-
         return DiffResult(files=file_diffs)
     except Exception:
         return DiffResult(reason="error")

--- a/src/actor/watch/prerendered_diff.py
+++ b/src/actor/watch/prerendered_diff.py
@@ -1,0 +1,100 @@
+"""Off-thread Rich renderable → Strips → cheap widget mount.
+
+The diff worker builds Rich renderables (Tables / Groups) per file off
+the main thread. Without this module, those renderables would have
+their `__rich_console__` invoked at *paint* time on the main thread to
+generate Segments — a CPU-bound step that can take hundreds of ms
+for a large diff and shows up as UI hangs on tab activation.
+
+This module pushes the Segment-generation work into the worker too:
+
+- `renderable_to_strips(renderable, width)` runs Rich's render pipeline
+  and converts the output into a list of `textual.strip.Strip`
+  objects. Safe to call from any thread; touches no widget state.
+- `PrerenderedDiff` is a tiny widget that holds the resulting Strips
+  and serves them via `render_line(y)` as a constant-time array
+  lookup. Mounting it is cheap; painting it is cheap; layout sees a
+  fixed height equal to the strip count.
+
+Width is captured at kick time and threaded through. Stage 1's cache
+key already includes content_width, so a real terminal resize kicks a
+new build with strips at the new width — no need for the widget to
+re-render on resize.
+"""
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+from rich.segment import Segment
+from textual.geometry import Size
+from textual.strip import Strip
+from textual.widget import Widget
+
+
+def renderable_to_strips(renderable: object, width: int) -> list[Strip]:
+    """Render a Rich renderable into a list of Textual `Strip`s at the
+    given width.
+
+    Forces truecolor + a wide-enough output so hex-color styles
+    emitted by the diff renderer survive intact (downgrading to
+    ANSI-256 would lose precision and shift the diff palette away
+    from the actor.sh theme).
+
+    The width passed here is the scroll's content width at kick time.
+    Slight overshoot (because we don't subtract the scrollbar
+    column) is harmless — Textual's render pipeline crops Strips to
+    the widget's actual width. Undershoot would be visible as a
+    shorter-than-needed line, but VerticalScroll's children are
+    handed the full inner width by default.
+    """
+    if width <= 0:
+        return []
+    console = Console(
+        width=width,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        file=StringIO(),
+        record=False,
+    )
+    options = console.options.update(width=width)
+    segments = list(console.render(renderable, options))
+    return [Strip(line) for line in Segment.split_lines(segments)]
+
+
+class PrerenderedDiff(Widget):
+    """Mounts a per-file diff that's already been converted to Strips.
+
+    Worker thread does the expensive work (Rich Table → Segments →
+    Strips); on the main thread, `render_line(y)` is just an array
+    index. Height is fixed to the strip count so VerticalScroll can
+    layout without invoking the renderable.
+
+    A trailing blank Strip is appended at construction time so files
+    have visual separation in the scroll (matches the pre-Stage-6
+    `Static(Group(renderable, Text("")))` layout).
+    """
+
+    DEFAULT_CSS = """
+    PrerenderedDiff {
+        height: auto;
+        width: 1fr;
+        background: ansi_default;
+    }
+    """
+
+    def __init__(self, strips: list[Strip], **kwargs) -> None:
+        super().__init__(**kwargs)
+        # Trailing blank line for inter-file spacing.
+        self._strips = list(strips) + [Strip([])]
+
+    def get_content_height(
+        self, container: Size, viewport: Size, width: int
+    ) -> int:
+        return len(self._strips)
+
+    def render_line(self, y: int) -> Strip:
+        if 0 <= y < len(self._strips):
+            return self._strips[y]
+        return Strip.blank(self.size.width)

--- a/src/actor/watch/prerendered_diff.py
+++ b/src/actor/watch/prerendered_diff.py
@@ -80,9 +80,14 @@ class PrerenderedDiff(Widget):
     PrerenderedDiff {
         height: auto;
         width: 1fr;
-        background: ansi_default;
+        background: $background;
     }
     """
+    # Concrete `$background` (not `ansi_default`) so Textual's dim-baking
+    # filter has an RGB triplet to mix against. Pre-rendered strips
+    # carry `dim=True` flags from Rich without a baked-in bgcolor —
+    # `ansi_default` resolves to Rich's DEFAULT color (no triplet) and
+    # the dim_color() pass crashes when it tries to unpack it.
 
     def __init__(self, strips: list[Strip], **kwargs) -> None:
         super().__init__(**kwargs)

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -20,10 +20,13 @@ from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
+from rich.segment import Segment
 from rich.text import Text
+from textual.strip import Strip
 
 from actor.watch.app import ActorWatchApp
 from actor.watch.diff_render import build_diff_renderables
+from actor.watch.prerendered_diff import PrerenderedDiff
 from actor.watch.helpers import (
     FileDiff,
     _git_cat_file_batch,
@@ -236,7 +239,7 @@ class ApplyDiffBuildTokenDiscardTests(unittest.TestCase):
             app._diff_append_file(
                 token=3,  # stale
                 file_path="x.py",
-                renderable=Text("hi"),
+                strips=[Strip([Segment("hi")])],
             )
         scroll.remove_children.assert_not_called()
         scroll.mount.assert_not_called()
@@ -1030,10 +1033,13 @@ class DiffAppendFileTests(unittest.TestCase):
         scroll = _scroll_with_width(100)
         with patch.object(app, "query_one", return_value=scroll):
             app._diff_append_file(
-                token=4, file_path="a.py", renderable=Text("rendered a"),
+                token=4, file_path="a.py", strips=[Strip([Segment("a")])],
             )
         scroll.remove_children.assert_called_once()
         scroll.mount.assert_called_once()
+        # The mounted widget is a PrerenderedDiff carrying our strips.
+        mounted = scroll.mount.call_args.args[0]
+        self.assertIsInstance(mounted, PrerenderedDiff)
         self.assertEqual(app._diff_streamed_token, 4)
         # Pending must be flipped off — real content is on screen
         # so the 300ms placeholder timer must NOT fire.
@@ -1046,7 +1052,7 @@ class DiffAppendFileTests(unittest.TestCase):
         scroll = _scroll_with_width(100)
         with patch.object(app, "query_one", return_value=scroll):
             app._diff_append_file(
-                token=4, file_path="b.py", renderable=Text("b"),
+                token=4, file_path="b.py", strips=[Strip([Segment("b")])],
             )
         scroll.remove_children.assert_not_called()
         scroll.mount.assert_called_once()
@@ -1061,22 +1067,21 @@ class DiffAppendFileTests(unittest.TestCase):
         mount_args: list[object] = []
         scroll.mount.side_effect = lambda widget: mount_args.append(widget)
 
-        def fresh_renderable(label: str) -> Text:
-            return Text(label)
+        def fresh_strips(label: str) -> list[Strip]:
+            return [Strip([Segment(label)])]
 
         with patch.object(app, "query_one", return_value=scroll):
-            app._diff_append_file(1, "a.py", fresh_renderable("A"))
-            app._diff_append_file(1, "b.py", fresh_renderable("B"))
-            app._diff_append_file(1, "c.py", fresh_renderable("C"))
+            app._diff_append_file(1, "a.py", fresh_strips("A"))
+            app._diff_append_file(1, "b.py", fresh_strips("B"))
+            app._diff_append_file(1, "c.py", fresh_strips("C"))
 
         self.assertEqual(len(mount_args), 3)
-        # Each mount holds a Static wrapping a Group(renderable, Text("")).
-        # The label letter sits inside the Group's first child.
+        # Each mount is a PrerenderedDiff; pull the label out of the
+        # first segment of its first strip.
         for widget, expected in zip(mount_args, ["A", "B", "C"]):
-            # widget is Static; Static.content is the Group; the first
-            # element of the Group is our supplied Text.
-            inner = widget.content
-            self.assertEqual(inner.renderables[0].plain, expected)
+            self.assertIsInstance(widget, PrerenderedDiff)
+            first_strip = widget._strips[0]
+            self.assertEqual(first_strip._segments[0].text, expected)
         # First call also cleared the scroll once; subsequent two did
         # not.
         scroll.remove_children.assert_called_once()
@@ -1272,7 +1277,7 @@ class ClearDetailCancelsStreamingTests(unittest.TestCase):
         scroll.reset_mock()
         with patch.object(app, "query_one", return_value=scroll):
             app._diff_append_file(token=3, file_path="x.py",
-                                  renderable=Text("x"))
+                                  strips=[Strip([Segment("x")])])
         scroll.mount.assert_not_called()
 
 

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -30,8 +30,10 @@ from actor.watch.helpers import (
     _parse_diff_files,
     compute_diff,
     compute_diff_shortstat,
+    git_index_mtime,
     parse_shortstat,
 )
+from actor.types import Status
 
 
 def _bare_app() -> ActorWatchApp:
@@ -50,6 +52,10 @@ def _bare_app() -> ActorWatchApp:
     app._diff_pending_actor = None
     app._diff_badge_token = 0
     app._diff_badge_target_actor = None
+    app._diff_poll_initialized = False
+    app._diff_poll_last_index_mtime = None
+    app._diff_poll_last_shortstat = None
+    app._prev_statuses = {}
     app._current_actors = []
     app._tab_base_labels = {
         "logs": "LIVE", "diff": "DIFF",
@@ -1268,6 +1274,372 @@ class ClearDetailCancelsStreamingTests(unittest.TestCase):
             app._diff_append_file(token=3, file_path="x.py",
                                   renderable=Text("x"))
         scroll.mount.assert_not_called()
+
+
+# -- Stage 5: live refresh while a run is in progress -----------------------
+
+
+def _stub_diff_poll_dom(
+    app, *, selected_actor=None, active_tab: str = "diff",
+):
+    """Return a `query_one` side-effect that resolves the two
+    DOM lookups `_diff_poll_actor` makes — the ActorTree (with a
+    `selected_actor` attribute) and the TabbedContent (with an
+    `active` attribute). The state-machine methods only read these
+    two values; everything else stays a vanilla MagicMock."""
+    tree = MagicMock()
+    tree.selected_actor = selected_actor
+    tabs = MagicMock()
+    tabs.active = active_tab
+
+    def query_one(selector, *_args, **_kwargs):
+        # ActorTree is queried by class, "#tabs" by id selector.
+        if isinstance(selector, str) and selector == "#tabs":
+            return tabs
+        return tree
+
+    return query_one
+
+
+class GitIndexMtimeTests(unittest.TestCase):
+    """The cheap "did anything happen" signal — works for primary
+    checkouts AND for `git worktree` checkouts where `.git` is a
+    file pointing at the per-worktree git dir."""
+
+    def test_returns_mtime_for_primary_checkout(self):
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = tempfile.mkdtemp(prefix="actor-index-primary-")
+        try:
+            _git("init", "-q", "-b", "main", tmp, cwd=tmp)
+            Path(tmp, "seed.txt").write_text("seed\n")
+            _git("add", "-A", cwd=tmp)
+            _git("commit", "-q", "-m", "seed", cwd=tmp)
+            actor = _fake_actor_for_repo(tmp)
+            mtime = git_index_mtime(actor)
+            self.assertIsNotNone(mtime)
+            self.assertIsInstance(mtime, float)
+            # Should match the actual file's mtime.
+            self.assertEqual(mtime, Path(tmp, ".git", "index").stat().st_mtime)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_returns_mtime_for_worktree_checkout(self):
+        """`actor new` typically lands as a `git worktree`, so
+        `<wt>/.git` is a *file* with `gitdir: <path>` pointing at the
+        per-worktree git dir under the parent repo."""
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        primary = tempfile.mkdtemp(prefix="actor-index-primary-for-wt-")
+        wt = tempfile.mkdtemp(prefix="actor-index-wt-")
+        os.rmdir(wt)  # `git worktree add` creates it
+        try:
+            _git("init", "-q", "-b", "main", primary, cwd=primary)
+            Path(primary, "seed.txt").write_text("seed\n")
+            _git("add", "-A", cwd=primary)
+            _git("commit", "-q", "-m", "seed", cwd=primary)
+            _git("worktree", "add", wt, "-b", "feature", cwd=primary)
+            actor = _fake_actor_for_repo(wt)
+            mtime = git_index_mtime(actor)
+            self.assertIsNotNone(mtime)
+            self.assertIsInstance(mtime, float)
+        finally:
+            shutil.rmtree(wt, ignore_errors=True)
+            shutil.rmtree(primary, ignore_errors=True)
+
+    def test_returns_none_when_not_a_repo(self):
+        tmp = tempfile.mkdtemp(prefix="actor-index-notrepo-")
+        try:
+            actor = _fake_actor_for_repo(tmp)
+            self.assertIsNone(git_index_mtime(actor))
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+class DiffPollActorTests(unittest.TestCase):
+    """`_diff_poll_actor` returns the eligible actor only when ALL
+    conditions hold: actor selected, RUNNING status, DIFF active."""
+
+    def test_returns_actor_when_running_and_diff_active(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._prev_statuses = {"alice": Status.RUNNING}
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="diff",
+            ),
+        ):
+            self.assertIs(app._diff_poll_actor(), actor)
+
+    def test_returns_none_when_no_actor_selected(self):
+        app = _bare_app()
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=None, active_tab="diff",
+            ),
+        ):
+            self.assertIsNone(app._diff_poll_actor())
+
+    def test_returns_none_when_actor_not_running(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._prev_statuses = {"alice": Status.DONE}
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="diff",
+            ),
+        ):
+            self.assertIsNone(app._diff_poll_actor())
+
+    def test_returns_none_when_diff_tab_inactive(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._prev_statuses = {"alice": Status.RUNNING}
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="logs",
+            ),
+        ):
+            self.assertIsNone(app._diff_poll_actor())
+
+
+class PollDiffForRunningTests(unittest.TestCase):
+    """The interval handler. Only spawns the signal-capture worker
+    when conditions hold; resets baseline state otherwise so a
+    re-entry doesn't compare against stale signals."""
+
+    def test_starts_worker_when_conditions_met(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._prev_statuses = {"alice": Status.RUNNING}
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="diff",
+            ),
+        ), patch.object(app, "_poll_diff_signals_worker") as worker:
+            app._poll_diff_for_running()
+        worker.assert_called_once_with(actor)
+
+    def test_resets_state_when_conditions_not_met(self):
+        app = _bare_app()
+        # Pretend a prior tick had observed signals.
+        app._diff_poll_initialized = True
+        app._diff_poll_last_index_mtime = 1.0
+        app._diff_poll_last_shortstat = (3, 1)
+        # No actor selected → conditions fail.
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=None,
+            ),
+        ), patch.object(app, "_poll_diff_signals_worker") as worker:
+            app._poll_diff_for_running()
+        worker.assert_not_called()
+        self.assertFalse(app._diff_poll_initialized)
+        self.assertIsNone(app._diff_poll_last_index_mtime)
+        self.assertIsNone(app._diff_poll_last_shortstat)
+
+    def test_resets_state_when_actor_not_running(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._prev_statuses = {"alice": Status.DONE}
+        app._diff_poll_initialized = True
+        app._diff_poll_last_index_mtime = 1.0
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="diff",
+            ),
+        ), patch.object(app, "_poll_diff_signals_worker") as worker:
+            app._poll_diff_for_running()
+        worker.assert_not_called()
+        self.assertFalse(app._diff_poll_initialized)
+
+    def test_resets_state_when_tab_inactive(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._prev_statuses = {"alice": Status.RUNNING}
+        app._diff_poll_initialized = True
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="logs",
+            ),
+        ), patch.object(app, "_poll_diff_signals_worker") as worker:
+            app._poll_diff_for_running()
+        worker.assert_not_called()
+        self.assertFalse(app._diff_poll_initialized)
+
+
+class EvaluateDiffPollSignalsTests(unittest.TestCase):
+    """Main-thread signal comparison. First observation baselines;
+    subsequent ticks fire `_maybe_refresh_diff(force=True)` if either
+    signal flipped."""
+
+    def _running_actor(self, app, actor):
+        app._prev_statuses = {actor.name: Status.RUNNING}
+        return _stub_diff_poll_dom(
+            app, selected_actor=actor, active_tab="diff",
+        )
+
+    def test_first_observation_baselines_no_refresh(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        with patch.object(
+            app, "query_one", side_effect=self._running_actor(app, actor),
+        ), patch.object(app, "_maybe_refresh_diff") as refresh:
+            app._evaluate_diff_poll_signals(
+                "alice", mtime=10.0, shortstat=(3, 1),
+            )
+        refresh.assert_not_called()
+        self.assertTrue(app._diff_poll_initialized)
+        self.assertEqual(app._diff_poll_last_index_mtime, 10.0)
+        self.assertEqual(app._diff_poll_last_shortstat, (3, 1))
+
+    def test_unchanged_signals_no_refresh(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_poll_initialized = True
+        app._diff_poll_last_index_mtime = 10.0
+        app._diff_poll_last_shortstat = (3, 1)
+        with patch.object(
+            app, "query_one", side_effect=self._running_actor(app, actor),
+        ), patch.object(app, "_maybe_refresh_diff") as refresh:
+            app._evaluate_diff_poll_signals(
+                "alice", mtime=10.0, shortstat=(3, 1),
+            )
+        refresh.assert_not_called()
+
+    def test_index_mtime_change_triggers_refresh(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_poll_initialized = True
+        app._diff_poll_last_index_mtime = 10.0
+        app._diff_poll_last_shortstat = (3, 1)
+        with patch.object(
+            app, "query_one", side_effect=self._running_actor(app, actor),
+        ), patch.object(app, "_maybe_refresh_diff") as refresh:
+            app._evaluate_diff_poll_signals(
+                "alice", mtime=20.0, shortstat=(3, 1),
+            )
+        refresh.assert_called_once_with(force=True)
+        # Baseline advanced.
+        self.assertEqual(app._diff_poll_last_index_mtime, 20.0)
+
+    def test_shortstat_change_triggers_refresh(self):
+        """Picks up unstaged edits the index doesn't reflect — the
+        whole reason we pair the two signals."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_poll_initialized = True
+        app._diff_poll_last_index_mtime = 10.0
+        app._diff_poll_last_shortstat = (3, 1)
+        with patch.object(
+            app, "query_one", side_effect=self._running_actor(app, actor),
+        ), patch.object(app, "_maybe_refresh_diff") as refresh:
+            app._evaluate_diff_poll_signals(
+                "alice", mtime=10.0, shortstat=(5, 2),
+            )
+        refresh.assert_called_once_with(force=True)
+        self.assertEqual(app._diff_poll_last_shortstat, (5, 2))
+
+    def test_actor_changed_mid_poll_drops_signals(self):
+        """Signals captured for `alice` mustn't refresh `bob`'s
+        diff. The worker can race with a tab/actor change between
+        the kick and the call_from_thread."""
+        app = _bare_app()
+        bob = _fake_actor("bob")
+        app._prev_statuses = {"bob": Status.RUNNING}
+        # Conditions hold for `bob` now.
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=bob, active_tab="diff",
+            ),
+        ), patch.object(app, "_maybe_refresh_diff") as refresh:
+            # ...but the worker is reporting signals captured for
+            # `alice` before the tab switch.
+            app._evaluate_diff_poll_signals(
+                "alice", mtime=99.0, shortstat=(7, 7),
+            )
+        refresh.assert_not_called()
+        # State must NOT advance to `alice`'s captured signals —
+        # those would corrupt `bob`'s baseline.
+        self.assertFalse(app._diff_poll_initialized)
+        self.assertIsNone(app._diff_poll_last_index_mtime)
+
+    def test_drops_signals_when_conditions_no_longer_hold(self):
+        """User switched to LIVE mid-poll; signals stale on arrival."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._prev_statuses = {"alice": Status.RUNNING}
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="logs",
+            ),
+        ), patch.object(app, "_maybe_refresh_diff") as refresh:
+            app._evaluate_diff_poll_signals(
+                "alice", mtime=10.0, shortstat=(3, 1),
+            )
+        refresh.assert_not_called()
+
+
+class DiffPollResetCleanlyTests(unittest.TestCase):
+    """End-to-end stop-cleanly behavior. After a tick where
+    conditions become false, the next tick where they become true
+    again must re-baseline rather than refresh on stale comparison."""
+
+    def test_re_entry_after_reset_treats_as_first_observation(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._prev_statuses = {"alice": Status.RUNNING}
+
+        # First tick: conditions met. Baseline records.
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="diff",
+            ),
+        ), patch.object(app, "_maybe_refresh_diff") as refresh:
+            app._evaluate_diff_poll_signals(
+                "alice", mtime=10.0, shortstat=(3, 1),
+            )
+        refresh.assert_not_called()
+        self.assertTrue(app._diff_poll_initialized)
+
+        # User leaves DIFF for LIVE. Interval still ticks.
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="logs",
+            ),
+        ), patch.object(app, "_poll_diff_signals_worker") as worker:
+            app._poll_diff_for_running()
+        worker.assert_not_called()
+        self.assertFalse(app._diff_poll_initialized)
+        self.assertIsNone(app._diff_poll_last_index_mtime)
+
+        # User comes back to DIFF. Even if signals differ from
+        # what was last seen *long ago*, the next eval is a fresh
+        # baseline — no surprise refresh.
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="diff",
+            ),
+        ), patch.object(app, "_maybe_refresh_diff") as refresh:
+            app._evaluate_diff_poll_signals(
+                "alice", mtime=99.0, shortstat=(99, 99),
+            )
+        refresh.assert_not_called()
+        self.assertTrue(app._diff_poll_initialized)
+        self.assertEqual(app._diff_poll_last_index_mtime, 99.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -2310,5 +2310,113 @@ class GitLocaleEnvTests(unittest.TestCase):
             shutil.rmtree(tmp, ignore_errors=True)
 
 
+# -- CR-loop fixes Round 3 ---------------------------------------------------
+
+
+class ApplyDiffErrorBadgeRaceGuardTests(unittest.TestCase):
+    """`_apply_diff_error` must invalidate any in-flight badge from
+    the same kick. Otherwise a badge worker that captured shortstat
+    counts before the build raised would land "+5 -3" on top of the
+    error message, producing a contradictory tab label vs. scroll
+    pane state. Symmetric with the existing guards in
+    `_apply_diff_build_done` and `_apply_diff_text`."""
+
+    def test_apply_diff_error_bumps_badge_token(self):
+        app = _bare_app()
+        app._diff_build_token = 7
+        app._diff_badge_token = 7
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_error(token=7, text="Diff error: kaboom")
+        # Badge token bumped past 7 → a late `_apply_diff_badge(token=7)`
+        # from the same kick will see the mismatch and skip.
+        self.assertGreater(app._diff_badge_token, 7)
+
+    def test_late_badge_after_error_does_not_overwrite_label(self):
+        """End-to-end: build raises and `_apply_diff_error` mounts
+        the error. Then the same kick's badge worker arrives with
+        valid shortstat counts. It must drop without committing
+        a label."""
+        app = _bare_app()
+        app._diff_build_token = 7
+        app._diff_badge_token = 7
+
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_error(token=7, text="Diff error: kaboom")
+
+        # Capture the post-error label so we can verify the late
+        # badge doesn't change it.
+        label_after_error = str(app._tab_base_labels["diff"])
+
+        with patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_badge(token=7, added=5, removed=3)
+
+        # Label unchanged — late badge dropped via token check.
+        self.assertEqual(str(app._tab_base_labels["diff"]), label_after_error)
+
+
+class FlushPendingDiffStaleActorTests(unittest.TestCase):
+    """`_flush_pending_diff_if_visible` looks up the stashed actor
+    by name in `_current_actors`. If the actor was discarded between
+    the stash and the flush, the lookup returns None — and the
+    stash must be cleared so subsequent tab activations don't
+    repeatedly attempt (and silently fail) to resolve a name that
+    will never appear again."""
+
+    def test_flush_clears_pending_actor_when_actor_discarded(self):
+        app = _bare_app()
+        app._diff_pending_actor = "ghost"
+        # `ghost` is NOT in `_current_actors` — simulating a discard
+        # that happened between the kick (which stashed) and the
+        # tab activation (which flushes).
+        app._current_actors = []
+
+        captured: dict = {}
+        def fake_after_refresh(fn):
+            captured["fn"] = fn
+
+        with patch.object(app, "call_after_refresh", side_effect=fake_after_refresh):
+            app._flush_pending_diff_if_visible()
+        self.assertIn("fn", captured)
+
+        # Drive the inner attempt with a non-zero-width scroll so it
+        # gets to the actor lookup branch.
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_kick_diff_build") as kick:
+            captured["fn"]()
+        kick.assert_not_called()
+        # Stash cleared — next tab activation won't re-attempt the
+        # same dead lookup.
+        self.assertIsNone(app._diff_pending_actor)
+
+    def test_flush_keeps_pending_actor_on_zero_width(self):
+        """Sanity: when the scroll is still zero-width (DIFF still
+        hidden somehow when the closure runs), the stash must
+        remain so a later activation can flush it."""
+        app = _bare_app()
+        app._diff_pending_actor = "alice"
+        actor = _fake_actor("alice")
+        app._current_actors = [actor]
+
+        captured: dict = {}
+        def fake_after_refresh(fn):
+            captured["fn"] = fn
+
+        with patch.object(app, "call_after_refresh", side_effect=fake_after_refresh):
+            app._flush_pending_diff_if_visible()
+
+        scroll = _scroll_with_width(0)
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_kick_diff_build") as kick:
+            captured["fn"]()
+        kick.assert_not_called()
+        # Stash retained so the next activation can try again.
+        self.assertEqual(app._diff_pending_actor, "alice")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -56,8 +56,10 @@ def _bare_app() -> ActorWatchApp:
     app._diff_badge_token = 0
     app._diff_badge_target_actor = None
     app._diff_poll_initialized = False
+    app._diff_poll_last_actor = None
     app._diff_poll_last_index_mtime = None
     app._diff_poll_last_shortstat = None
+    app._diff_poll_last_untracked = None
     app._prev_statuses = {}
     app._current_actors = []
     app._tab_base_labels = {
@@ -186,10 +188,14 @@ class KickDiffBuildHiddenTabTests(unittest.TestCase):
         self.assertEqual(app._diff_build_target_width, 100)
         worker.assert_called_once()
         args, _kwargs = worker.call_args
-        token, called_actor, called_width = args
+        # Stage-5 fix: kick passes `force` through to the worker so
+        # live-poll-driven force-refreshes bypass the cache-key
+        # short-circuit. Default kick is force=False.
+        token, called_actor, called_width, force = args
         self.assertEqual(token, 1)
         self.assertIs(called_actor, actor)
         self.assertEqual(called_width, 100)
+        self.assertFalse(force)
 
     def test_flush_pending_diff_kicks_when_pane_visible(self):
         """After a hidden-tab kick stashes an actor, the next tab
@@ -887,7 +893,9 @@ class BadgeBeforeBuildTests(unittest.TestCase):
              patch.object(app, "_kick_diff_build") as build_kick:
             app._maybe_refresh_diff()
         badge_kick.assert_called_once_with(actor)
-        build_kick.assert_called_once_with(actor)
+        # `force` is propagated to the build kick so live-poll-driven
+        # refreshes bypass the cache-key short-circuit.
+        build_kick.assert_called_once_with(actor, force=False)
 
     def test_badge_apply_can_land_before_build_apply(self):
         """Their tokens are independent counters, so a fast badge
@@ -1234,9 +1242,13 @@ class StreamingWorkerEndToEndTests(unittest.TestCase):
                           )):
             ActorWatchApp._build_diff_worker.__wrapped__(app, 1, actor, 100)
         names = [n for n, _a in applied]
-        self.assertEqual(names, ["_apply_diff_text"])
+        # Render error path now routes through `_apply_diff_error`
+        # (which doesn't promote the cache key) instead of
+        # `_apply_diff_text` (which did, leaving the user stuck on
+        # the error mount until HEAD or width changed).
+        self.assertEqual(names, ["_apply_diff_error"])
         # Reason string includes the exception message.
-        self.assertIn("kaboom", applied[0][1][2])
+        self.assertIn("kaboom", applied[0][1][1])
 
 
 class ClearDetailCancelsStreamingTests(unittest.TestCase):
@@ -1502,24 +1514,28 @@ class EvaluateDiffPollSignalsTests(unittest.TestCase):
             app, "query_one", side_effect=self._running_actor(app, actor),
         ), patch.object(app, "_maybe_refresh_diff") as refresh:
             app._evaluate_diff_poll_signals(
-                "alice", mtime=10.0, shortstat=(3, 1),
+                "alice", mtime=10.0, shortstat=(3, 1), untracked=2,
             )
         refresh.assert_not_called()
         self.assertTrue(app._diff_poll_initialized)
+        self.assertEqual(app._diff_poll_last_actor, "alice")
         self.assertEqual(app._diff_poll_last_index_mtime, 10.0)
         self.assertEqual(app._diff_poll_last_shortstat, (3, 1))
+        self.assertEqual(app._diff_poll_last_untracked, 2)
 
     def test_unchanged_signals_no_refresh(self):
         app = _bare_app()
         actor = _fake_actor("alice")
         app._diff_poll_initialized = True
+        app._diff_poll_last_actor = "alice"
         app._diff_poll_last_index_mtime = 10.0
         app._diff_poll_last_shortstat = (3, 1)
+        app._diff_poll_last_untracked = 0
         with patch.object(
             app, "query_one", side_effect=self._running_actor(app, actor),
         ), patch.object(app, "_maybe_refresh_diff") as refresh:
             app._evaluate_diff_poll_signals(
-                "alice", mtime=10.0, shortstat=(3, 1),
+                "alice", mtime=10.0, shortstat=(3, 1), untracked=0,
             )
         refresh.assert_not_called()
 
@@ -1527,13 +1543,15 @@ class EvaluateDiffPollSignalsTests(unittest.TestCase):
         app = _bare_app()
         actor = _fake_actor("alice")
         app._diff_poll_initialized = True
+        app._diff_poll_last_actor = "alice"
         app._diff_poll_last_index_mtime = 10.0
         app._diff_poll_last_shortstat = (3, 1)
+        app._diff_poll_last_untracked = 0
         with patch.object(
             app, "query_one", side_effect=self._running_actor(app, actor),
         ), patch.object(app, "_maybe_refresh_diff") as refresh:
             app._evaluate_diff_poll_signals(
-                "alice", mtime=20.0, shortstat=(3, 1),
+                "alice", mtime=20.0, shortstat=(3, 1), untracked=0,
             )
         refresh.assert_called_once_with(force=True)
         # Baseline advanced.
@@ -1545,16 +1563,39 @@ class EvaluateDiffPollSignalsTests(unittest.TestCase):
         app = _bare_app()
         actor = _fake_actor("alice")
         app._diff_poll_initialized = True
+        app._diff_poll_last_actor = "alice"
         app._diff_poll_last_index_mtime = 10.0
         app._diff_poll_last_shortstat = (3, 1)
+        app._diff_poll_last_untracked = 0
         with patch.object(
             app, "query_one", side_effect=self._running_actor(app, actor),
         ), patch.object(app, "_maybe_refresh_diff") as refresh:
             app._evaluate_diff_poll_signals(
-                "alice", mtime=10.0, shortstat=(5, 2),
+                "alice", mtime=10.0, shortstat=(5, 2), untracked=0,
             )
         refresh.assert_called_once_with(force=True)
         self.assertEqual(app._diff_poll_last_shortstat, (5, 2))
+
+    def test_untracked_count_change_triggers_refresh(self):
+        """Stage-5 third signal: a new untracked file (the most
+        common output shape from an actor's `Write` tool) doesn't
+        flip mtime or shortstat, so without `untracked` the live
+        refresh would never fire on file creation."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_poll_initialized = True
+        app._diff_poll_last_actor = "alice"
+        app._diff_poll_last_index_mtime = 10.0
+        app._diff_poll_last_shortstat = (3, 1)
+        app._diff_poll_last_untracked = 0
+        with patch.object(
+            app, "query_one", side_effect=self._running_actor(app, actor),
+        ), patch.object(app, "_maybe_refresh_diff") as refresh:
+            app._evaluate_diff_poll_signals(
+                "alice", mtime=10.0, shortstat=(3, 1), untracked=1,
+            )
+        refresh.assert_called_once_with(force=True)
+        self.assertEqual(app._diff_poll_last_untracked, 1)
 
     def test_actor_changed_mid_poll_drops_signals(self):
         """Signals captured for `alice` mustn't refresh `bob`'s
@@ -1573,13 +1614,45 @@ class EvaluateDiffPollSignalsTests(unittest.TestCase):
             # ...but the worker is reporting signals captured for
             # `alice` before the tab switch.
             app._evaluate_diff_poll_signals(
-                "alice", mtime=99.0, shortstat=(7, 7),
+                "alice", mtime=99.0, shortstat=(7, 7), untracked=5,
             )
         refresh.assert_not_called()
         # State must NOT advance to `alice`'s captured signals —
         # those would corrupt `bob`'s baseline.
         self.assertFalse(app._diff_poll_initialized)
         self.assertIsNone(app._diff_poll_last_index_mtime)
+
+    def test_actor_switch_re_baselines_without_refresh(self):
+        """When the selected actor changes between polls, the next
+        evaluation must re-baseline rather than compare bob's
+        signals against alice's stale baseline (which would always
+        diverge and fire a redundant force-refresh on top of the
+        actor-switch kick `on_tree_node_highlighted` already
+        triggered)."""
+        app = _bare_app()
+        bob = _fake_actor("bob")
+        app._prev_statuses = {"bob": Status.RUNNING}
+        # Baseline was for alice, but the user has switched to bob.
+        app._diff_poll_initialized = True
+        app._diff_poll_last_actor = "alice"
+        app._diff_poll_last_index_mtime = 10.0
+        app._diff_poll_last_shortstat = (3, 1)
+        app._diff_poll_last_untracked = 0
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=bob, active_tab="diff",
+            ),
+        ), patch.object(app, "_maybe_refresh_diff") as refresh:
+            app._evaluate_diff_poll_signals(
+                "bob", mtime=99.0, shortstat=(7, 7), untracked=5,
+            )
+        # No refresh — bob's first observation is a baseline.
+        refresh.assert_not_called()
+        self.assertEqual(app._diff_poll_last_actor, "bob")
+        self.assertEqual(app._diff_poll_last_index_mtime, 99.0)
+        self.assertEqual(app._diff_poll_last_shortstat, (7, 7))
+        self.assertEqual(app._diff_poll_last_untracked, 5)
 
     def test_drops_signals_when_conditions_no_longer_hold(self):
         """User switched to LIVE mid-poll; signals stale on arrival."""
@@ -1593,7 +1666,7 @@ class EvaluateDiffPollSignalsTests(unittest.TestCase):
             ),
         ), patch.object(app, "_maybe_refresh_diff") as refresh:
             app._evaluate_diff_poll_signals(
-                "alice", mtime=10.0, shortstat=(3, 1),
+                "alice", mtime=10.0, shortstat=(3, 1), untracked=0,
             )
         refresh.assert_not_called()
 
@@ -1616,7 +1689,7 @@ class DiffPollResetCleanlyTests(unittest.TestCase):
             ),
         ), patch.object(app, "_maybe_refresh_diff") as refresh:
             app._evaluate_diff_poll_signals(
-                "alice", mtime=10.0, shortstat=(3, 1),
+                "alice", mtime=10.0, shortstat=(3, 1), untracked=0,
             )
         refresh.assert_not_called()
         self.assertTrue(app._diff_poll_initialized)
@@ -1643,11 +1716,330 @@ class DiffPollResetCleanlyTests(unittest.TestCase):
             ),
         ), patch.object(app, "_maybe_refresh_diff") as refresh:
             app._evaluate_diff_poll_signals(
-                "alice", mtime=99.0, shortstat=(99, 99),
+                "alice", mtime=99.0, shortstat=(99, 99), untracked=99,
             )
         refresh.assert_not_called()
         self.assertTrue(app._diff_poll_initialized)
         self.assertEqual(app._diff_poll_last_index_mtime, 99.0)
+
+
+# -- CR-loop fixes: regression tests ---------------------------------------
+
+
+class StreamCancelInvalidatesCacheTests(unittest.TestCase):
+    """When a streaming build is cancelled mid-flight after at least
+    one file mounted, partial content remains on screen but the
+    cache key cannot stay promoted from the *previous* successful
+    build — otherwise a subsequent kick at the same key would
+    cache-hit and leave the user staring at the partial state
+    forever (e.g. resize away then back to a previously-cached width
+    while a re-render was in flight)."""
+
+    def test_cancel_after_first_append_invalidates_cache_key(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        # Cache holds a key from a *different* prior build (different
+        # head_oid). The worker's cache check shouldn't early-out;
+        # we want the worker to actually start streaming so we can
+        # observe the mid-stream cancellation path.
+        app._diff_last_applied_key = ("alice", "different-oid", 100)
+        app._diff_build_token = 5
+        app._diff_streamed_token = -1
+
+        result = MagicMock()
+        result.files = [
+            FileDiff(f"f{i}.py", f"old{i}\n", f"new{i}\n", added=1, removed=1)
+            for i in range(3)
+        ]
+        result.reason = ""
+
+        applied: list[tuple] = []
+
+        def cft(fn, *a, **kw):
+            applied.append((fn.__name__, a))
+            # `_diff_append_file` would set `_diff_streamed_token` on
+            # the main thread; emulate that here so
+            # `_on_stream_cancelled` sees streamed_token == token.
+            if fn.__name__ == "_diff_append_file":
+                app._diff_streamed_token = a[0]
+            # After the first append lands, simulate a newer kick.
+            if len([x for x in applied if x[0] == "_diff_append_file"]) == 1:
+                app._diff_build_token = 6
+
+        with _stub_theme(), \
+             patch("actor.watch.app.read_head_oid", return_value="oid"), \
+             patch("actor.watch.app.compute_diff", return_value=result), \
+             patch.object(app, "call_from_thread", side_effect=cft):
+            ActorWatchApp._build_diff_worker.__wrapped__(
+                app, 5, actor, 100, False,
+            )
+
+        # Worker bailed via _on_stream_cancelled, which scheduled
+        # _invalidate_diff_cache_key on the main thread.
+        names = [n for n, _a in applied]
+        self.assertIn("_invalidate_diff_cache_key", names)
+        # And finalizer did NOT run (no cache-key promotion of the
+        # cancelled build).
+        self.assertNotIn("_apply_diff_build_done", names)
+
+
+class ForceRefreshBypassesCacheTests(unittest.TestCase):
+    """Live poll fires `_maybe_refresh_diff(force=True)` precisely
+    BECAUSE the worktree changed even though HEAD didn't move. The
+    cache key is keyed on (actor, head_oid, width), so without a
+    bypass the worker would always cache-hit and the live refresh
+    would never repaint."""
+
+    def test_force_true_skips_cache_hit_short_circuit(self):
+        app = _bare_app()
+        # Cache is populated with the exact key the worker will
+        # compute next.
+        app._diff_last_applied_key = ("alice", "oid", 100)
+        actor = _fake_actor("alice")
+        app._diff_build_token = 11
+
+        result = MagicMock()
+        result.files = None
+        result.reason = "working tree clean"
+        applied: list[tuple] = []
+        with _stub_theme(), \
+             patch("actor.watch.app.read_head_oid", return_value="oid"), \
+             patch("actor.watch.app.compute_diff", return_value=result) as compute, \
+             patch.object(app, "call_from_thread",
+                          side_effect=lambda fn, *a, **kw: applied.append(
+                              (fn.__name__, a),
+                          )):
+            ActorWatchApp._build_diff_worker.__wrapped__(
+                app, 11, actor, 100, True,  # force=True
+            )
+        # compute_diff RAN despite the cache key matching.
+        compute.assert_called_once()
+        # And _apply_diff_text was called (no files reason path),
+        # NOT _mark_diff_build_done (cache hit early-out).
+        names = [n for n, _a in applied]
+        self.assertEqual(names, ["_apply_diff_text"])
+
+    def test_force_false_keeps_cache_hit_short_circuit(self):
+        """Sanity: non-force kicks still cache-hit when the key
+        matches. Otherwise the cache layer is dead weight."""
+        app = _bare_app()
+        app._diff_last_applied_key = ("alice", "oid", 100)
+        actor = _fake_actor("alice")
+        app._diff_build_token = 11
+
+        applied: list[str] = []
+        with _stub_theme(), \
+             patch("actor.watch.app.read_head_oid", return_value="oid"), \
+             patch("actor.watch.app.compute_diff") as compute, \
+             patch.object(app, "call_from_thread",
+                          side_effect=lambda fn, *a, **kw: applied.append(
+                              fn.__name__,
+                          )):
+            ActorWatchApp._build_diff_worker.__wrapped__(
+                app, 11, actor, 100, False,  # force=False
+            )
+        compute.assert_not_called()
+        self.assertEqual(applied, ["_mark_diff_build_done"])
+
+
+class ApplyDiffErrorTests(unittest.TestCase):
+    """Render-error path is split out from `_apply_diff_text` so
+    error states don't poison the cache and lock the user out of
+    retries until HEAD or width changes."""
+
+    def test_error_clears_pending_and_invalidates_cache_key(self):
+        app = _bare_app()
+        app._diff_build_token = 7
+        app._diff_build_pending = True
+        # A previous successful build cached a key.
+        app._diff_last_applied_key = ("alice", "oid", 100)
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_error(token=7, text="Diff error: kaboom")
+        scroll.remove_children.assert_called_once()
+        scroll.mount.assert_called_once()
+        self.assertFalse(app._diff_build_pending)
+        # Cache key dropped — next non-force kick at the same key
+        # rebuilds rather than hitting the stale cache.
+        self.assertIsNone(app._diff_last_applied_key)
+
+    def test_error_uses_markup_false_static(self):
+        """Exception messages can contain `[red]`-like substrings
+        that Rich's default markup parser would interpret. Mounting
+        with `markup=False` keeps the text literal."""
+        from textual.widgets import Static
+        app = _bare_app()
+        app._diff_build_token = 1
+        scroll = MagicMock()
+        scroll.size = MagicMock()
+        scroll.size.width = 100
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_error(token=1, text="error: [red]boom[/red]")
+        widget = scroll.mount.call_args.args[0]
+        self.assertIsInstance(widget, Static)
+        # Textual's Static stores the markup flag as `_render_markup`.
+        self.assertFalse(widget._render_markup)
+
+
+class ParseDiffFilesRenameTests(unittest.TestCase):
+    """Renames need the OLD path to look up the pre-image at the
+    merge base — querying the new path in that tree would miss
+    because the rename hadn't happened yet, causing the diff to
+    render as if the entire file was newly added."""
+
+    def test_rename_with_modifications_captures_old_path(self):
+        diff = (
+            "diff --git a/old.py b/new.py\n"
+            "similarity index 87%\n"
+            "rename from old.py\n"
+            "rename to new.py\n"
+            "index abc..def 100644\n"
+            "--- a/old.py\n"
+            "+++ b/new.py\n"
+            "@@ -1,3 +1,3 @@\n"
+            " ctx\n"
+            "-removed\n"
+            "+added\n"
+        )
+        files = _parse_diff_files(diff)
+        self.assertEqual(len(files), 1)
+        self.assertEqual(files[0]["path"], "new.py")
+        self.assertEqual(files[0]["old_path"], "old.py")
+        self.assertEqual(files[0]["added"], 1)
+        self.assertEqual(files[0]["removed"], 1)
+
+    def test_pure_rename_no_content_change_still_captures_paths(self):
+        diff = (
+            "diff --git a/old.py b/new.py\n"
+            "similarity index 100%\n"
+            "rename from old.py\n"
+            "rename to new.py\n"
+        )
+        files = _parse_diff_files(diff)
+        self.assertEqual(len(files), 1)
+        self.assertEqual(files[0]["path"], "new.py")
+        self.assertEqual(files[0]["old_path"], "old.py")
+
+    def test_compute_diff_uses_old_path_for_rename_lookup(self):
+        """End-to-end: a renamed file's pre-image is read from the
+        merge base via its OLD name. Without the fix, cat-file
+        would query `<base>:new.py` (missing) and the diff would
+        render as a wholly-new file."""
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = tempfile.mkdtemp(prefix="actor-rename-")
+        try:
+            _git("init", "-q", "-b", "main", tmp, cwd=tmp)
+            # 10-line file so a 1-line modification leaves >90%
+            # similarity — well above git's default rename detection
+            # threshold (50%).
+            seed = "\n".join(f"line {i}" for i in range(10)) + "\n"
+            Path(tmp, "old.py").write_text(seed)
+            _git("add", "-A", cwd=tmp)
+            _git("commit", "-q", "-m", "seed", cwd=tmp)
+            _git("mv", "old.py", "new.py", cwd=tmp)
+            # Modify just one line so git's rename detection still
+            # pairs the files together via similarity heuristic.
+            modified = seed.replace("line 5\n", "LINE FIVE\n")
+            Path(tmp, "new.py").write_text(modified)
+            actor = _fake_actor_for_repo(tmp)
+            result = compute_diff(actor)
+            self.assertIsNotNone(result.files)
+            self.assertEqual(len(result.files), 1)
+            fd = result.files[0]
+            self.assertEqual(fd.file_path, "new.py")
+            # Pre-image is the OLD content — captured via the rename
+            # header. Without the fix this would have been "".
+            self.assertEqual(fd.old_content, seed)
+            self.assertEqual(fd.new_content, modified)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+class ParseDiffFilesQuotedPathTests(unittest.TestCase):
+    """`compute_diff` pins `core.quotepath=false` so the parser sees
+    raw utf-8 paths instead of git's default octal-escaped quoted
+    form. Verify the diff command includes the flag."""
+
+    def test_compute_diff_passes_core_quotepath_false(self):
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = _build_repo(n_files=1)
+        try:
+            actor = _fake_actor_for_repo(tmp)
+            counter = _SubprocessCounter()
+            with patch("actor.watch.helpers.subprocess", counter):
+                compute_diff(actor)
+            diff_calls = [
+                c for c in counter.calls
+                if c[:1] == ["git"] and "diff" in c
+            ]
+            # The diff invocation includes `-c core.quotepath=false`.
+            self.assertTrue(
+                any(
+                    c[1:3] == ["-c", "core.quotepath=false"]
+                    and "diff" in c
+                    for c in diff_calls
+                ),
+                f"expected -c core.quotepath=false in diff invocation; "
+                f"got {diff_calls!r}",
+            )
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+class WordDiffLowSimilarityTests(unittest.TestCase):
+    """When two paired lines are too dissimilar (>40% changed),
+    the word-diff path produces a uniform `*_word_bg` smear instead
+    of useful highlighting. Returning None tells the caller to fall
+    through to the standard syntax-highlighted line-bg path."""
+
+    def test_returns_none_on_low_similarity(self):
+        from actor.watch.diff_render import _word_diff
+        # Two completely different lines — ratio = 0.
+        result = _word_diff(
+            "this is the old line", "totally different content here",
+        )
+        self.assertIsNone(result)
+
+    def test_returns_tokens_on_high_similarity(self):
+        from actor.watch.diff_render import _word_diff
+        # Single-token change in a 5-token line — ratio ~0.8.
+        result = _word_diff(
+            "first second third fourth fifth",
+            "first second THIRD fourth fifth",
+        )
+        self.assertIsNotNone(result)
+        old_tokens, new_tokens = result
+        # Tokenization splits on whitespace runs. Verify per-token
+        # changed flags exist.
+        self.assertTrue(any(changed for _t, changed in old_tokens))
+        self.assertTrue(any(changed for _t, changed in new_tokens))
+
+
+class GitCatFileBatchCleanupTests(unittest.TestCase):
+    """The `with subprocess.Popen(...)` context manager guarantees
+    pipe + child cleanup even if `communicate()` raises mid-call.
+    The previous bare try/except leaked the child + three pipes."""
+
+    def test_communicate_exception_does_not_leak(self):
+        from actor.watch.helpers import _git_cat_file_batch
+        # Construct a Popen mock whose communicate raises and whose
+        # __exit__ records the cleanup.
+        proc_mock = MagicMock()
+        proc_mock.communicate.side_effect = OSError("boom")
+        cm_mock = MagicMock()
+        cm_mock.__enter__ = MagicMock(return_value=proc_mock)
+        cm_mock.__exit__ = MagicMock(return_value=False)
+        with patch("actor.watch.helpers.subprocess.Popen", return_value=cm_mock):
+            result = _git_cat_file_batch(["abc:foo"], "/tmp")
+        # All requested refs map to "" on failure.
+        self.assertEqual(result, {"abc:foo": ""})
+        # The context manager's __exit__ ran, ensuring cleanup of
+        # the child process and its pipes.
+        cm_mock.__exit__.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -1,0 +1,339 @@
+"""Stage-1 logs-pattern parity for the watch DIFF tab.
+
+Covers cancellation, token discard, hidden-tab stash + flush, and
+width-aware cache invalidation. Mirrors the patterns the logs view
+already uses; see `actor.watch.log_renderer` and the `_kick_log_build`
+state machine in `actor.watch.app` for the reference implementation."""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from actor.watch.app import ActorWatchApp
+from actor.watch.diff_render import build_diff_renderables
+from actor.watch.helpers import FileDiff
+
+
+def _bare_app() -> ActorWatchApp:
+    """Construct an ActorWatchApp without running its __init__ — the
+    real init wires up Textual machinery (loop, DOM, DB) that we don't
+    need for direct method tests. We attach only what each method
+    reads, then drive the methods by hand."""
+    app = ActorWatchApp.__new__(ActorWatchApp)
+    # Reset class-level defaults to instance state so tests are
+    # isolated from one another (class attrs are shared otherwise).
+    app._diff_build_token = 0
+    app._diff_build_pending = False
+    app._diff_build_target_actor = None
+    app._diff_build_target_width = 0
+    app._diff_last_applied_key = None
+    app._diff_pending_actor = None
+    app._current_actors = []
+    app._tab_base_labels = {
+        "logs": "LIVE", "diff": "DIFF",
+        "info": "OVERVIEW", "interactive": "INTERACTIVE",
+    }
+    return app
+
+
+def _fake_actor(name: str = "alice") -> MagicMock:
+    """Minimal stand-in for actor.types.Actor — only `.name` and
+    `.dir` are read by the diff state machine."""
+    a = MagicMock()
+    a.name = name
+    a.dir = f"/tmp/{name}"
+    return a
+
+
+def _scroll_with_width(width: int) -> MagicMock:
+    """Stand-in for the VerticalScroll widget. The state machine
+    only reads `.size.width` plus the mount/remove API."""
+    scroll = MagicMock()
+    scroll.size = MagicMock()
+    scroll.size.width = width
+    return scroll
+
+
+# -- build_diff_renderables --------------------------------------------------
+
+
+class BuildDiffRenderablesCancellationTests(unittest.TestCase):
+    """The off-thread builder must cooperate with cancellation —
+    return None as soon as `is_cancelled()` flips True. Mirrors the
+    contract `build_log_renderables` already follows."""
+
+    def test_cancels_before_starting(self):
+        files = [FileDiff("a.txt", "old\n", "new\n")]
+        result = build_diff_renderables(files, dark=True, is_cancelled=lambda: True)
+        self.assertIsNone(result)
+
+    def test_runs_to_completion_when_never_cancelled(self):
+        files = [
+            FileDiff("a.py", "x = 1\n", "x = 2\n"),
+            FileDiff("b.py", "", "hello\n"),
+        ]
+        result = build_diff_renderables(files, dark=True)
+        self.assertIsNotNone(result)
+        parts, added, removed = result
+        # Two files → at least 2 renderables, plus blank separators.
+        self.assertGreaterEqual(len(parts), 2)
+        # b.py is a "new file" with one added line; a.py replaces one
+        # line so +1 / -1.
+        self.assertEqual(added, 2)
+        self.assertEqual(removed, 1)
+
+    def test_cancels_mid_file_render(self):
+        """`is_cancelled` flipping after the first file's render must
+        abort before the second file is processed."""
+        files = [
+            FileDiff("first.py", "a\n", "b\n"),
+            FileDiff("second.py", "c\n", "d\n"),
+        ]
+        # is_cancelled returns True on the 3rd call (after first file
+        # rendered + post-render check). Counter chosen so the first
+        # file completes but the second never starts.
+        calls = {"n": 0}
+        def is_cancelled() -> bool:
+            calls["n"] += 1
+            # Cancel after a few checks (between files).
+            return calls["n"] > 3
+        result = build_diff_renderables(files, dark=True, is_cancelled=is_cancelled)
+        self.assertIsNone(result)
+
+
+# -- App-level state machine -------------------------------------------------
+
+
+class KickDiffBuildHiddenTabTests(unittest.TestCase):
+    """When the DIFF pane is hidden TabbedContent collapses it to
+    width 0. Kicking a build at width 0 caches segments at the wrong
+    width; the kick path must skip and stash the actor for a later
+    flush instead."""
+
+    def test_kick_at_width_zero_stashes_actor_and_skips_build(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        with patch.object(app, "query_one", return_value=_scroll_with_width(0)), \
+             patch.object(app, "set_timer") as set_timer, \
+             patch.object(app, "_build_diff_worker") as worker:
+            app._kick_diff_build(actor)
+        self.assertEqual(app._diff_pending_actor, "alice")
+        self.assertFalse(app._diff_build_pending)
+        self.assertEqual(app._diff_build_token, 0)
+        worker.assert_not_called()
+        set_timer.assert_not_called()
+
+    def test_kick_at_real_width_starts_worker_and_clears_stash(self):
+        app = _bare_app()
+        # Pre-stash from an earlier hidden-tab kick.
+        app._diff_pending_actor = "alice"
+        actor = _fake_actor("alice")
+        with patch.object(app, "query_one", return_value=_scroll_with_width(100)), \
+             patch.object(app, "set_timer"), \
+             patch.object(app, "_build_diff_worker") as worker:
+            app._kick_diff_build(actor)
+        self.assertIsNone(app._diff_pending_actor)
+        self.assertTrue(app._diff_build_pending)
+        self.assertEqual(app._diff_build_token, 1)
+        self.assertEqual(app._diff_build_target_actor, "alice")
+        self.assertEqual(app._diff_build_target_width, 100)
+        worker.assert_called_once()
+        args, _kwargs = worker.call_args
+        token, called_actor, called_width = args
+        self.assertEqual(token, 1)
+        self.assertIs(called_actor, actor)
+        self.assertEqual(called_width, 100)
+
+    def test_flush_pending_diff_kicks_when_pane_visible(self):
+        """After a hidden-tab kick stashes an actor, the next tab
+        activation should call `_flush_pending_diff_if_visible`,
+        which re-kicks via `call_after_refresh`."""
+        app = _bare_app()
+        app._diff_pending_actor = "alice"
+        actor = _fake_actor("alice")
+        app._current_actors = [actor]
+
+        # Capture the closure passed to call_after_refresh and run it
+        # immediately so we can assert against the kick result.
+        captured: dict[str, callable] = {}
+        def fake_after_refresh(fn):
+            captured["fn"] = fn
+
+        with patch.object(app, "call_after_refresh", side_effect=fake_after_refresh):
+            app._flush_pending_diff_if_visible()
+        self.assertIn("fn", captured)
+
+        with patch.object(app, "query_one", return_value=_scroll_with_width(80)), \
+             patch.object(app, "set_timer"), \
+             patch.object(app, "_build_diff_worker") as worker:
+            captured["fn"]()
+        # The stashed actor was found in _current_actors and re-kicked.
+        worker.assert_called_once()
+
+    def test_flush_noop_when_no_stash(self):
+        app = _bare_app()
+        with patch.object(app, "call_after_refresh") as after:
+            app._flush_pending_diff_if_visible()
+        after.assert_not_called()
+
+
+class ApplyDiffBuildTokenDiscardTests(unittest.TestCase):
+    """Stale builds (whose token has been superseded) must drop their
+    output silently. Same discipline as the logs apply path."""
+
+    def test_apply_diff_build_drops_when_token_stale(self):
+        app = _bare_app()
+        app._diff_build_token = 5  # main thread bumped past
+        app._diff_build_pending = True
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll):
+            app._apply_diff_build(
+                token=3,  # stale
+                cache_key=("alice", "deadbeef", 100),
+                parts=[],
+                total_added=10,
+                total_removed=2,
+            )
+        # The stale apply touched neither the widget nor the cache.
+        scroll.remove_children.assert_not_called()
+        scroll.mount.assert_not_called()
+        self.assertIsNone(app._diff_last_applied_key)
+        # Pending flag is owned by the latest in-flight build; stale
+        # apply must not clear it.
+        self.assertTrue(app._diff_build_pending)
+
+    def test_apply_diff_build_commits_when_token_matches(self):
+        app = _bare_app()
+        app._diff_build_token = 7
+        app._diff_build_pending = True
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_build(
+                token=7,
+                cache_key=("alice", "deadbeef", 100),
+                parts=[],
+                total_added=3,
+                total_removed=4,
+            )
+        scroll.remove_children.assert_called_once()
+        scroll.mount.assert_called_once()
+        self.assertEqual(app._diff_last_applied_key, ("alice", "deadbeef", 100))
+        self.assertFalse(app._diff_build_pending)
+        # Tab label reflects the totals.
+        self.assertIn("±7", app._tab_base_labels["diff"])
+
+    def test_apply_diff_text_drops_when_token_stale(self):
+        app = _bare_app()
+        app._diff_build_token = 4
+        app._diff_build_pending = True
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll):
+            app._apply_diff_text(
+                token=2,
+                cache_key=("alice", "abc", 100),
+                text="working tree clean",
+            )
+        scroll.mount.assert_not_called()
+        self.assertIsNone(app._diff_last_applied_key)
+
+
+class CacheKeyAndWidthChangeTests(unittest.TestCase):
+    """`(actor.name, head_oid, content_width)` is the cache key. Same
+    triple → no rebuild. Width change → rebuild even if everything
+    else is unchanged."""
+
+    def test_cache_hit_skips_compute_diff_and_clears_pending(self):
+        app = _bare_app()
+        app._diff_last_applied_key = ("alice", "deadbeef", 100)
+        actor = _fake_actor("alice")
+        # Simulate the kick that an actor-switch (or repeat-click)
+        # would have made: bump token + set pending, then run worker.
+        app._diff_build_token = 9
+        app._diff_build_pending = True
+        marks: list[int] = []
+        with patch("actor.watch.app.read_head_oid", return_value="deadbeef"), \
+             patch("actor.watch.app.compute_diff") as compute, \
+             patch.object(app, "call_from_thread",
+                          side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+            with patch.object(app, "_mark_diff_build_done",
+                              side_effect=marks.append):
+                # Call the underlying function the @work decorator wraps.
+                ActorWatchApp._build_diff_worker.__wrapped__(app, 9, actor, 100)
+        # Cache hit — no compute_diff and the pending flag was cleared.
+        compute.assert_not_called()
+        self.assertEqual(marks, [9])
+
+    def test_cache_miss_runs_compute_diff(self):
+        app = _bare_app()
+        # Different oid → cache miss.
+        app._diff_last_applied_key = ("alice", "old-oid", 100)
+        actor = _fake_actor("alice")
+        app._diff_build_token = 11
+        app._diff_build_pending = True
+        # compute_diff returns "no files" → reason path so we don't
+        # need real FileDiff objects to exercise the cache branch.
+        result = MagicMock()
+        result.files = None
+        result.reason = "working tree clean"
+        applied: list[tuple] = []
+        with patch("actor.watch.app.read_head_oid", return_value="new-oid"), \
+             patch("actor.watch.app.compute_diff", return_value=result) as compute, \
+             patch.object(app, "call_from_thread",
+                          side_effect=lambda fn, *a, **kw: applied.append((fn, a))):
+            ActorWatchApp._build_diff_worker.__wrapped__(app, 11, actor, 100)
+        compute.assert_called_once()
+        self.assertEqual(len(applied), 1)
+        fn, args = applied[0]
+        # _apply_diff_text(token, cache_key, reason). Bound-method
+        # objects compare by ==, not is — accessing the attribute
+        # creates a fresh method instance each time.
+        self.assertEqual(fn, app._apply_diff_text)
+        self.assertEqual(args[0], 11)
+        self.assertEqual(args[1], ("alice", "new-oid", 100))
+        self.assertEqual(args[2], "working tree clean")
+
+    def test_width_change_invalidates_cache(self):
+        """Same actor + same HEAD but resized terminal → cache miss
+        because content_width is part of the key."""
+        app = _bare_app()
+        app._diff_last_applied_key = ("alice", "deadbeef", 100)
+        actor = _fake_actor("alice")
+        app._diff_build_token = 12
+        app._diff_build_pending = True
+        result = MagicMock()
+        result.files = None
+        result.reason = ""
+        with patch("actor.watch.app.read_head_oid", return_value="deadbeef"), \
+             patch("actor.watch.app.compute_diff", return_value=result) as compute, \
+             patch.object(app, "call_from_thread",
+                          side_effect=lambda fn, *a, **kw: None):
+            # Worker runs at width 140 — cache key differs by width.
+            ActorWatchApp._build_diff_worker.__wrapped__(app, 12, actor, 140)
+        compute.assert_called_once()
+
+
+class WorkerCancellationTests(unittest.TestCase):
+    """The worker observes cancellation via `_diff_build_token`
+    changing on the main thread. A newer kick must short-circuit the
+    in-flight worker before it commits."""
+
+    def test_worker_bails_when_token_advances_before_compute(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        # Simulate a newer kick mid-worker by bumping the token before
+        # the worker checks it.
+        app._diff_build_token = 99
+        app._diff_build_pending = True
+        with patch("actor.watch.app.read_head_oid", return_value="x"), \
+             patch("actor.watch.app.compute_diff") as compute, \
+             patch.object(app, "call_from_thread") as cft:
+            ActorWatchApp._build_diff_worker.__wrapped__(
+                app, 1, actor, 100,  # stale token = 1, current = 99
+            )
+        compute.assert_not_called()
+        cft.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -2418,5 +2418,165 @@ class FlushPendingDiffStaleActorTests(unittest.TestCase):
         self.assertEqual(app._diff_pending_actor, "alice")
 
 
+# -- CR-loop fixes Round 4 ---------------------------------------------------
+
+
+class ApplyDiffErrorRetryEligibilityTests(unittest.TestCase):
+    """`_apply_diff_error` must reset `_diff_loaded_for` to `None`
+    so that re-selecting the same actor in the tree retries the
+    build, instead of short-circuiting at `_maybe_refresh_diff`'s
+    actor-already-loaded check. Without this, the user would be
+    stuck on the error message until they switched actors and back
+    (or waited for a live poll force-refresh to fire)."""
+
+    def test_apply_diff_error_resets_loaded_for(self):
+        app = _bare_app()
+        app._diff_build_token = 7
+        app._diff_loaded_for = "alice"
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_error(token=7, text="Diff error: kaboom")
+        # Loaded-for cleared → next `_maybe_refresh_diff(force=False)`
+        # on alice will pass the early-out and re-kick.
+        self.assertIsNone(app._diff_loaded_for)
+
+    def test_re_select_after_error_re_kicks(self):
+        """End-to-end: after an error, the user re-clicks the same
+        actor in the tree → `_maybe_refresh_diff` does NOT short-
+        circuit and a fresh build kicks."""
+        app = _bare_app()
+        app._diff_build_token = 7
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_error(token=7, text="Diff error: kaboom")
+        # Now simulate re-selection of the same actor.
+        actor = _fake_actor("alice")
+        tree = MagicMock()
+        tree.selected_actor = actor
+        with patch.object(app, "query_one", return_value=tree), \
+             patch.object(app, "_kick_diff_badge") as badge_kick, \
+             patch.object(app, "_kick_diff_build") as build_kick:
+            app._maybe_refresh_diff()
+        # Both paths kicked despite this being the same actor — the
+        # error reset cleared the early-out gate.
+        badge_kick.assert_called_once_with(actor)
+        build_kick.assert_called_once_with(actor, force=False)
+
+
+class PlaceholderSkipsForSameActorTests(unittest.TestCase):
+    """The 300ms `Loading diff...` placeholder should NOT replace
+    fresh content during a live-poll force-refresh of the same
+    actor. Otherwise every 2s the user sees the placeholder flash
+    and clobber the diff that was just rendered. The placeholder
+    fires only when there's no existing content for this actor
+    yet — i.e., the first build for an actor or a switch to a
+    different actor."""
+
+    def test_placeholder_skipped_when_same_actor_has_committed_content(self):
+        app = _bare_app()
+        # Prior build for alice already committed content.
+        app._diff_last_applied_key = ("alice", "oid", 100)
+        # New kick is for the same actor (e.g. live-poll force-refresh).
+        app._diff_build_token = 5
+        app._diff_build_pending = True
+        app._diff_build_target_actor = "alice"
+
+        # Drive the placeholder closure directly.
+        actor = _fake_actor("alice")
+        captured: dict = {}
+        def fake_set_timer(_delay, fn):
+            captured["fn"] = fn
+        with patch.object(app, "query_one", return_value=_scroll_with_width(100)), \
+             patch.object(app, "set_timer", side_effect=fake_set_timer), \
+             patch.object(app, "_build_diff_worker"):
+            # Re-trigger _kick_diff_build to pick up the newly-prepared
+            # state; we just want the closure.
+            app._diff_build_token = 4  # kick will increment to 5
+            app._diff_build_pending = False  # kick will set to True
+            app._diff_build_target_actor = None  # kick will set
+            app._kick_diff_build(actor)
+        self.assertIn("fn", captured)
+
+        # Now invoke the closure with a fresh scroll — verify it
+        # does NOT clear or mount because the same actor already has
+        # content.
+        scroll = MagicMock()
+        scroll.size = MagicMock()
+        scroll.size.width = 100
+        with patch.object(app, "query_one", return_value=scroll):
+            captured["fn"]()
+        scroll.remove_children.assert_not_called()
+        scroll.mount.assert_not_called()
+
+    def test_placeholder_fires_when_no_committed_content(self):
+        """First build for an actor (no prior cache key) → placeholder
+        fires normally. Otherwise users would never see the loading
+        indicator on initial diff renders."""
+        app = _bare_app()
+        # No prior content.
+        app._diff_last_applied_key = None
+        app._diff_build_token = 3
+        app._diff_build_pending = True
+        app._diff_build_target_actor = "alice"
+
+        actor = _fake_actor("alice")
+        captured: dict = {}
+        def fake_set_timer(_delay, fn):
+            captured["fn"] = fn
+        with patch.object(app, "query_one", return_value=_scroll_with_width(100)), \
+             patch.object(app, "set_timer", side_effect=fake_set_timer), \
+             patch.object(app, "_build_diff_worker"):
+            app._diff_build_token = 2  # kick will increment to 3
+            app._diff_build_pending = False
+            app._kick_diff_build(actor)
+        self.assertIn("fn", captured)
+
+        scroll = MagicMock()
+        scroll.size = MagicMock()
+        scroll.size.width = 100
+        with patch.object(app, "query_one", return_value=scroll):
+            captured["fn"]()
+        # Placeholder fired — scroll cleared and "Loading diff..."
+        # static mounted.
+        scroll.remove_children.assert_called_once()
+        scroll.mount.assert_called_once()
+
+    def test_placeholder_fires_for_different_actor(self):
+        """Switching to a new actor whose content we don't have →
+        placeholder still fires (we'd otherwise leave the prior
+        actor's content visible while the new one builds, which
+        is far more confusing than a brief loading indicator)."""
+        app = _bare_app()
+        # Prior build for alice — but the new kick is for bob.
+        app._diff_last_applied_key = ("alice", "oid", 100)
+        app._diff_build_token = 5
+        app._diff_build_pending = True
+        app._diff_build_target_actor = "bob"
+
+        actor = _fake_actor("bob")
+        captured: dict = {}
+        def fake_set_timer(_delay, fn):
+            captured["fn"] = fn
+        with patch.object(app, "query_one", return_value=_scroll_with_width(100)), \
+             patch.object(app, "set_timer", side_effect=fake_set_timer), \
+             patch.object(app, "_build_diff_worker"):
+            app._diff_build_token = 4
+            app._diff_build_pending = False
+            app._diff_build_target_actor = None
+            app._kick_diff_build(actor)
+        self.assertIn("fn", captured)
+
+        scroll = MagicMock()
+        scroll.size = MagicMock()
+        scroll.size.width = 100
+        with patch.object(app, "query_one", return_value=scroll):
+            captured["fn"]()
+        # Placeholder fired — different actor than what's cached.
+        scroll.remove_children.assert_called_once()
+        scroll.mount.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -16,8 +16,11 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from rich.text import Text
 
 from actor.watch.app import ActorWatchApp
 from actor.watch.diff_render import build_diff_renderables
@@ -71,6 +74,22 @@ def _scroll_with_width(width: int) -> MagicMock:
     scroll.size = MagicMock()
     scroll.size.width = width
     return scroll
+
+
+@contextmanager
+def _stub_theme(dark: bool = True):
+    """Patch `ActorWatchApp.current_theme` so worker tests can read
+    `is_dark` without paying for the full Textual app setup. The
+    reactive descriptor on the App class needs PropertyMock to override
+    cleanly — direct attribute assignment goes through Reactive.__set__
+    which complains about the missing app context."""
+    theme = MagicMock()
+    theme.dark = dark
+    with patch.object(
+        ActorWatchApp, "current_theme",
+        new_callable=PropertyMock, return_value=theme,
+    ):
+        yield
 
 
 # -- build_diff_renderables --------------------------------------------------
@@ -198,48 +217,57 @@ class KickDiffBuildHiddenTabTests(unittest.TestCase):
 
 class ApplyDiffBuildTokenDiscardTests(unittest.TestCase):
     """Stale builds (whose token has been superseded) must drop their
-    output silently. Same discipline as the logs apply path."""
+    output silently. Same discipline as the logs apply path. Stage 4
+    splits the old single-call apply into per-file streaming
+    (`_diff_append_file`) plus a finalizer (`_apply_diff_build_done`);
+    stale-token discipline applies to both."""
 
-    def test_apply_diff_build_drops_when_token_stale(self):
+    def test_diff_append_file_drops_when_token_stale(self):
         app = _bare_app()
         app._diff_build_token = 5  # main thread bumped past
-        app._diff_build_pending = True
         scroll = _scroll_with_width(100)
         with patch.object(app, "query_one", return_value=scroll):
-            app._apply_diff_build(
+            app._diff_append_file(
+                token=3,  # stale
+                file_path="x.py",
+                renderable=Text("hi"),
+            )
+        scroll.remove_children.assert_not_called()
+        scroll.mount.assert_not_called()
+        # Streamed-token sentinel stays put; the next live append for
+        # the current token will still trigger a clear.
+        self.assertEqual(app._diff_streamed_token, -1)
+
+    def test_apply_diff_build_done_drops_when_token_stale(self):
+        app = _bare_app()
+        app._diff_build_token = 5
+        app._diff_build_pending = True
+        with patch.object(app, "_update_diff_tab_label") as upd:
+            app._apply_diff_build_done(
                 token=3,  # stale
                 cache_key=("alice", "deadbeef", 100),
-                parts=[],
                 total_added=10,
                 total_removed=2,
             )
-        # The stale apply touched neither the widget nor the cache.
-        scroll.remove_children.assert_not_called()
-        scroll.mount.assert_not_called()
+        upd.assert_not_called()
         self.assertIsNone(app._diff_last_applied_key)
         # Pending flag is owned by the latest in-flight build; stale
-        # apply must not clear it.
+        # finalizer must not clear it.
         self.assertTrue(app._diff_build_pending)
 
-    def test_apply_diff_build_commits_when_token_matches(self):
+    def test_apply_diff_build_done_commits_when_token_matches(self):
         app = _bare_app()
         app._diff_build_token = 7
         app._diff_build_pending = True
-        scroll = _scroll_with_width(100)
-        with patch.object(app, "query_one", return_value=scroll), \
-             patch.object(app, "_refresh_tab_arrows"):
-            app._apply_diff_build(
+        with patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_build_done(
                 token=7,
                 cache_key=("alice", "deadbeef", 100),
-                parts=[],
                 total_added=3,
                 total_removed=4,
             )
-        scroll.remove_children.assert_called_once()
-        scroll.mount.assert_called_once()
         self.assertEqual(app._diff_last_applied_key, ("alice", "deadbeef", 100))
         self.assertFalse(app._diff_build_pending)
-        # Tab label reflects the totals.
         self.assertIn("±7", app._tab_base_labels["diff"])
 
     def test_apply_diff_text_drops_when_token_stale(self):
@@ -852,7 +880,8 @@ class BadgeBeforeBuildTests(unittest.TestCase):
     def test_badge_apply_can_land_before_build_apply(self):
         """Their tokens are independent counters, so a fast badge
         worker committing first doesn't bump the build token. The
-        build's later apply still has its token intact and lands."""
+        build's later finalizer still has its token intact and
+        lands."""
         app = _bare_app()
         # Both paths kicked together.
         app._diff_badge_token = 1
@@ -867,16 +896,14 @@ class BadgeBeforeBuildTests(unittest.TestCase):
         self.assertEqual(app._diff_build_token, 1)
         self.assertTrue(app._diff_build_pending)
 
-        # Build commits later with its own counts. Last write wins;
-        # the build's number is authoritative (e.g. it includes
-        # untracked files that shortstat misses).
-        scroll = _scroll_with_width(100)
-        with patch.object(app, "query_one", return_value=scroll), \
-             patch.object(app, "_refresh_tab_arrows"):
-            app._apply_diff_build(
+        # Build's per-file streams complete and the finalizer
+        # commits with its own (authoritative) counts. Last write
+        # wins; the build's number includes untracked files that
+        # shortstat misses.
+        with patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_build_done(
                 token=1,
                 cache_key=("alice", "deadbeef", 100),
-                parts=[],
                 total_added=14,  # diverges from badge's 12 (untracked)
                 total_removed=3,
             )
@@ -936,6 +963,311 @@ class BadgeWorkerCancellationTests(unittest.TestCase):
                 app, 1, actor,
             )
         cft.assert_not_called()
+
+
+# -- Stage 4: per-file streaming render -------------------------------------
+
+
+class IterDiffRenderablesTests(unittest.TestCase):
+    """The streaming generator yields one tuple per file as the
+    worker renders ahead. The watch app's `_build_diff_worker` calls
+    `call_from_thread(_diff_append_file, ...)` for each yielded tuple
+    so files appear progressively rather than after one giant final
+    mount."""
+
+    def test_yields_one_tuple_per_file_in_order(self):
+        from actor.watch.diff_render import iter_diff_renderables
+        files = [
+            FileDiff("a.py", "x = 1\n", "x = 2\n", added=1, removed=1),
+            FileDiff("b.py", "", "hi\n", added=1, removed=0),
+            FileDiff("c.py", "old\n", "", added=0, removed=1),
+        ]
+        results = list(iter_diff_renderables(files, dark=True))
+        self.assertEqual(len(results), 3)
+        # Streaming order matches input order — that's what the
+        # consumer relies on for mount-order correctness.
+        self.assertEqual([r[0] for r in results], ["a.py", "b.py", "c.py"])
+        # Counts ride straight off FileDiff (Stage 2 plumbing); the
+        # generator doesn't recompute them.
+        self.assertEqual([(r[2], r[3]) for r in results],
+                         [(1, 1), (1, 0), (0, 1)])
+
+    def test_cancel_stops_iteration_before_next_file(self):
+        from actor.watch.diff_render import iter_diff_renderables
+        files = [
+            FileDiff("a.py", "1\n", "2\n", added=1, removed=1),
+            FileDiff("b.py", "1\n", "2\n", added=1, removed=1),
+            FileDiff("c.py", "1\n", "2\n", added=1, removed=1),
+        ]
+        # Cancel after first yield by flipping the flag from the
+        # consumer side. The generator's pre-render check kicks in
+        # on the next iteration and stops cleanly.
+        cancelled = {"flag": False}
+        results: list = []
+        for tup in iter_diff_renderables(
+            files, dark=True, is_cancelled=lambda: cancelled["flag"],
+        ):
+            results.append(tup)
+            cancelled["flag"] = True  # cancel after the first yield
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0][0], "a.py")
+
+
+class DiffAppendFileTests(unittest.TestCase):
+    """First append for a fresh kick clears the scroll (placeholder
+    + any prior content); subsequent appends just mount. Stale
+    tokens skip everything."""
+
+    def test_first_append_clears_scroll_then_mounts(self):
+        app = _bare_app()
+        app._diff_build_token = 4
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll):
+            app._diff_append_file(
+                token=4, file_path="a.py", renderable=Text("rendered a"),
+            )
+        scroll.remove_children.assert_called_once()
+        scroll.mount.assert_called_once()
+        self.assertEqual(app._diff_streamed_token, 4)
+        # Pending must be flipped off — real content is on screen
+        # so the 300ms placeholder timer must NOT fire.
+        self.assertFalse(app._diff_build_pending)
+
+    def test_subsequent_appends_skip_clear(self):
+        app = _bare_app()
+        app._diff_build_token = 4
+        app._diff_streamed_token = 4  # first append already happened
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll):
+            app._diff_append_file(
+                token=4, file_path="b.py", renderable=Text("b"),
+            )
+        scroll.remove_children.assert_not_called()
+        scroll.mount.assert_called_once()
+
+    def test_stream_order_preserved_across_appends(self):
+        """Mount calls land in the order the worker invoked them —
+        which mirrors the iter_diff_renderables yield order, which
+        mirrors compute_diff's file order."""
+        app = _bare_app()
+        app._diff_build_token = 1
+        scroll = _scroll_with_width(100)
+        mount_args: list[object] = []
+        scroll.mount.side_effect = lambda widget: mount_args.append(widget)
+
+        def fresh_renderable(label: str) -> Text:
+            return Text(label)
+
+        with patch.object(app, "query_one", return_value=scroll):
+            app._diff_append_file(1, "a.py", fresh_renderable("A"))
+            app._diff_append_file(1, "b.py", fresh_renderable("B"))
+            app._diff_append_file(1, "c.py", fresh_renderable("C"))
+
+        self.assertEqual(len(mount_args), 3)
+        # Each mount holds a Static wrapping a Group(renderable, Text("")).
+        # The label letter sits inside the Group's first child.
+        for widget, expected in zip(mount_args, ["A", "B", "C"]):
+            # widget is Static; Static.content is the Group; the first
+            # element of the Group is our supplied Text.
+            inner = widget.content
+            self.assertEqual(inner.renderables[0].plain, expected)
+        # First call also cleared the scroll once; subsequent two did
+        # not.
+        scroll.remove_children.assert_called_once()
+
+
+class StreamingWorkerEndToEndTests(unittest.TestCase):
+    """Drive `_build_diff_worker` directly with a small file set;
+    verify per-file `_diff_append_file` calls happen in order, the
+    finalizer runs once, and a stale token mid-stream stops the
+    finalizer from committing."""
+
+    def _make_files(self, n: int) -> list[FileDiff]:
+        return [
+            FileDiff(
+                f"f{i}.py", f"old{i}\n", f"new{i}\n",
+                added=1, removed=1,
+            )
+            for i in range(n)
+        ]
+
+    def test_worker_streams_then_finalizes(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_build_token = 5
+
+        result = MagicMock()
+        result.files = self._make_files(3)
+        result.reason = ""
+
+        applied: list[tuple] = []
+        # Capture call_from_thread invocations to verify ordering.
+        with _stub_theme(), \
+             patch("actor.watch.app.read_head_oid", return_value="oid"), \
+             patch("actor.watch.app.compute_diff", return_value=result), \
+             patch.object(app, "call_from_thread",
+                          side_effect=lambda fn, *a, **kw: applied.append(
+                              (fn.__name__, a),
+                          )):
+            ActorWatchApp._build_diff_worker.__wrapped__(app, 5, actor, 100)
+
+        # Three append calls in order, then exactly one finalizer.
+        names = [n for n, _a in applied]
+        self.assertEqual(
+            names,
+            ["_diff_append_file", "_diff_append_file",
+             "_diff_append_file", "_apply_diff_build_done"],
+            f"unexpected call sequence: {names!r}",
+        )
+        # The append calls landed in input file order.
+        append_paths = [a[1] for n, a in applied if n == "_diff_append_file"]
+        self.assertEqual(append_paths, ["f0.py", "f1.py", "f2.py"])
+        # Finalizer received the aggregated counts (Stage 2 plumbing).
+        finalizer_args = applied[-1][1]
+        # (token, cache_key, total_added, total_removed)
+        self.assertEqual(finalizer_args[0], 5)
+        self.assertEqual(finalizer_args[1], ("alice", "oid", 100))
+        self.assertEqual(finalizer_args[2], 3)
+        self.assertEqual(finalizer_args[3], 3)
+
+    def test_cancel_mid_stream_skips_finalizer(self):
+        """Token bumped after the second file's append → worker bails
+        before the finalizer. Partial mounts already on screen stay
+        until the next kick's first append clears them. The cache key
+        must NOT be promoted."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_build_token = 5
+
+        result = MagicMock()
+        result.files = self._make_files(5)
+        result.reason = ""
+
+        applied: list[tuple] = []
+
+        def cft(fn, *a, **kw):
+            applied.append((fn.__name__, a))
+            # After the second append lands, simulate a newer kick
+            # by bumping the token. The worker's post-loop
+            # `is_cancelled()` check then sees the mismatch and
+            # returns before finalizing.
+            if len([x for x in applied if x[0] == "_diff_append_file"]) == 2:
+                app._diff_build_token = 6
+
+        with _stub_theme(), \
+             patch("actor.watch.app.read_head_oid", return_value="oid"), \
+             patch("actor.watch.app.compute_diff", return_value=result), \
+             patch.object(app, "call_from_thread", side_effect=cft):
+            ActorWatchApp._build_diff_worker.__wrapped__(app, 5, actor, 100)
+
+        names = [n for n, _a in applied]
+        # Two appends made it through before cancellation; the
+        # generator's pre-render check on iteration 3 saw the bumped
+        # token and stopped. No finalizer.
+        self.assertEqual(names, ["_diff_append_file", "_diff_append_file"])
+        # Cache key must NOT have been finalized — the next kick has
+        # to re-render rather than seeing a stale "already applied".
+        self.assertIsNone(app._diff_last_applied_key)
+
+    def test_empty_file_list_routes_through_text_path(self):
+        """`compute_diff` returns reason="working tree clean" with
+        files=None when nothing changed. That path is text-only — no
+        streaming, no finalizer, single `_apply_diff_text` mount."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_build_token = 9
+
+        result = MagicMock()
+        result.files = None
+        result.reason = "working tree clean"
+
+        applied: list[str] = []
+        with patch("actor.watch.app.read_head_oid", return_value="oid"), \
+             patch("actor.watch.app.compute_diff", return_value=result), \
+             patch.object(app, "call_from_thread",
+                          side_effect=lambda fn, *a, **kw: applied.append(
+                              fn.__name__,
+                          )):
+            ActorWatchApp._build_diff_worker.__wrapped__(app, 9, actor, 100)
+        self.assertEqual(applied, ["_apply_diff_text"])
+
+    def test_render_exception_routes_to_error_text(self):
+        """A render error mid-stream wipes the scroll and surfaces
+        "Diff error: ..." in its place. `_apply_diff_text` does the
+        remove_children itself, so partial appends don't linger above
+        the error message."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_build_token = 1
+
+        result = MagicMock()
+        result.files = self._make_files(2)
+        result.reason = ""
+
+        applied: list[tuple] = []
+
+        def boom(*_a, **_kw):
+            raise RuntimeError("kaboom")
+
+        with _stub_theme(), \
+             patch("actor.watch.app.read_head_oid", return_value="oid"), \
+             patch("actor.watch.app.compute_diff", return_value=result), \
+             patch("actor.watch.app.iter_diff_renderables",
+                   side_effect=boom), \
+             patch.object(app, "call_from_thread",
+                          side_effect=lambda fn, *a, **kw: applied.append(
+                              (fn.__name__, a),
+                          )):
+            ActorWatchApp._build_diff_worker.__wrapped__(app, 1, actor, 100)
+        names = [n for n, _a in applied]
+        self.assertEqual(names, ["_apply_diff_text"])
+        # Reason string includes the exception message.
+        self.assertIn("kaboom", applied[0][1][2])
+
+
+class ClearDetailCancelsStreamingTests(unittest.TestCase):
+    """Selecting nothing must wipe the diff and invalidate any
+    in-flight stream — bumping the token alone is enough; the
+    streaming worker's call_from_thread for the stale token is a
+    no-op via the `_diff_append_file` token check."""
+
+    def test_clear_detail_bumps_token_and_drops_pending(self):
+        app = _bare_app()
+        app._diff_build_token = 3
+        app._diff_build_pending = True
+        app._diff_streamed_token = 3
+        app._diff_last_applied_key = ("alice", "x", 100)
+        # _bare_app doesn't include the full DOM — substitute mocks
+        # for what `_clear_detail` queries.
+        info = MagicMock()
+        log = MagicMock()
+        log.lines = []
+        table = MagicMock()
+        scroll = MagicMock()
+
+        def query_one(selector, *_args):
+            if "info" in selector:
+                return info
+            if "logs" in selector:
+                return log
+            if "runs" in selector:
+                return table
+            return scroll
+
+        app._log_cursors = {}
+        with patch.object(app, "query_one", side_effect=query_one), \
+             patch.object(app, "_update_diff_tab_label"):
+            app._clear_detail()
+        self.assertEqual(app._diff_build_token, 4)
+        self.assertFalse(app._diff_build_pending)
+        self.assertIsNone(app._diff_last_applied_key)
+        # Subsequent `_diff_append_file` calls for the OLD token now
+        # fall through the stale-token guard.
+        scroll.reset_mock()
+        with patch.object(app, "query_one", return_value=scroll):
+            app._diff_append_file(token=3, file_path="x.py",
+                                  renderable=Text("x"))
+        scroll.mount.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -277,7 +277,9 @@ class ApplyDiffBuildTokenDiscardTests(unittest.TestCase):
             )
         self.assertEqual(app._diff_last_applied_key, ("alice", "deadbeef", 100))
         self.assertFalse(app._diff_build_pending)
-        self.assertIn("±7", app._tab_base_labels["diff"])
+        # New label shape: "DIFF +3 -4" (added 3, removed 4); colors live
+        # in segments. Assert on the plain text.
+        self.assertEqual(app._tab_base_labels["diff"].plain, "DIFF +3 -4")
 
     def test_apply_diff_text_drops_when_token_stale(self):
         app = _bare_app()
@@ -833,8 +835,9 @@ class ApplyDiffBadgeTests(unittest.TestCase):
         app._diff_badge_token = 7
         with patch.object(app, "_refresh_tab_arrows"):
             app._apply_diff_badge(token=7, added=5, removed=3)
-        # Label rendered with the combined ± total.
-        self.assertEqual(app._tab_base_labels["diff"], "DIFF (±8)")
+        # Label rendered with separate +/- spans (colors come from the
+        # theme; assert on the plain text shape).
+        self.assertEqual(app._tab_base_labels["diff"].plain, "DIFF +5 -3")
 
 
 class KickDiffBadgeTests(unittest.TestCase):
@@ -900,7 +903,7 @@ class BadgeBeforeBuildTests(unittest.TestCase):
         # Badge fires first.
         with patch.object(app, "_refresh_tab_arrows"):
             app._apply_diff_badge(token=1, added=12, removed=3)
-        self.assertEqual(app._tab_base_labels["diff"], "DIFF (±15)")
+        self.assertEqual(app._tab_base_labels["diff"].plain, "DIFF +12 -3")
         # Build path's token is untouched — it can still land.
         self.assertEqual(app._diff_build_token, 1)
         self.assertTrue(app._diff_build_pending)
@@ -916,7 +919,7 @@ class BadgeBeforeBuildTests(unittest.TestCase):
                 total_added=14,  # diverges from badge's 12 (untracked)
                 total_removed=3,
             )
-        self.assertEqual(app._tab_base_labels["diff"], "DIFF (±17)")
+        self.assertEqual(app._tab_base_labels["diff"].plain, "DIFF +14 -3")
         self.assertFalse(app._diff_build_pending)
 
 

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -1,17 +1,32 @@
-"""Stage-1 logs-pattern parity for the watch DIFF tab.
+"""Stage-1 + Stage-2 tests for the watch DIFF tab.
 
-Covers cancellation, token discard, hidden-tab stash + flush, and
-width-aware cache invalidation. Mirrors the patterns the logs view
-already uses; see `actor.watch.log_renderer` and the `_kick_log_build`
-state machine in `actor.watch.app` for the reference implementation."""
+Stage 1 — logs-pattern parity: cancellation, token discard, hidden-tab
+stash + flush, width-aware cache invalidation. Mirrors the patterns
+the logs view already uses; see `actor.watch.log_renderer` and the
+`_kick_log_build` state machine in `actor.watch.app`.
+
+Stage 2 — batched git invocations: `compute_diff` collapses N+5
+subprocess spawns into a constant ≤4 regardless of file count, and
+parsed ± counts ride through `FileDiff.added` / `removed` so the
+renderer doesn't re-run difflib just to label the tab."""
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from actor.watch.app import ActorWatchApp
 from actor.watch.diff_render import build_diff_renderables
-from actor.watch.helpers import FileDiff
+from actor.watch.helpers import (
+    FileDiff,
+    _git_cat_file_batch,
+    _parse_diff_files,
+    compute_diff,
+)
 
 
 def _bare_app() -> ActorWatchApp:
@@ -333,6 +348,358 @@ class WorkerCancellationTests(unittest.TestCase):
             )
         compute.assert_not_called()
         cft.assert_not_called()
+
+
+# -- Stage 2: batched git invocations ---------------------------------------
+
+
+def _git(*args: str, cwd: str) -> subprocess.CompletedProcess:
+    """Run a git subprocess in `cwd`, raise on failure. Configured to
+    skip the user's commit signing / hooks so the temp repo doesn't
+    inherit machine-specific git config."""
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd, env=env, check=True,
+        capture_output=True, text=True,
+    )
+
+
+def _build_repo(n_files: int) -> str:
+    """Create a temporary git repo with `n_files` files committed and
+    then modified in the working tree. Returns the worktree path. The
+    caller is responsible for cleanup."""
+    tmp = tempfile.mkdtemp(prefix="actor-diff-stress-")
+    _git("init", "-q", "-b", "main", tmp, cwd=tmp)
+    for i in range(n_files):
+        Path(tmp, f"file_{i:03d}.txt").write_text(f"old content {i}\nline 2\n")
+    _git("add", "-A", cwd=tmp)
+    _git("commit", "-q", "-m", "initial", cwd=tmp)
+    # Modify every file so all show up in the merge-base diff.
+    for i in range(n_files):
+        Path(tmp, f"file_{i:03d}.txt").write_text(f"new content {i}\nline 2\n")
+    return tmp
+
+
+def _fake_actor_for_repo(tmp: str) -> MagicMock:
+    a = MagicMock()
+    a.dir = tmp
+    a.base_branch = "main"
+    a.name = "stress"
+    return a
+
+
+class _SubprocessCounter:
+    """Wraps the real `subprocess` module and records every spawn the
+    helpers module triggers via `subprocess.run` / `subprocess.Popen`.
+
+    Patching the module-attribute (e.g. ``subprocess.run``) directly
+    has a nasty interaction: ``subprocess.run`` internally calls
+    ``Popen`` through the same module object, so a patched run + a
+    patched Popen would each record one extra call per `run`. This
+    wrapper sidesteps that by replacing the entire `subprocess`
+    reference inside `actor.watch.helpers` — only that module's
+    explicit calls get recorded; the implementation-detail Popen
+    calls inside the real `subprocess.run` are unaffected."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.PIPE = subprocess.PIPE
+
+    def run(self, args, *a, **kw):
+        self.calls.append(list(args))
+        return subprocess.run(args, *a, **kw)
+
+    def Popen(self, args, *a, **kw):
+        self.calls.append(list(args))
+        return subprocess.Popen(args, *a, **kw)
+
+
+class ComputeDiffSubprocessCountTests(unittest.TestCase):
+    """The whole point of Stage 2: subprocess count is bounded
+    regardless of how many files changed. Each test below spawns a
+    real temp git repo so the parser + cat-file batch are exercised
+    end-to-end against actual git output, not a hand-rolled fixture."""
+
+    def test_50_file_diff_uses_bounded_subprocess_count(self):
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = _build_repo(n_files=50)
+        try:
+            actor = _fake_actor_for_repo(tmp)
+            counter = _SubprocessCounter()
+            with patch("actor.watch.helpers.subprocess", counter):
+                result = compute_diff(actor)
+
+            # Acceptance bar from the plan: ~3 git calls plus 1
+            # ls-files. Stage 2 hits exactly four for a tracked-only
+            # diff:
+            #   1. git merge-base
+            #   2. git diff --no-color <base>
+            #   3. git ls-files --others --exclude-standard
+            #   4. git cat-file --batch
+            self.assertLessEqual(
+                len(counter.calls), 4,
+                f"compute_diff spawned {len(counter.calls)} "
+                f"subprocesses for 50 files; commands were "
+                f"{counter.calls!r}",
+            )
+            # cat-file was the one that used to scale with N — make
+            # sure it's now a single call.
+            cat_file_calls = [
+                c for c in counter.calls if c[:2] == ["git", "cat-file"]
+            ]
+            self.assertEqual(
+                len(cat_file_calls), 1,
+                f"expected a single cat-file batch; got {cat_file_calls!r}",
+            )
+            # Result is correct — every modified file shows up with
+            # ± counts pulled straight from git diff (no extra
+            # difflib pass).
+            self.assertIsNotNone(result.files)
+            self.assertEqual(len(result.files), 50)
+            for fd in result.files:
+                self.assertEqual(fd.added, 1)
+                self.assertEqual(fd.removed, 1)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_pure_untracked_skips_cat_file_batch(self):
+        """No tracked changes → no old-content reads needed → no
+        cat-file invocation. Bounded above by 3 subprocesses."""
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = tempfile.mkdtemp(prefix="actor-diff-untracked-")
+        try:
+            _git("init", "-q", "-b", "main", tmp, cwd=tmp)
+            Path(tmp, "seed.txt").write_text("seed\n")
+            _git("add", "-A", cwd=tmp)
+            _git("commit", "-q", "-m", "seed", cwd=tmp)
+            for i in range(10):
+                Path(tmp, f"new_{i}.txt").write_text(f"hi {i}\n")
+            actor = _fake_actor_for_repo(tmp)
+
+            counter = _SubprocessCounter()
+            with patch("actor.watch.helpers.subprocess", counter):
+                result = compute_diff(actor)
+
+            cat_file_calls = [
+                c for c in counter.calls if c[:2] == ["git", "cat-file"]
+            ]
+            self.assertEqual(
+                cat_file_calls, [],
+                "no tracked changes → cat-file --batch shouldn't run",
+            )
+            self.assertLessEqual(len(counter.calls), 3)
+            self.assertIsNotNone(result.files)
+            self.assertEqual(len(result.files), 10)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+class ParseDiffFilesTests(unittest.TestCase):
+    """Per-file metadata extraction from `git diff --no-color` output.
+    Drives the ± counts that ride through FileDiff into the renderer."""
+
+    def test_modified_file_counts(self):
+        diff = (
+            "diff --git a/foo.py b/foo.py\n"
+            "index abc..def 100644\n"
+            "--- a/foo.py\n"
+            "+++ b/foo.py\n"
+            "@@ -1,3 +1,4 @@\n"
+            " ctx\n"
+            "-removed\n"
+            "+added one\n"
+            "+added two\n"
+        )
+        files = _parse_diff_files(diff)
+        self.assertEqual(len(files), 1)
+        self.assertEqual(files[0]["path"], "foo.py")
+        self.assertEqual(files[0]["added"], 2)
+        self.assertEqual(files[0]["removed"], 1)
+        self.assertFalse(files[0]["is_new"])
+        self.assertFalse(files[0]["is_deleted"])
+        self.assertFalse(files[0]["is_binary"])
+
+    def test_new_file(self):
+        diff = (
+            "diff --git a/new.py b/new.py\n"
+            "new file mode 100644\n"
+            "index 0000000..abc\n"
+            "--- /dev/null\n"
+            "+++ b/new.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+line one\n"
+            "+line two\n"
+        )
+        files = _parse_diff_files(diff)
+        self.assertEqual(len(files), 1)
+        self.assertTrue(files[0]["is_new"])
+        self.assertEqual(files[0]["added"], 2)
+        self.assertEqual(files[0]["removed"], 0)
+        self.assertEqual(files[0]["path"], "new.py")
+
+    def test_deleted_file(self):
+        diff = (
+            "diff --git a/gone.py b/gone.py\n"
+            "deleted file mode 100644\n"
+            "index abc..0000000\n"
+            "--- a/gone.py\n"
+            "+++ /dev/null\n"
+            "@@ -1,2 +0,0 @@\n"
+            "-bye\n"
+            "-bye again\n"
+        )
+        files = _parse_diff_files(diff)
+        self.assertEqual(len(files), 1)
+        self.assertTrue(files[0]["is_deleted"])
+        self.assertEqual(files[0]["removed"], 2)
+        # The path lives on `--- a/...` for deletes — used to look up
+        # the merge-base content via cat-file.
+        self.assertEqual(files[0]["path"], "gone.py")
+
+    def test_binary_file_marked_no_counts(self):
+        diff = (
+            "diff --git a/img.png b/img.png\n"
+            "index abc..def 100644\n"
+            "Binary files a/img.png and b/img.png differ\n"
+        )
+        files = _parse_diff_files(diff)
+        self.assertEqual(len(files), 1)
+        self.assertTrue(files[0]["is_binary"])
+        self.assertEqual(files[0]["added"], 0)
+        self.assertEqual(files[0]["removed"], 0)
+
+    def test_multiple_hunks_aggregate(self):
+        diff = (
+            "diff --git a/multi.py b/multi.py\n"
+            "--- a/multi.py\n"
+            "+++ b/multi.py\n"
+            "@@ -1,2 +1,2 @@\n"
+            "-a\n"
+            "+a2\n"
+            "@@ -10,2 +10,3 @@\n"
+            " ctx\n"
+            "+b\n"
+            "+c\n"
+        )
+        files = _parse_diff_files(diff)
+        self.assertEqual(files[0]["added"], 3)
+        self.assertEqual(files[0]["removed"], 1)
+
+    def test_no_newline_marker_ignored(self):
+        diff = (
+            "diff --git a/x.txt b/x.txt\n"
+            "--- a/x.txt\n"
+            "+++ b/x.txt\n"
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "\\ No newline at end of file\n"
+            "+new\n"
+            "\\ No newline at end of file\n"
+        )
+        files = _parse_diff_files(diff)
+        self.assertEqual(files[0]["added"], 1)
+        self.assertEqual(files[0]["removed"], 1)
+
+
+class GitCatFileBatchTests(unittest.TestCase):
+    """One cat-file --batch call satisfies all old-content reads.
+    Round-trip with a real git invocation to keep the protocol-parsing
+    honest — easy to break in subtle ways without an integration test."""
+
+    def test_batch_returns_contents_for_existing_refs(self):
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = tempfile.mkdtemp(prefix="actor-cat-file-")
+        try:
+            _git("init", "-q", "-b", "main", tmp, cwd=tmp)
+            Path(tmp, "a.txt").write_text("alpha\n")
+            Path(tmp, "b.txt").write_text("bravo\nbravo2\n")
+            _git("add", "-A", cwd=tmp)
+            _git("commit", "-q", "-m", "seed", cwd=tmp)
+            head = _git("rev-parse", "HEAD", cwd=tmp).stdout.strip()
+
+            contents = _git_cat_file_batch(
+                [f"{head}:a.txt", f"{head}:b.txt"], tmp,
+            )
+            self.assertEqual(contents[f"{head}:a.txt"], "alpha\n")
+            self.assertEqual(contents[f"{head}:b.txt"], "bravo\nbravo2\n")
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_missing_ref_returns_empty_string(self):
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = tempfile.mkdtemp(prefix="actor-cat-file-missing-")
+        try:
+            _git("init", "-q", "-b", "main", tmp, cwd=tmp)
+            Path(tmp, "real.txt").write_text("real\n")
+            _git("add", "-A", cwd=tmp)
+            _git("commit", "-q", "-m", "seed", cwd=tmp)
+            head = _git("rev-parse", "HEAD", cwd=tmp).stdout.strip()
+
+            contents = _git_cat_file_batch(
+                [f"{head}:real.txt", f"{head}:does-not-exist.txt"], tmp,
+            )
+            self.assertEqual(contents[f"{head}:real.txt"], "real\n")
+            # Missing refs map to "" — used for new files in the
+            # tracked diff, where the merge-base side has no blob.
+            self.assertEqual(contents[f"{head}:does-not-exist.txt"], "")
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_empty_input_no_subprocess(self):
+        with patch("actor.watch.helpers.subprocess.Popen") as p:
+            result = _git_cat_file_batch([], "/tmp")
+        self.assertEqual(result, {})
+        p.assert_not_called()
+
+
+class FileDiffCountsPlumbingTests(unittest.TestCase):
+    """Stage 2 plumbs ± counts from `git diff` parse → FileDiff →
+    build_diff_renderables, skipping the duplicate difflib pass."""
+
+    def test_explicit_counts_take_precedence_over_fallback(self):
+        # If caller passes counts, they're used verbatim — even when
+        # they contradict the contents (e.g. a synthetic test fixture).
+        fd = FileDiff(
+            "x.py", old_content="a\nb\n", new_content="a\nb\nc\n",
+            added=99, removed=88,
+        )
+        self.assertEqual(fd.added, 99)
+        self.assertEqual(fd.removed, 88)
+
+    def test_missing_counts_fall_back_to_difflib(self):
+        # Backwards-compat: callers (incl. the Stage-1 test helpers)
+        # that didn't pre-compute counts get them computed from the
+        # contents, so the FileDiff API stays usable in tests and ad-hoc
+        # debug scripts.
+        fd = FileDiff("x.py", old_content="a\nb\n", new_content="a\nc\n")
+        self.assertEqual(fd.added, 1)
+        self.assertEqual(fd.removed, 1)
+
+    def test_build_uses_filediff_counts_not_content(self):
+        """Renderer must trust FileDiff.added/removed and not re-derive
+        them. Use mismatched counts to prove no re-derivation."""
+        fd = FileDiff(
+            "x.py", old_content="a\n", new_content="b\n",
+            # Lying counts — content shows +1/-1 but we report
+            # +5/-3. The renderer must surface the reported numbers.
+            added=5, removed=3,
+        )
+        result = build_diff_renderables([fd], dark=True)
+        self.assertIsNotNone(result)
+        _parts, total_added, total_removed = result
+        self.assertEqual(total_added, 5)
+        self.assertEqual(total_removed, 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -26,6 +26,8 @@ from actor.watch.helpers import (
     _git_cat_file_batch,
     _parse_diff_files,
     compute_diff,
+    compute_diff_shortstat,
+    parse_shortstat,
 )
 
 
@@ -43,6 +45,8 @@ def _bare_app() -> ActorWatchApp:
     app._diff_build_target_width = 0
     app._diff_last_applied_key = None
     app._diff_pending_actor = None
+    app._diff_badge_token = 0
+    app._diff_badge_target_actor = None
     app._current_actors = []
     app._tab_base_labels = {
         "logs": "LIVE", "diff": "DIFF",
@@ -700,6 +704,238 @@ class FileDiffCountsPlumbingTests(unittest.TestCase):
         _parts, total_added, total_removed = result
         self.assertEqual(total_added, 5)
         self.assertEqual(total_removed, 3)
+
+
+# -- Stage 3: cheap-badge-first ----------------------------------------------
+
+
+class ParseShortstatTests(unittest.TestCase):
+    """`git diff --shortstat` summary line parser. Drives the
+    near-instant DIFF (±N) badge so the user sees diff size before
+    the full render commits."""
+
+    def test_modifications(self):
+        line = " 3 files changed, 7 insertions(+), 2 deletions(-)\n"
+        self.assertEqual(parse_shortstat(line), (7, 2))
+
+    def test_only_insertions(self):
+        line = " 1 file changed, 1 insertion(+)\n"
+        self.assertEqual(parse_shortstat(line), (1, 0))
+
+    def test_only_deletions(self):
+        line = " 1 file changed, 1 deletion(-)\n"
+        self.assertEqual(parse_shortstat(line), (0, 1))
+
+    def test_empty_input(self):
+        self.assertEqual(parse_shortstat(""), (0, 0))
+
+    def test_garbled_input_returns_zeros(self):
+        # The badge is best-effort — a malformed line shouldn't crash
+        # the worker, just produce zeros.
+        self.assertEqual(parse_shortstat("nonsense\n"), (0, 0))
+
+
+class ComputeDiffShortstatTests(unittest.TestCase):
+    """End-to-end: shortstat against a real temp repo. Verifies the
+    two-subprocess path (merge-base + shortstat) returns the right
+    counts for a working-tree diff."""
+
+    def test_returns_added_removed_for_modified_files(self):
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = _build_repo(n_files=5)
+        try:
+            actor = _fake_actor_for_repo(tmp)
+            counts = compute_diff_shortstat(actor)
+            self.assertEqual(counts, (5, 5))  # 1 add + 1 del per file
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_returns_zeros_when_no_changes(self):
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = tempfile.mkdtemp(prefix="actor-shortstat-clean-")
+        try:
+            _git("init", "-q", "-b", "main", tmp, cwd=tmp)
+            Path(tmp, "seed.txt").write_text("seed\n")
+            _git("add", "-A", cwd=tmp)
+            _git("commit", "-q", "-m", "seed", cwd=tmp)
+            actor = _fake_actor_for_repo(tmp)
+            counts = compute_diff_shortstat(actor)
+            self.assertEqual(counts, (0, 0))
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_returns_none_when_not_a_repo(self):
+        tmp = tempfile.mkdtemp(prefix="actor-shortstat-notrepo-")
+        try:
+            actor = MagicMock()
+            actor.dir = tmp
+            actor.base_branch = "main"
+            actor.name = "x"
+            self.assertIsNone(compute_diff_shortstat(actor))
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+class ApplyDiffBadgeTests(unittest.TestCase):
+    """Token discipline mirrors the build apply path: stale badge
+    workers (whose token was superseded by a newer kick) drop their
+    output silently."""
+
+    def test_apply_diff_badge_drops_when_token_stale(self):
+        app = _bare_app()
+        app._diff_badge_token = 5
+        # Older worker calls back with a stale token; nothing happens.
+        with patch.object(app, "_update_diff_tab_label") as upd:
+            app._apply_diff_badge(token=3, added=10, removed=2)
+        upd.assert_not_called()
+
+    def test_apply_diff_badge_updates_label_when_token_matches(self):
+        app = _bare_app()
+        app._diff_badge_token = 7
+        with patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_badge(token=7, added=5, removed=3)
+        # Label rendered with the combined ± total.
+        self.assertEqual(app._tab_base_labels["diff"], "DIFF (±8)")
+
+
+class KickDiffBadgeTests(unittest.TestCase):
+    """The badge kick is independent of the build kick — it fires
+    even when DIFF is hidden, doesn't depend on widget width, and
+    bumps its own token counter."""
+
+    def test_kick_bumps_token_and_starts_worker(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        with patch.object(app, "_build_diff_badge_worker") as worker:
+            app._kick_diff_badge(actor)
+        self.assertEqual(app._diff_badge_token, 1)
+        self.assertEqual(app._diff_badge_target_actor, "alice")
+        worker.assert_called_once()
+        args, _kwargs = worker.call_args
+        self.assertEqual(args[0], 1)
+        self.assertIs(args[1], actor)
+
+    def test_kick_fires_even_when_diff_pane_hidden(self):
+        """The badge sits in the always-visible tabs bar, so it must
+        update independently of which tab is currently active."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        # Simulate hidden DIFF pane (width 0) — Stage 1's build kick
+        # would stash. The badge kick MUST NOT consult widget width.
+        with patch.object(app, "query_one",
+                          return_value=_scroll_with_width(0)), \
+             patch.object(app, "_build_diff_badge_worker") as worker:
+            app._kick_diff_badge(actor)
+        worker.assert_called_once()
+
+
+class BadgeBeforeBuildTests(unittest.TestCase):
+    """Acceptance bar from the plan: badge appears before the full
+    build commits. Both paths fire from the same kick; their
+    completion ordering is independent (worker → main-thread apply
+    via call_from_thread)."""
+
+    def test_maybe_refresh_diff_kicks_both_paths(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        tree = MagicMock()
+        tree.selected_actor = actor
+        with patch.object(app, "query_one", return_value=tree), \
+             patch.object(app, "_kick_diff_badge") as badge_kick, \
+             patch.object(app, "_kick_diff_build") as build_kick:
+            app._maybe_refresh_diff()
+        badge_kick.assert_called_once_with(actor)
+        build_kick.assert_called_once_with(actor)
+
+    def test_badge_apply_can_land_before_build_apply(self):
+        """Their tokens are independent counters, so a fast badge
+        worker committing first doesn't bump the build token. The
+        build's later apply still has its token intact and lands."""
+        app = _bare_app()
+        # Both paths kicked together.
+        app._diff_badge_token = 1
+        app._diff_build_token = 1
+        app._diff_build_pending = True
+
+        # Badge fires first.
+        with patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_badge(token=1, added=12, removed=3)
+        self.assertEqual(app._tab_base_labels["diff"], "DIFF (±15)")
+        # Build path's token is untouched — it can still land.
+        self.assertEqual(app._diff_build_token, 1)
+        self.assertTrue(app._diff_build_pending)
+
+        # Build commits later with its own counts. Last write wins;
+        # the build's number is authoritative (e.g. it includes
+        # untracked files that shortstat misses).
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_build(
+                token=1,
+                cache_key=("alice", "deadbeef", 100),
+                parts=[],
+                total_added=14,  # diverges from badge's 12 (untracked)
+                total_removed=3,
+            )
+        self.assertEqual(app._tab_base_labels["diff"], "DIFF (±17)")
+        self.assertFalse(app._diff_build_pending)
+
+
+class BadgeWorkerCancellationTests(unittest.TestCase):
+    """Newer kicks supersede older badge workers via the token. The
+    worker checks its token both before and after the subprocess
+    work so a stale result never reaches the apply step."""
+
+    def test_worker_bails_when_token_advances_before_shortstat(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        # Newer kick already advanced the token.
+        app._diff_badge_token = 99
+        with patch("actor.watch.app.compute_diff_shortstat") as ss, \
+             patch.object(app, "call_from_thread") as cft:
+            ActorWatchApp._build_diff_badge_worker.__wrapped__(
+                app, 1, actor,  # stale token = 1, current = 99
+            )
+        ss.assert_not_called()
+        cft.assert_not_called()
+
+    def test_worker_bails_when_token_advances_after_shortstat(self):
+        """Token can advance during the subprocess call — a faster
+        kick from a tab activation, for example. The post-shortstat
+        check must catch that."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_badge_token = 1
+        # compute_diff_shortstat returns counts but in the meantime a
+        # newer kick bumped the token.
+        def shortstat_then_advance(_actor):
+            app._diff_badge_token = 2
+            return (5, 3)
+        with patch("actor.watch.app.compute_diff_shortstat",
+                   side_effect=shortstat_then_advance), \
+             patch.object(app, "call_from_thread") as cft:
+            ActorWatchApp._build_diff_badge_worker.__wrapped__(
+                app, 1, actor,
+            )
+        cft.assert_not_called()
+
+    def test_worker_skips_apply_when_shortstat_returns_none(self):
+        """compute_diff_shortstat returns None on git failure (no
+        repo, missing base, etc.) — the worker just returns rather
+        than committing zeros, leaving any prior badge intact."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_badge_token = 1
+        with patch("actor.watch.app.compute_diff_shortstat",
+                   return_value=None), \
+             patch.object(app, "call_from_thread") as cft:
+            ActorWatchApp._build_diff_badge_worker.__wrapped__(
+                app, 1, actor,
+            )
+        cft.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -2042,5 +2042,273 @@ class GitCatFileBatchCleanupTests(unittest.TestCase):
         cm_mock.__exit__.assert_called_once()
 
 
+# -- CR-loop fixes Round 2 ---------------------------------------------------
+
+
+class InteractivePollEligibilityTests(unittest.TestCase):
+    """`Status.INTERACTIVE` is a display-only overlay applied to
+    actors with a live interactive session; under the hood they're
+    typically also RUNNING. Excluding them from live-poll eligibility
+    silently disables the live diff refresh for one of the most common
+    use cases — a user driving an agent interactively and watching its
+    edits land. Both states must qualify."""
+
+    def test_interactive_status_is_eligible_for_polling(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._prev_statuses = {"alice": Status.INTERACTIVE}
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="diff",
+            ),
+        ):
+            self.assertIs(app._diff_poll_actor(), actor)
+
+    def test_done_status_is_not_eligible(self):
+        """Sanity: only RUNNING and INTERACTIVE qualify; idle/done
+        actors don't get auto-refresh (their worktree shouldn't be
+        changing)."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._prev_statuses = {"alice": Status.DONE}
+        with patch.object(
+            app, "query_one",
+            side_effect=_stub_diff_poll_dom(
+                app, selected_actor=actor, active_tab="diff",
+            ),
+        ):
+            self.assertIsNone(app._diff_poll_actor())
+
+
+class ComputeDiffErrorRoutingTests(unittest.TestCase):
+    """`compute_diff` returns `DiffResult(reason="error")` on
+    catch-all failures. That path must NOT cache the result —
+    otherwise a transient git failure poisons the cache and locks
+    the user out of retries until HEAD or width changes. The worker
+    routes "error" reasons through `_apply_diff_error` (which
+    invalidates the cache key); benign reasons still go through
+    `_apply_diff_text` (which caches)."""
+
+    def test_error_reason_routes_to_apply_diff_error(self):
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_build_token = 3
+
+        result = MagicMock()
+        result.files = None
+        result.reason = "error"
+
+        applied: list[tuple] = []
+        with patch("actor.watch.app.read_head_oid", return_value="oid"), \
+             patch("actor.watch.app.compute_diff", return_value=result), \
+             patch.object(app, "call_from_thread",
+                          side_effect=lambda fn, *a, **kw: applied.append(
+                              (fn.__name__, a),
+                          )):
+            ActorWatchApp._build_diff_worker.__wrapped__(
+                app, 3, actor, 100, False,
+            )
+        names = [n for n, _a in applied]
+        self.assertEqual(names, ["_apply_diff_error"])
+
+    def test_benign_reason_still_routes_to_apply_diff_text(self):
+        """Sanity: non-error reasons (e.g. "working tree clean",
+        "no repository") still cache via `_apply_diff_text`."""
+        app = _bare_app()
+        actor = _fake_actor("alice")
+        app._diff_build_token = 3
+
+        result = MagicMock()
+        result.files = None
+        result.reason = "working tree clean"
+
+        applied: list[tuple] = []
+        with patch("actor.watch.app.read_head_oid", return_value="oid"), \
+             patch("actor.watch.app.compute_diff", return_value=result), \
+             patch.object(app, "call_from_thread",
+                          side_effect=lambda fn, *a, **kw: applied.append(
+                              (fn.__name__, a),
+                          )):
+            ActorWatchApp._build_diff_worker.__wrapped__(
+                app, 3, actor, 100, False,
+            )
+        names = [n for n, _a in applied]
+        self.assertEqual(names, ["_apply_diff_text"])
+
+
+class PureRenameStillVisibleTests(unittest.TestCase):
+    """A rename with similarity=100% has identical content on both
+    sides. The previous `if old != new: append` filter dropped these
+    silently, leading the diff view to display "working tree clean"
+    when the user can plainly see in `git status` that something
+    changed. Renames must still surface as a FileDiff entry."""
+
+    def test_pure_rename_appears_in_compute_diff(self):
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = tempfile.mkdtemp(prefix="actor-rename-pure-")
+        try:
+            _git("init", "-q", "-b", "main", tmp, cwd=tmp)
+            seed = "\n".join(f"line {i}" for i in range(10)) + "\n"
+            Path(tmp, "old.py").write_text(seed)
+            _git("add", "-A", cwd=tmp)
+            _git("commit", "-q", "-m", "seed", cwd=tmp)
+            # Pure rename — git mv with no content modification.
+            _git("mv", "old.py", "new.py", cwd=tmp)
+            actor = _fake_actor_for_repo(tmp)
+            result = compute_diff(actor)
+            self.assertIsNotNone(
+                result.files,
+                f"pure rename should surface in the diff (reason={result.reason!r})",
+            )
+            self.assertEqual(len(result.files), 1)
+            fd = result.files[0]
+            self.assertEqual(fd.file_path, "new.py")
+            # Content matches on both sides for a pure rename.
+            self.assertEqual(fd.old_content, fd.new_content)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+class BuildInvalidatesBadgeTokenTests(unittest.TestCase):
+    """The build's count is authoritative (it includes untracked
+    files; shortstat doesn't). When a build commits its label, any
+    in-flight badge worker from the same kick must be invalidated
+    so it can't later overwrite with a smaller, less-correct count."""
+
+    def test_apply_diff_build_done_bumps_badge_token(self):
+        app = _bare_app()
+        app._diff_build_token = 5
+        app._diff_badge_token = 5
+        with patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_build_done(
+                token=5,
+                cache_key=("alice", "oid", 100),
+                total_added=10,
+                total_removed=2,
+            )
+        # Badge token bumped past 5 → any in-flight badge worker
+        # whose `_apply_diff_badge(token=5, ...)` arrives later
+        # will see a token mismatch and skip.
+        self.assertGreater(app._diff_badge_token, 5)
+
+    def test_apply_diff_text_bumps_badge_token(self):
+        """Same guard for the cacheable text-mount path: an
+        in-flight badge worker shouldn't overwrite a 'working tree
+        clean' label with a shortstat-derived count."""
+        app = _bare_app()
+        app._diff_build_token = 5
+        app._diff_badge_token = 5
+        scroll = _scroll_with_width(100)
+        with patch.object(app, "query_one", return_value=scroll), \
+             patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_text(
+                token=5,
+                cache_key=("alice", "oid", 100),
+                text="working tree clean",
+            )
+        self.assertGreater(app._diff_badge_token, 5)
+
+    def test_late_badge_drops_after_build_apply(self):
+        """End-to-end: build commits first, then a late-arriving
+        badge for the same kick is rejected by the token check
+        rather than clobbering the build's label."""
+        app = _bare_app()
+        app._diff_build_token = 5
+        app._diff_badge_token = 5
+
+        # Build applies first with authoritative count.
+        with patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_build_done(
+                token=5,
+                cache_key=("alice", "oid", 100),
+                total_added=12,
+                total_removed=3,
+            )
+        # The label is a Rich Text using the green +N / red -N pill
+        # style (a Stage-3 follow-up); the displayed numbers come
+        # from `total_added` / `total_removed`.
+        label_after_build = str(app._tab_base_labels["diff"])
+        self.assertIn("+12", label_after_build)
+        self.assertIn("-3", label_after_build)
+
+        # Late badge from the same kick (token=5) tries to apply
+        # with shortstat-only count (e.g. missing untracked).
+        # It must be dropped — its token is now stale because the
+        # build apply bumped `_diff_badge_token`.
+        with patch.object(app, "_refresh_tab_arrows"):
+            app._apply_diff_badge(token=5, added=8, removed=3)
+        # Label still reflects the build's authoritative count,
+        # not the badge's smaller one.
+        label_after_badge = str(app._tab_base_labels["diff"])
+        self.assertIn("+12", label_after_badge)
+        self.assertNotIn("+8", label_after_badge)
+
+
+class GitLocaleEnvTests(unittest.TestCase):
+    """`compute_diff` and `compute_diff_shortstat` parse stderr
+    looking for "fatal: not a git repository". Under non-English
+    locales (`LC_MESSAGES=de_DE.UTF-8`, etc.) git emits translated
+    messages and the substring check fails. Pinning `LC_ALL=C` on
+    every git invocation that we read stderr from keeps the
+    detection robust."""
+
+    def test_compute_diff_passes_lc_all_c(self):
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = _build_repo(n_files=1)
+        try:
+            actor = _fake_actor_for_repo(tmp)
+            captured_envs: list = []
+            real_run = subprocess.run
+
+            def capture(args, *a, **kw):
+                captured_envs.append(kw.get("env"))
+                return real_run(args, *a, **kw)
+
+            with patch("actor.watch.helpers.subprocess.run",
+                       side_effect=capture):
+                compute_diff(actor)
+            # At least one git call carried `LC_ALL=C`.
+            self.assertTrue(
+                any(
+                    env is not None and env.get("LC_ALL") == "C"
+                    for env in captured_envs
+                ),
+                f"expected at least one git call with LC_ALL=C; "
+                f"got envs {[e and e.get('LC_ALL') for e in captured_envs]!r}",
+            )
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_compute_diff_shortstat_passes_lc_all_c(self):
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        tmp = _build_repo(n_files=1)
+        try:
+            actor = _fake_actor_for_repo(tmp)
+            captured_envs: list = []
+            real_run = subprocess.run
+
+            def capture(args, *a, **kw):
+                captured_envs.append(kw.get("env"))
+                return real_run(args, *a, **kw)
+
+            with patch("actor.watch.helpers.subprocess.run",
+                       side_effect=capture):
+                compute_diff_shortstat(actor)
+            self.assertTrue(
+                all(
+                    env is not None and env.get("LC_ALL") == "C"
+                    for env in captured_envs
+                ),
+                f"every shortstat git call should carry LC_ALL=C; "
+                f"got envs {[e and e.get('LC_ALL') for e in captured_envs]!r}",
+            )
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_prerendered_diff.py
+++ b/tests/test_prerendered_diff.py
@@ -1,0 +1,100 @@
+"""Tests for the off-thread renderable→Strips path.
+
+The diff worker calls `renderable_to_strips` to push the CPU-bound
+Segment-generation step out of the main thread. The mounted
+`PrerenderedDiff` widget then serves those Strips via a constant-time
+array index, so painting is effectively free per file.
+"""
+from __future__ import annotations
+
+import unittest
+
+from rich.segment import Segment
+from rich.text import Text
+from textual.geometry import Size
+from textual.strip import Strip
+
+from actor.watch.prerendered_diff import (
+    PrerenderedDiff,
+    renderable_to_strips,
+)
+
+
+class RenderableToStripsTests(unittest.TestCase):
+    def test_zero_width_returns_empty_list(self):
+        self.assertEqual(renderable_to_strips(Text("hi"), 0), [])
+
+    def test_single_line_yields_one_strip(self):
+        strips = renderable_to_strips(Text("hello"), 80)
+        # One source line → one Strip. (Rich appends one trailing
+        # \n in render output that becomes a separator, so we
+        # tolerate either 1 or 2 strips depending on render shape;
+        # the important thing is "hello" survives intact in the
+        # first non-empty strip.)
+        self.assertGreaterEqual(len(strips), 1)
+        text = "".join(seg.text for seg in strips[0]).rstrip()
+        self.assertIn("hello", text)
+
+    def test_multiline_yields_multiple_strips(self):
+        strips = renderable_to_strips(Text("line one\nline two\nline three"), 80)
+        joined = [
+            "".join(seg.text for seg in s).rstrip()
+            for s in strips
+        ]
+        # Accept any non-empty trailing strip; primary content must
+        # appear in order.
+        non_empty = [line for line in joined if line]
+        self.assertEqual(non_empty[:3], ["line one", "line two", "line three"])
+
+    def test_styled_text_preserves_colors_in_segments(self):
+        # Hex colors must survive — downgrading to ANSI-256 would
+        # round to nearest, shifting the diff palette.
+        styled = Text("colored", style="#ff0000 on #001122")
+        strips = renderable_to_strips(styled, 80)
+        # First strip should contain at least one segment with the
+        # original color encoded.
+        first = strips[0]
+        styles = [seg.style for seg in first if seg.style is not None]
+        self.assertTrue(
+            any(
+                s.color is not None and s.color.triplet is not None
+                and (s.color.triplet.red, s.color.triplet.green,
+                     s.color.triplet.blue) == (255, 0, 0)
+                for s in styles
+            ),
+            f"expected (255, 0, 0) RGB in styles {styles!r}",
+        )
+
+
+class PrerenderedDiffWidgetTests(unittest.TestCase):
+    """The widget's render-side contract: render_line returns the
+    pre-baked strip; height matches strip count + 1 trailing blank."""
+
+    def _make(self, n: int) -> PrerenderedDiff:
+        strips = [Strip([Segment(f"line {i}")]) for i in range(n)]
+        return PrerenderedDiff(strips)
+
+    def test_get_content_height_matches_strip_count_plus_separator(self):
+        w = self._make(5)
+        # +1 for the trailing blank separator the widget appends.
+        self.assertEqual(
+            w.get_content_height(Size(100, 100), Size(100, 100), 100),
+            6,
+        )
+
+    def test_render_line_returns_indexed_strip(self):
+        w = self._make(3)
+        strip = w.render_line(1)
+        self.assertEqual(strip._segments[0].text, "line 1")
+
+    def test_render_line_out_of_range_returns_blank(self):
+        w = self._make(2)
+        # Past the trailing separator → blank.
+        strip = w.render_line(99)
+        # Strip.blank produces a Strip whose text content is empty
+        # (or whitespace) at the requested width.
+        self.assertEqual("".join(seg.text for seg in strip).strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Brings the watch DIFF pane up to parity with the LIVE/logs pane and beyond. No more main-thread hangs on tab activation; cooperative cancellation + cache + per-file streaming + an instant tab badge.

Plan lived in `Work/plans/actor.sh/Diff view optimization.md` (Obsidian).

## Stages

1. **Logs-pattern parity** (`b5aab85`) — split `_refresh_diff` into `_kick_diff_build` + `_build_diff_worker` + `_apply_diff_build_done`. Cancellation token, 300ms `Loading diff...` placeholder, `(actor.name, head_oid, content_width)` cache key, hidden-tab stash + flush on activation.
2. **Batched git** (`12eb35b`) — `compute_diff` collapses N+5 subprocesses into a constant ≤4: `merge-base`, `git diff --no-color <merge-base>` (parsed in-process), `ls-files --others`, single `git cat-file --batch` for all old contents. Drops the per-file `git show`. 50-file diff cold-start: 55 subprocs → 4.
3. **Cheap badge first** (`f7e5c43`) — independent `git diff --shortstat` worker (`@work group=diff_badge`) populates the `DIFF +N -M` tab label in <100ms while the heavier full build is still parsing diffs. Two paths, two tokens, two applies.
4. **Per-file streaming** (`896c888`) — `iter_diff_renderables` generator yields per-file; worker `call_from_thread`s each file as soon as its render finishes. First file appears in <200ms even on big diffs. Mid-stream cancel is deterministic; finalizer commits cache key only on clean drain.
5. **Live refresh during run** (`92d32bb`) — 2s poller fires only when an actor is `RUNNING` and DIFF is the active tab. Two-signal change detection: `.git/index` mtime (catches staged changes microseconds-cheap) + `git diff --shortstat` (catches unstaged worktree edits). `git_index_mtime` handles both primary checkouts and `git worktree` checkouts (which is what `actor new` produces).
6. **Pre-rendered strips off-thread** (`8267f59`, `673582b`) — `renderable_to_strips` runs Rich's render pipeline in the worker, producing `textual.strip.Strip` lists. Mounted via a tiny `PrerenderedDiff` widget whose `render_line(y)` is a constant-time array index; no Rich render at paint time. Eliminates the perceptible UI hang on tab activation. Widget's CSS pins `background: $background` so Rich's `dim=True` flag bakes out cleanly during Textual's `ANSIToTruecolor` filter pass (otherwise `Color('default')` has no triplet to dim against → `TypeError`).
7. **Pill-style themed label** (`1dff69a`, `648c5d9`) — `DIFF +35 -7` with the same green/red bg the diff body uses for added/removed lines (`DARK_COLORS.added_bg` / `removed_bg`). Strips styles when the tab is focused-active so Textual's reverse-video focus paint comes through cleanly instead of mudding the badge colors.

## Test plan
- [x] `uv run python -m unittest discover tests` — **543 tests, all green** (was 462 before this branch)
- [x] DIFF tab activation no longer hangs even on a 2.5k-line, 4-file diff (the test repo against main)
- [x] Switching actors quickly never shows stale output; resize during render kicks fresh build at new width
- [x] Hidden DIFF tab does no work; activating flushes the stashed kick
- [x] Badge updates near-instantly while file content streams in
- [x] omarchy theme switch carries through to the diff body and badge colors

## Files

```
src/actor/watch/app.py             | wire-up, kick/worker/apply trios, polling
src/actor/watch/diff_render.py     | iter_diff_renderables generator, ± from FileDiff
src/actor/watch/helpers.py         | batched compute_diff, parse_shortstat, git_index_mtime, read_head_oid
src/actor/watch/prerendered_diff.py| renderable_to_strips + PrerenderedDiff widget (new)
tests/test_diff_view.py            | 60 new tests across the 5 stages
tests/test_prerendered_diff.py     | 7 new tests for the strips path (new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)