### PR TITLE
ask block: user-configurable MCP tool guidance (#52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,39 @@ per-agent `defaults "<name>" { ... }` shape.
 Load programmatically via `actor.config.load_config(cwd=..., home=...)` —
 both args default to `Path.cwd()` / `$HOME` so tests can inject temp dirs.
 
+### Ask block
+
+A top-level `ask { }` block holds free-form natural-language guidance
+that gets appended to the corresponding MCP tool descriptions at server
+startup. The orchestrator reads them as part of its tool catalog and
+decides when to use `AskUserQuestion` before acting.
+
+```kdl
+ask {
+    on-start   "Always confirm the agent kind for risky tasks."
+    before-run "Skip questions; assume per-run config never changes."
+    on-discard null   # silence the default — discard never asks
+}
+```
+
+Valid keys: `on-start` (appended to `new_actor`), `before-run`
+(appended to `run_actor`), `on-discard` (appended to `discard_actor`).
+No `after-run` — there's nothing to ask after a run completes.
+
+Per-key resolution:
+
+- key absent → fall through to the hardcoded default (orchestrator's
+  baseline guidance for that tool)
+- value is a string → append that string verbatim
+- value is `null` or `""` → user opt-out; append nothing
+
+Tool descriptions are static per MCP-server lifetime. Edits to
+`settings.kdl` apply on the next `actor main` (re-exec to pick them
+up). Project-level `ask` blocks override user-level per key, same merge
+rule as templates and hooks.
+
+The hardcoded defaults live in `ASK_DEFAULTS` in `src/actor/config.py`.
+
 ### Lifecycle hooks
 
 A top-level `hooks { }` block declares shell commands that fire around

--- a/src/actor/_skill/SKILL.md
+++ b/src/actor/_skill/SKILL.md
@@ -240,6 +240,18 @@ actor new auth-review --role reviewer --config model=haiku "..."    # CLI overri
 actor new auth-review --role reviewer --agent codex "..."           # CLI agent beats role (errors if role has a prompt)
 ```
 
+### Ask block (user-configurable tool guidance)
+
+The user can put a top-level `ask { }` block in settings.kdl whose
+strings get appended to the descriptions of `new_actor`, `run_actor`,
+and `discard_actor` at MCP-server startup. You read those appendices
+as part of the tool's description and follow them — they tell you when
+to use `AskUserQuestion` before calling the tool. Defaults exist if
+the user hasn't customized them.
+
+You don't need to read settings.kdl yourself; the guidance is already
+folded into the tool description you see. Just follow it.
+
 ### Create without running
 
 ```

--- a/src/actor/config.py
+++ b/src/actor/config.py
@@ -74,10 +74,33 @@ class Hooks:
 
 
 @dataclass
+class Ask:
+    """User-configurable guidance strings appended to MCP tool descriptions.
+
+    `values` maps a kdl key (e.g. `"on-start"`) to its setting:
+      - key absent             → use the hardcoded default for that key
+      - value is a string      → append that string verbatim to the tool doc
+      - value is `None` or ""  → user opted out; append nothing
+
+    Resolution happens at MCP-server startup; tool descriptions are then
+    static for the server's lifetime. Edit settings.kdl + restart `actor
+    main` to change them.
+    """
+    values: Dict[str, Optional[str]] = field(default_factory=dict)
+
+    def resolved(self, key: str, default: str) -> str:
+        if key not in self.values:
+            return default
+        v = self.values[key]
+        return v if v else ""
+
+
+@dataclass
 class AppConfig:
     roles: Dict[str, Role] = field(default_factory=dict)
     agent_defaults: Dict[str, AgentDefaults] = field(default_factory=dict)
     hooks: Hooks = field(default_factory=Hooks)
+    ask: Ask = field(default_factory=Ask)
 
 
 _HOOK_KEYS = {
@@ -85,6 +108,54 @@ _HOOK_KEYS = {
     "before-run": "before_run",
     "after-run": "after_run",
     "on-discard": "on_discard",
+}
+
+
+# Whitelist of valid keys inside an `ask { }` block. Mirrors the hooks
+# vocabulary minus `after-run` — there's no point asking the user a
+# question after a run has already finished.
+_ASK_KEYS: Tuple[str, ...] = ("on-start", "before-run", "on-discard")
+
+
+# Hardcoded defaults appended to MCP tool descriptions when the
+# user hasn't set a value in `ask { }`. Each one is the orchestrator's
+# baseline guidance for "should I ask the user something before this
+# tool call?". Users can override per-key in settings.kdl, or silence
+# with `null` / `""`.
+ASK_DEFAULTS: Dict[str, str] = {
+    "on-start": (
+        "Before calling `new_actor`, use `AskUserQuestion` to surface any "
+        "parameter choices that would meaningfully affect the actor's "
+        "behavior. Structural params (`agent`, `base`, `no_worktree`, "
+        "`use_subscription`) are visible on the tool itself; for agent "
+        "config keys (thinking effort, permission mode, allowed tools, "
+        "etc.) consult the agent's config reference — `claude-config.md` "
+        "for claude, `codex-config.md` for codex. Only ask when the "
+        "user's request leaves the choice genuinely ambiguous — skip "
+        "questions whose answer is already clear from context or whose "
+        "default is fine. Keep it to at most 2-3 questions; batch them "
+        "into a single `AskUserQuestion` call when possible."
+    ),
+    "before-run": (
+        "Before calling `run_actor`, use `AskUserQuestion` only when the "
+        "prompt is genuinely vague (e.g. \"try again\" or \"continue\" "
+        "with no context) or when the user signals they want per-run "
+        "config tweaks — thinking effort, model, etc. — different from "
+        "the actor's defaults. Those go through the `config` param and "
+        "only apply to this run. Consult the agent's config reference "
+        "(`claude-config.md` / `codex-config.md`) for valid overrides. "
+        "Default to proceeding without asking — most run calls don't "
+        "need a question. Keep it to at most 1-2 questions when you do "
+        "ask, batched."
+    ),
+    "on-discard": (
+        "Before calling `discard_actor`, use `AskUserQuestion` only when "
+        "the user's target is ambiguous (\"discard it\" with multiple "
+        "candidates in play) or when there's a running session they "
+        "might want to inspect first (check with `show_actor`). Discard "
+        "is usually a cleanup operation — default to proceeding when "
+        "the target is explicit."
+    ),
 }
 
 
@@ -377,6 +448,62 @@ def _parse_hooks(node, source: Path) -> Hooks:
     return hooks
 
 
+def _parse_ask_block(node, source: Path) -> Ask:
+    """Parse a top-level `ask { ... }` block.
+
+    Each child is a single key/value pair where the value is either a
+    string (custom guidance) or `null` (silence the default). The
+    whitelist (`_ASK_KEYS`) gates which keys are allowed; unknown keys
+    are rejected with a hint listing the valid set.
+    """
+    if node.args:
+        raise ConfigError(
+            f"ask block in {source} does not accept positional args"
+        )
+    if getattr(node, "props", None):
+        raise ConfigError(
+            f"ask block in {source} does not accept properties"
+        )
+    ask = Ask()
+    seen: set[str] = set()
+    for child in node.nodes:
+        key = child.name
+        if key not in _ASK_KEYS:
+            raise ConfigError(
+                f"ask block in {source}: unknown key '{key}' "
+                f"(valid: {', '.join(_ASK_KEYS)})"
+            )
+        if key in seen:
+            raise ConfigError(
+                f"ask block in {source}: duplicate key '{key}'"
+            )
+        seen.add(key)
+        if not child.args:
+            raise ConfigError(
+                f"ask block in {source}: '{key}' needs a value "
+                f"(string, or `null` to silence the default)"
+            )
+        if len(child.args) > 1:
+            raise ConfigError(
+                f"ask block in {source}: '{key}' has extra args "
+                f"(only a single value is supported)"
+            )
+        if getattr(child, "props", None):
+            raise ConfigError(
+                f"ask block in {source}: '{key}' does not accept properties"
+            )
+        raw = child.args[0]
+        if raw is None:
+            ask.values[key] = None
+            continue
+        if not isinstance(raw, str):
+            raise ConfigError(
+                f"ask block in {source}: '{key}' must be a string or null"
+            )
+        ask.values[key] = raw
+    return ask
+
+
 def _parse_kdl_file(path: Path) -> AppConfig:
     try:
         text = path.read_text()
@@ -388,6 +515,7 @@ def _parse_kdl_file(path: Path) -> AppConfig:
         raise ConfigError(f"parse error in {path}: {e}") from e
     cfg = AppConfig()
     hooks_seen = False
+    ask_seen = False
     for node in doc.nodes:
         if node.name == "role":
             role = _parse_role(node, path)
@@ -410,9 +538,15 @@ def _parse_kdl_file(path: Path) -> AppConfig:
                 )
             hooks_seen = True
             cfg.hooks = _parse_hooks(node, path)
-        # Silently ignore alias / ask — follow-up tickets (#33 / #52)
-        # add them; keeping the parser lenient here preserves forward
-        # compat for any new top-level blocks.
+        elif node.name == "ask":
+            if ask_seen:
+                raise ConfigError(
+                    f"duplicate ask block in {path}"
+                )
+            ask_seen = True
+            cfg.ask = _parse_ask_block(node, path)
+        # Silently ignore alias — follow-up ticket (#33) — to keep the
+        # parser lenient for forward compat with future top-level blocks.
     return cfg
 
 
@@ -459,10 +593,15 @@ def _merge(base: AppConfig, over: AppConfig) -> AppConfig:
         after_run=over.hooks.after_run if over.hooks.after_run is not None else base.hooks.after_run,
         on_discard=over.hooks.on_discard if over.hooks.on_discard is not None else base.hooks.on_discard,
     )
