### PR TITLE
Watch logs: invalidate per-actor cache when session_id changes (transcript pollution on discard+recreate)

### DIFF
--- a/src/actor/watch/app.py
+++ b/src/actor/watch/app.py
@@ -621,6 +621,22 @@ class ActorWatchApp(App):
         # time the next worker takes the lock it sees the advanced
         # cursor and skips already-read bytes.
         with self._log_lock:
+            # Detect session_id change for this actor name. Happens when
+            # the user discards-and-recreates an actor with the same
+            # name: the cached entries belong to the prior incarnation's
+            # JSONL file, the cursor is a byte offset into that file,
+            # and neither has anything to say about the new session.
+            # Without this reset, `_append_logs` would extend the new
+            # actor's entries onto the old actor's bucket and the user
+            # sees a concatenated transcript across both lifetimes.
+            last_session = self._log_session_for_actor.get(actor.name)
+            if last_session != actor.agent_session:
+                self._log_session_for_actor[actor.name] = actor.agent_session
+                self._log_entries_by_actor.pop(actor.name, None)
+                self._log_cursors.pop(actor.name, None)
+                # Defer clearing _last_log_* to the main thread via
+                # _append_logs (which runs there); the worker doesn't
+                # touch widget state.
             cursor = self._log_cursors.get(actor.name)
             new_entries, next_cursor = read_log_entries_since(actor, cursor)
             if next_cursor is not None:
@@ -634,6 +650,11 @@ class ActorWatchApp(App):
     # back. Entries survive for the TUI session lifetime.
     _log_entries_by_actor: dict[str, list] = {}
     _log_cursors: dict[str, object] = {}
+    # Tracks the session_id last seen for each actor name so a new
+    # session under the same name (after discard + recreate) is
+    # detected and the stale entries/cursor are dropped before the
+    # new file's bytes are parsed onto the previous transcript.
+    _log_session_for_actor: dict[str, str] = {}
     _log_lock = threading.Lock()
 
     _last_log_actor: str | None = None

--- a/tests/test_watch_log_cache.py
+++ b/tests/test_watch_log_cache.py
@@ -1,0 +1,144 @@
+"""Watch app's per-actor log cache invalidation.
+
+The watch keeps `(entries, cursor)` per actor name so switching back to
+a previously-viewed actor doesn't re-parse the JSONL from byte 0.
+That's an optimization until the same name is reused — discard +
+re-create with the same name produces a brand-new session_id and a
+fresh JSONL file. The cursor is a byte offset into the prior file
+and the bucket is the prior transcript; either left untouched and
+the new actor's read appends onto the old transcript.
+
+The fix detects the session_id mismatch in `_refresh_logs` (under
+the read lock, before the cursor is consulted) and pops both
+caches. These tests exercise that detection path directly via the
+@work-decorated method's `__wrapped__` attribute so we don't need
+a running Textual loop.
+"""
+from __future__ import annotations
+
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from actor.watch.app import ActorWatchApp
+
+
+def _bare_app() -> ActorWatchApp:
+    """Construct an ActorWatchApp without `__init__`. Only the log
+    caches are exercised here, so we set up just those fields and
+    the lock the worker takes."""
+    app = ActorWatchApp.__new__(ActorWatchApp)
+    app._log_entries_by_actor = {}
+    app._log_cursors = {}
+    app._log_session_for_actor = {}
+    app._log_lock = threading.Lock()
+    return app
+
+
+def _fake_actor(name: str, agent_session: str) -> MagicMock:
+    a = MagicMock()
+    a.name = name
+    a.agent_session = agent_session
+    a.dir = f"/tmp/{name}"
+    return a
+
+
+class LogCacheSessionInvalidationTests(unittest.TestCase):
+
+    def test_session_change_drops_bucket_and_cursor(self):
+        """Discard + recreate scenario: old session left state in the
+        caches; new actor with the same name has a different
+        session_id; the worker sees the mismatch and pops both
+        per-name caches before reading from disk."""
+        app = _bare_app()
+        app._log_entries_by_actor["hello-world"] = ["old entry 1", "old entry 2"]
+        app._log_cursors["hello-world"] = 1234
+        app._log_session_for_actor["hello-world"] = "old-session-uuid"
+
+        new_actor = _fake_actor("hello-world", agent_session="new-session-uuid")
+
+        # Worker reads the new file from byte 0; we don't care what
+        # comes back here, only that the caches got reset.
+        with patch(
+            "actor.watch.app.read_log_entries_since",
+            return_value=([], 0),
+        ), patch.object(app, "call_from_thread"):
+            ActorWatchApp._refresh_logs.__wrapped__(app, new_actor)
+
+        # Old bucket dropped — _append_logs would re-populate via
+        # call_from_thread, which we mocked out, so it must be absent.
+        self.assertNotIn("hello-world", app._log_entries_by_actor)
+        # Cursor table gets the freshly-returned offset (0 here from
+        # the mocked read), keyed against the new session.
+        self.assertEqual(app._log_cursors["hello-world"], 0)
+        self.assertEqual(
+            app._log_session_for_actor["hello-world"], "new-session-uuid",
+        )
+
+    def test_same_session_keeps_bucket_and_advances_cursor(self):
+        """Steady-state polling on the same actor: caches survive
+        across calls, cursor advances by whatever the read returned."""
+        app = _bare_app()
+        app._log_entries_by_actor["alice"] = ["entry"]
+        app._log_cursors["alice"] = 100
+        app._log_session_for_actor["alice"] = "stable-session"
+
+        actor = _fake_actor("alice", agent_session="stable-session")
+
+        with patch(
+            "actor.watch.app.read_log_entries_since",
+            return_value=([], 250),
+        ), patch.object(app, "call_from_thread"):
+            ActorWatchApp._refresh_logs.__wrapped__(app, actor)
+
+        # Bucket survives — same session, same name, no reason to wipe.
+        self.assertEqual(app._log_entries_by_actor["alice"], ["entry"])
+        # Cursor advanced from 100 to 250.
+        self.assertEqual(app._log_cursors["alice"], 250)
+        self.assertEqual(
+            app._log_session_for_actor["alice"], "stable-session",
+        )
+
+    def test_first_observation_records_session_without_clearing(self):
+        """First time we see this actor name — `_log_session_for_actor`
+        has no entry. Don't pop anything (there's nothing to pop), just
+        record the session_id so subsequent calls have a baseline to
+        compare against."""
+        app = _bare_app()
+        # Caches start empty; no prior session recorded.
+
+        actor = _fake_actor("brand-new", agent_session="first-session")
+
+        with patch(
+            "actor.watch.app.read_log_entries_since",
+            return_value=([], 42),
+        ), patch.object(app, "call_from_thread"):
+            ActorWatchApp._refresh_logs.__wrapped__(app, actor)
+
+        self.assertEqual(
+            app._log_session_for_actor["brand-new"], "first-session",
+        )
+        self.assertEqual(app._log_cursors["brand-new"], 42)
+
+    def test_cursor_only_advances_when_read_succeeds(self):
+        """If `read_log_entries_since` returns `next_cursor=None`
+        (e.g. no newline yet), the cursor table is left untouched —
+        same contract as before the session-detection patch."""
+        app = _bare_app()
+        app._log_session_for_actor["alice"] = "stable"
+        app._log_cursors["alice"] = 100
+
+        actor = _fake_actor("alice", agent_session="stable")
+
+        with patch(
+            "actor.watch.app.read_log_entries_since",
+            return_value=([], None),
+        ), patch.object(app, "call_from_thread"):
+            ActorWatchApp._refresh_logs.__wrapped__(app, actor)
+
+        # next_cursor is None → cursor table unchanged.
+        self.assertEqual(app._log_cursors["alice"], 100)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes a transcript-pollution bug: discarding an actor and creating a new one with the same name shows a concatenated history across both lifetimes in the LIVE pane.

