### PR TITLE
Watch DIFF: clear badge label on actor change so failed kicks don't show stale numbers

### DIFF
--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -891,9 +891,23 @@ class ActorWatchApp(App):
     def _maybe_refresh_diff(self, force: bool = False) -> None:
         actor = self.query_one(ActorTree).selected_actor
         if actor is None:
+            # Selection cleared (e.g. previously-selected actor was
+            # discarded with no replacement). Wipe the badge so the
+            # tabs bar doesn't display stale ±N from the prior actor.
+            if self._diff_loaded_for is not None:
+                self._update_diff_tab_label()
+                self._diff_loaded_for = None
             return
         if not force and self._diff_loaded_for == actor.name:
             return
+        # Actor change: reset the badge before kicking. If the new
+        # actor's shortstat call fails (broken base ref, no repo,
+        # etc.) `_apply_diff_badge` is never called and the previous
+        # actor's ±N would otherwise stick on the label. Clearing
+        # here means a failed kick falls back to plain "DIFF" rather
+        # than misleading numbers from a different worktree.
+        if self._diff_loaded_for != actor.name:
+            self._update_diff_tab_label()
         self._diff_loaded_for = actor.name
         # Kick both paths together. The badge is independent of the
         # full build — even if the build is stashed because DIFF is


### PR DESCRIPTION
## Summary

When the selected actor changes (or the previously-selected actor is discarded with no auto-replacement), the DIFF tab's `+N -M` badge was sticking around with the *previous* actor's numbers if the new actor's `compute_diff_shortstat` call failed (broken base ref, missing repo, etc.). Symptoms:

1. Discard the actor that has a non-trivial diff. Selection moves to a different actor.
2. The new actor's badge kick runs `git diff --shortstat` against its own base.
3. If that base no longer exists (deleted branch, etc.) the call returns `None`, `_apply_diff_badge` is never called, and the old actor's badge stays pinned.

Repro: discard the `diff-stage1` actor while it has the cached numbers showing; selection moves to `hello-world` whose `base_branch` was `omarchy-improvements` (deleted with PR #59) → badge stays at `+2583 -79`.

## Fix

`_maybe_refresh_diff` now resets the badge to plain `DIFF` before kicking the new actor's badge worker. Successful kicks repopulate with real counts; failed kicks leave the neutral "DIFF" instead of misleading numbers from a different worktree. Symmetric handling for the `actor is None` selection-cleared path.

Pre-existing actors with stale base refs (like the discovered `hello-world → omarchy-improvements`) would be a separate hygiene fix — possibly an `actor doctor` check for branches that no longer exist.

## Test plan
- [x] `uv run python -m unittest discover tests` — 576/576 green
- [x] Manual: discarded `diff-stage1` while badge showed `+2583 -79`; selection moved to `hello-world`; badge correctly cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)