+    # Per-key overlay: project's explicit set of an ask key wins. Absence
+    # in `over` means "didn't mention it", so the base value (or ultimately
+    # the hardcoded default) is preserved.
+    merged_ask = Ask(values={**base.ask.values, **over.ask.values})
     return AppConfig(
         roles=merged_roles,
         agent_defaults=merged_defaults,
         hooks=merged_hooks,
+        ask=merged_ask,
     )
 
 

--- a/src/actor/server.py
+++ b/src/actor/server.py
@@ -72,6 +72,44 @@ def _build_instructions(for_host: str | None = None) -> str:
 mcp = ActorMCP("actor.sh", instructions=_build_instructions())
 
 
+def _resolve_ask_strings() -> dict[str, str]:
+    """Resolve the `ask { }` strings from settings.kdl, falling back to
+    hardcoded defaults if the kdl is missing/malformed.
+
+    Computed once at module load — tool descriptions are then static for
+    the server's lifetime. A malformed settings.kdl logs a warning to
+    stderr but doesn't crash the import; defaults take over so MCP still
+    works.
+    """
+    from .config import ASK_DEFAULTS, load_config
+    try:
+        cfg = load_config()
+    except Exception as e:
+        print(
+            f"[actor-mcp] ignoring settings.kdl for ask block (will use "
+            f"hardcoded defaults): {e}",
+            file=sys.stderr,
+        )
+        return dict(ASK_DEFAULTS)
+    return {key: cfg.ask.resolved(key, default) for key, default in ASK_DEFAULTS.items()}
+
+
+_ASK_RESOLVED: dict[str, str] = _resolve_ask_strings()
+
+
+def _ask_tool(ask_key: str):
+    """Decorator wrapper around `@mcp.tool()` that appends the resolved
+    `ask` guidance for `ask_key` to the tool's docstring before
+    registering. Empty / silenced ask values append nothing — the
+    docstring stays as-is."""
+    def decorator(func):
+        base = (func.__doc__ or "").rstrip()
+        appendix = _ASK_RESOLVED.get(ask_key, "")
+        description = base + ("\n\n" + appendix if appendix else "")
+        return mcp.tool(description=description)(func)
+    return decorator
+
+
 def _db() -> Database:
     return Database.open(_db_path())
 