## Repro

1. Spawn `hello-world` with prompt A; let it finish.
2. `discard_actor(hello-world)` (via MCP, CLI, or watch hotkey).
3. Spawn a *new* `hello-world` with prompt B.
4. Select the new actor in `actor watch`.
5. LIVE pane shows prompt A's entire transcript, followed by prompt B's response.

## Root cause

`ActorWatchApp` keeps two class-level dicts keyed by actor **name**:

```python
_log_entries_by_actor: dict[str, list] = {}   # accumulated parsed entries
_log_cursors: dict[str, object] = {}          # byte offset into the JSONL
```

The optimization is "switching actors doesn't force a re-parse from byte 0." When the *same name* is reused after a discard, the new actor has a different `session_id` (and thus a different JSONL file at `~/.claude/projects/<encoded-cwd>/<session_id>.jsonl`), but the cache assumes the bucket and cursor still apply. The new file's bytes get appended to the old bucket; the old cursor (an offset into the old file) is interpreted against the new file, producing nonsense reads.

## Fix

Add `_log_session_for_actor: dict[str, str]` tracking the last-seen `session_id` per actor name. In `_refresh_logs`, under `_log_lock`, compare `actor.agent_session` against the recorded value:

- Mismatch (or first observation under that name with a non-matching value) → pop both per-name caches, record the new `session_id`, fall through to a full read from byte 0.
- Match → existing fast path: cursor advance, append new entries.

`_set_logs`'s existing "actor changed?" check then sees the bucket length drop and routes through a full rebuild instead of trying to append.

## Why this isn't just refactoring class-level state

The deeper issue (these dicts are class-level instead of instance-level — see issue #61 item #4) is real but a bigger sweep across all the `_*_by_actor` / `_*_target_*` state. This PR fixes the user-visible symptom precisely; the broader cleanup can land separately without changing this fix's semantics.

## Test plan

- [x] New `tests/test_watch_log_cache.py` exercises the four state transitions: session change drops caches, same session keeps bucket and advances cursor, first observation just records baseline, `next_cursor=None` doesn't advance.
- [x] Full suite: 576 → 580 tests, all green.
- [x] Manual repro: discarded + recreated `hello-world` while `actor watch` was running on the same process; new actor's LIVE pane shows only its own transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)