@@ -158,7 +196,7 @@ def stop_actor(name: str) -> str:
     return cmd_stop(db, agent, RealProcessManager(), name=name)
 
 
-@mcp.tool()
+@_ask_tool("on-discard")
 def discard_actor(name: str, force: bool = False) -> str:
     """Remove an actor from the database. Stops it first if running. Worktree stays on disk.
 
@@ -248,7 +286,7 @@ def _spawn_background_run(
     threading.Thread(target=_run, daemon=True).start()
 
 
-@mcp.tool()
+@_ask_tool("on-start")
 def new_actor(
     name: str,
     prompt: str | None = None,
@@ -331,7 +369,7 @@ def new_actor(
     return f"Actor '{name}' created at {actor.dir}."
 
 
-@mcp.tool()
+@_ask_tool("before-run")
 def run_actor(
     name: str,
     prompt: str,

--- a/tests/test_cli_and_mcp.py
+++ b/tests/test_cli_and_mcp.py
@@ -659,5 +659,70 @@ class McpToolTests(unittest.TestCase):
         spawn.assert_not_called()
 
 
+class AskBlockIntegrationTests(unittest.TestCase):
+    """`ask { }` strings are appended to the affected MCP tool descriptions
+    at server-startup time. Verified by inspecting the registered tool's
+    description via FastMCP's tool list."""
+
+    def _tool_descriptions(self):
+        # Run the async list against an isolated event loop so the test
+        # works in any host context.
+        import asyncio
+        from actor import server
+        return {t.name: t.description for t in asyncio.run(server.mcp.list_tools())}
+
+    def test_default_ask_strings_present_in_tool_descriptions(self):
+        # The hardcoded defaults should already be appended (no settings.kdl
+        # in the test cwd, so resolved() returns the defaults — _ASK_RESOLVED
+        # captured them at module import).
+        from actor.config import ASK_DEFAULTS
+        descs = self._tool_descriptions()
+        # Each affected tool should contain the FIRST line of its default
+        # — not full equality, since the docstring base is also there.
+        first_line = lambda s: s.splitlines()[0]
+        self.assertIn(first_line(ASK_DEFAULTS["on-start"]), descs["new_actor"])
+        self.assertIn(first_line(ASK_DEFAULTS["before-run"]), descs["run_actor"])
+        self.assertIn(first_line(ASK_DEFAULTS["on-discard"]), descs["discard_actor"])
+
+    def test_unaffected_tools_have_no_ask_appendix(self):
+        # `list_actors`, `show_actor`, etc. don't take ask annotations —
+        # their descriptions stay as the original docstring.
+        from actor.config import ASK_DEFAULTS
+        descs = self._tool_descriptions()
+        # The on-start default mentions "AskUserQuestion" — make sure it
+        # didn't accidentally land in tools that aren't supposed to carry it.
+        self.assertNotIn("AskUserQuestion", descs["list_actors"])
+        self.assertNotIn("AskUserQuestion", descs["show_actor"])
+        self.assertNotIn("AskUserQuestion", descs["stop_actor"])
+        self.assertNotIn("AskUserQuestion", descs["list_roles"])
+
+    def test_ask_tool_decorator_with_silenced_value_appends_nothing(self):
+        # Direct unit test of the helper — given an empty appendix, no
+        # blank line gets tacked onto the docstring.
+        from actor import server
+        # Build a fresh decorator with a synthetic ask key/value mapping
+        # that's silenced. Use a temporary FastMCP so we don't mutate the
+        # module-level `mcp`.
+        from mcp.server.fastmcp import FastMCP
+        local_mcp = FastMCP("test")
+        original_mcp = server.mcp
+        original_resolved = server._ASK_RESOLVED
+        try:
+            server.mcp = local_mcp
+            server._ASK_RESOLVED = {"on-start": ""}
+
+            @server._ask_tool("on-start")
+            def fake_tool() -> str:
+                """base docstring"""
+                return "ok"
+
+            import asyncio
+            tools = {t.name: t for t in asyncio.run(local_mcp.list_tools())}
+            self.assertEqual(tools["fake_tool"].description, "base docstring")
+        finally:
+            server.mcp = original_mcp
+            server._ASK_RESOLVED = original_resolved
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -568,5 +568,144 @@ class TestLoadConfigAgentBlocks(unittest.TestCase):
             )
 
 
+class TestLoadConfigAskBlock(unittest.TestCase):
+    """`ask { }` top-level block — guidance strings appended to MCP tool docs."""
+
+    def _write(self, path: Path, body: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    def test_ask_absent_resolves_to_default(self):
+        # No settings.kdl → ask is empty → resolved() returns default.
+        from actor.config import ASK_DEFAULTS
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(
+                cfg.ask.resolved("on-start", ASK_DEFAULTS["on-start"]),
+                ASK_DEFAULTS["on-start"],
+            )
+
+    def test_ask_string_value_overrides_default(self):
+        from actor.config import ASK_DEFAULTS
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'ask {\n    on-start "custom guidance"\n}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(
+                cfg.ask.resolved("on-start", ASK_DEFAULTS["on-start"]),
+                "custom guidance",
+            )
+
+    def test_ask_null_value_silences_default(self):
+        # `null` means "user opted out" — resolved() returns "" so the
+        # caller appends nothing.
+        from actor.config import ASK_DEFAULTS
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'ask {\n    on-start null\n}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(
+                cfg.ask.resolved("on-start", ASK_DEFAULTS["on-start"]),
+                "",
+            )
+
+    def test_ask_empty_string_silences_default(self):
+        # `""` is the second documented opt-out form. Same effect as null.
+        from actor.config import ASK_DEFAULTS
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'ask {\n    on-start ""\n}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(
+                cfg.ask.resolved("on-start", ASK_DEFAULTS["on-start"]),
+                "",
+            )
+
+    def test_ask_unknown_key_rejected(self):
+        # The whitelist gates which keys are allowed. `after-run` isn't
+        # in it (nothing to ask after the run finishes).
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'ask {\n    after-run "nope"\n}\n',
+            )
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("after-run", str(ctx.exception))
+            self.assertIn("on-start", str(ctx.exception))
+
+    def test_ask_non_string_non_null_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'ask {\n    on-start 42\n}\n',
+            )
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("string", str(ctx.exception))
+
+    def test_ask_duplicate_key_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'ask {\n    on-start "a"\n    on-start "b"\n}\n',
+            )
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("duplicate", str(ctx.exception))
+
+    def test_ask_duplicate_block_rejected(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'ask {\n    on-start "a"\n}\nask {\n    before-run "b"\n}\n',
+            )
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(cwd=Path(cwd), home=Path(home))
+            self.assertIn("duplicate ask", str(ctx.exception))
+
+    def test_ask_project_overrides_user_per_key(self):
+        # Per-key overlay: project's set wins for keys it specifies; user's
+        # set survives for keys project doesn't touch.
+        from actor.config import ASK_DEFAULTS
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'ask {\n    on-start "user start"\n    before-run "user run"\n}\n',
+            )
+            self._write(
+                Path(cwd) / ".actor" / "settings.kdl",
+                'ask {\n    on-start "project start"\n}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            self.assertEqual(
+                cfg.ask.resolved("on-start", ASK_DEFAULTS["on-start"]),
+                "project start",
+            )
+            # User's before-run is preserved (project didn't override).
+            self.assertEqual(
+                cfg.ask.resolved("before-run", ASK_DEFAULTS["before-run"]),
+                "user run",
+            )
+
+    def test_ask_empty_block_is_no_op(self):
+        # `ask { }` parses fine; resolved() returns defaults for all keys.
+        from actor.config import ASK_DEFAULTS
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as cwd:
+            self._write(
+                Path(home) / ".actor" / "settings.kdl",
+                'ask {\n}\n',
+            )
+            cfg = load_config(cwd=Path(cwd), home=Path(home))
+            for key, default in ASK_DEFAULTS.items():
+                self.assertEqual(cfg.ask.resolved(key, default), default)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #52

## Summary

Top-level `ask { }` block in settings.kdl whose strings get appended to the descriptions of `new_actor` / `run_actor` / `discard_actor` at MCP-server startup. The orchestrator reads them as part of its tool catalog and decides when to use `AskUserQuestion` before acting.

```kdl
ask {
    on-start   "..."   # appended to new_actor's description
    before-run "..."   # appended to run_actor's
    on-discard null    # silence the default
}
```

Per-key resolution: absent → hardcoded default, string → append verbatim, null/`""` → silenced. Project-overrides-user per-key. Whitelist enforces valid keys. Malformed settings.kdl falls back to defaults with stderr warning (no crash).

## Test plan

Unit + integration (+13 tests, 649 total green):
- [x] Parser: defaults, string override, null silence, `""` silence, unknown-key rejection, non-string rejection, duplicate-key rejection, duplicate-block rejection, project-overrides-user merge, empty `ask { }` is a no-op
- [x] Server: default appendix lands in `new_actor` / `run_actor` / `discard_actor` descriptions; unaffected tools (`list_actors`, `show_actor`, `stop_actor`, `list_roles`) carry no `AskUserQuestion` text
- [x] Decorator: silenced (empty) appendix appends nothing — docstring stays as-is

End-to-end (subprocess) before opening the PR:
- [x] User-home `~/.actor/settings.kdl` override + `null` silence (custom HOME)
- [x] Project beats user per-key (nested cwd + HOME)
- [x] Malformed kdl falls back to defaults with stderr warning, doesn't crash MCP import
- [x] **Real MCP wire**: spawned `actor mcp` as a subprocess, did the JSON-RPC handshake, parsed the `tools/list` response, confirmed the appendix lands in the wire bytes claude receives

🤖 Generated with [Claude Code](https://claude.com/claude-code)