### PR TITLE
docs site: Hugo scaffold + full content + GH Pages deploy

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,47 @@
+name: Deploy site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - 'docs/content/**'
+      - '.github/workflows/deploy-site.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.161.1'
+          extended: true
+      - uses: actions/configure-pages@v5
+        id: pages
+      - name: Build
+        working-directory: site
+        run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__/
 *.pyc
 .DS_Store
 .claude/
+site/public/
+site/resources/
+site/.hugo_build.lock

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,0 +1,9 @@
+---
+title: "actor.sh"
+description: "A main actor session backed by parallel coding sub-agents in isolated git worktrees."
+weight: 0
+---
+
+actor.sh manages multiple Claude Code or Codex agents running in parallel, each on its own branch in its own git worktree. You talk to one orchestrator session — `actor main` — and it spawns specialized sub-actors to handle the actual work, verifies their output, and reports back.
+
+Start with [Getting started](getting-started/) for installation and your first actor. The [Concepts](concepts/) section explains the model — what an actor is, how roles, hooks, and channel notifications fit together. [Guides](guides/) cover task-shaped configuration topics, and [Reference](reference/) is a flat lookup of every CLI subcommand, MCP tool, and config key.

--- a/docs/content/concepts/01-actors-and-worktrees.md
+++ b/docs/content/concepts/01-actors-and-worktrees.md
@@ -1,0 +1,44 @@
+---
+title: "Actors and worktrees"
+description: "An actor is a coding agent running a task on its own git branch in an isolated worktree."
+weight: 1
+---
+
+An **actor** is a coding agent — `claude` or `codex` — running a task on its own git branch, inside its own working tree. Actors are the unit of work in actor.sh: each one is isolated from your main checkout and from every other actor, so you can run several in parallel without them stepping on each other's edits.
+
+## The worktree model
+
+When you create an actor, actor.sh creates a git worktree at `~/.actor/worktrees/<name>/` on a new branch named after the actor. The branch is forked off your current branch by default; pass `--base develop` (CLI) or `base="develop"` (MCP) to fork off something else. The actor's agent runs with that worktree as its cwd, so every edit it makes — staged or unstaged, committed or not — stays inside its own branch.
+
+```bash
+actor new fix-nav "Fix the broken mobile nav"
+# creates branch  fix-nav   off the current branch
+# worktree at     ~/.actor/worktrees/fix-nav/
+```
+
+For directories that aren't git repositories, pass `--no-worktree` (CLI) or `no_worktree=True` (MCP). The actor runs in the original directory with no branch isolation.
+
+## Lifecycle
+
+An actor moves through three commands:
+
+- **`new`** — create the actor: register it in the database, create the worktree, optionally start a first run if a prompt is given.
+- **`run`** — run a task on an existing actor. The agent's session is preserved across runs — calling `run_actor` a second time resumes the same Claude or Codex session, so context carries over.
+- **`stop`** — interrupt a running agent. The actor stays around; you can `run` it again.
+- **`discard`** — remove the worktree and the database row.
+
+Multiple `run_actor` calls against the same actor keep building on the same session — you can hand off work, inspect logs, run again with more guidance.
+
+## Database and runtime paths
+
+State lives at `~/.actor/actor.db`, a SQLite database created on first use. Worktrees live at `~/.actor/worktrees/<name>/`. Claude session logs land in `~/.claude/projects/<encoded-dir>/<session-id>.jsonl` — `logs_actor` reads from there.
+
+## What discard does NOT clean up
+
+`discard` removes the worktree directory and the database row, but **leaves the underlying git branch in place**. This is intentional: the default `on-discard` hook only catches unstaged modifications, so committed work would be silently destroyed if the branch were force-deleted. The trade-off is that `actor new <same-name>` after a discard fails with "branch already exists" until you delete the branch yourself in the source repo (after confirming its commits are merged or unwanted), or pick a different name.
+
+## Parent-child tracking
+
+Actors can spawn other actors. When an agent inside an actor calls `new_actor`, the child inherits the `ACTOR_NAME` env var of its parent and is recorded in the database with a `parent` column pointing back. `discard` cascades: discarding a parent stops and removes its children first, then the parent itself.
+
+See the [settings.kdl tour](../../guides/03-settings-kdl/) for how to customize default behavior, and [roles](../02-roles/) for shaping what an actor does on creation.

--- a/docs/content/concepts/01-actors-and-worktrees.md
+++ b/docs/content/concepts/01-actors-and-worktrees.md
@@ -2,6 +2,7 @@
 title: "Actors and worktrees"
 description: "An actor is a coding agent running a task on its own git branch in an isolated worktree."
 weight: 1
+slug: "actors-and-worktrees"
 ---
 
 An **actor** is a coding agent — `claude` or `codex` — running a task on its own git branch, inside its own working tree. Actors are the unit of work in actor.sh: each one is isolated from your main checkout and from every other actor, so you can run several in parallel without them stepping on each other's edits.

--- a/docs/content/concepts/02-roles.md
+++ b/docs/content/concepts/02-roles.md
@@ -2,6 +2,7 @@
 title: "Roles"
 description: "Named presets in settings.kdl that bundle an agent, a system prompt, and config keys."
 weight: 2
+slug: "roles"
 ---
 
 A **role** is a named preset for `actor new`. It bundles an agent kind, a system prompt that shapes the actor's identity, and any number of config keys you want defaulted in. Roles let you define "what kind of actor" once and reuse it across tasks.

--- a/docs/content/concepts/02-roles.md
+++ b/docs/content/concepts/02-roles.md
@@ -1,0 +1,71 @@
+---
+title: "Roles"
+description: "Named presets in settings.kdl that bundle an agent, a system prompt, and config keys."
+weight: 2
+---
+
+A **role** is a named preset for `actor new`. It bundles an agent kind, a system prompt that shapes the actor's identity, and any number of config keys you want defaulted in. Roles let you define "what kind of actor" once and reuse it across tasks.
+
+## Defining a role
+
+Roles live in `~/.actor/settings.kdl` (user-wide) or `<repo>/.actor/settings.kdl` (project-local). Each role is a top-level `role` block with the role name as its sole positional argument:
+
+```kdl
+role "reviewer" {
+    description "Concise code review; flag bugs and style issues."
+    agent "claude"
+    model "sonnet"
+    prompt "You are a senior code reviewer. Be concise; flag bugs, security issues, and style violations. Don't fix anything — report findings only."
+}
+
+role "qa" {
+    description "Run tests after changes; report failures concisely."
+    agent "claude"
+    model "opus"
+    effort "max"
+    prompt "You're a QA engineer. Run the tests, report what fails."
+}
+```
+
+The recognized fields inside a role block are:
+
+- `agent` — `"claude"` or `"codex"`. Picks which CLI the actor runs.
+- `prompt` — the role's **system prompt** (its identity), described below.
+- `description` — short "when to use this role" text, surfaced by `actor roles` and `list_roles`.
+- Any other key (e.g. `model`, `effort`, `permission-mode`, `use-subscription`) — stored as a config key and merged into the actor's config at creation time.
+
+Project-level roles override user-level ones with the same name (whole-role replacement, no per-field merge).
+
+## Prompt is identity, not task
+
+The `prompt` field is the actor's **system prompt**, not a default task. For a Claude actor, it's injected as `--append-system-prompt`, layering the role's identity on top of Claude Code's defaults. The per-call task — the prompt you pass to `actor new` or `new_actor` — is something else; it tells the actor what to do, not who it is. They coexist.
+
+```bash
+actor new auth-review --role reviewer "Review src/auth/*.py for security issues"
+```
+
+Here `reviewer`'s `prompt` (the system prompt) gives the actor its reviewer identity; `"Review src/auth/*.py..."` is the task.
+
+Codex doesn't yet support role-level system prompts. A role with both `prompt` and `agent "codex"` is rejected at `actor new` time with a clear error.
+
+## The built-in `main` role
+
+A built-in `main` role exists by default — the main actor preset that `actor main` loads. Override it by adding `role "main" { ... }` to your settings.kdl; the override replaces the built-in entirely.
+
+## Discovery
+
+You don't have to remember role names — `actor roles` (CLI) and `mcp__actor__list_roles` (MCP) print the merged role table with names, agents, and descriptions. If you typo a role name on `actor new --role <bad>`, the error lists what's available.
+
+## Precedence
+
+At `actor new`, role values are layered between settings.kdl defaults and explicit CLI flags:
+
+1. Class-level hardcoded defaults
+2. User `defaults` block in settings.kdl
+3. Project `defaults` block
+4. Role config (`--role`)
+5. Explicit CLI overrides (`--agent`, `--config key=value`)
+
+Explicit `--agent` or `--config` flags beat the role; the per-call task prompt doesn't compete with the role's system prompt.
+
+See the [settings.kdl tour](../../guides/03-settings-kdl/) for the full file shape and the [config keys reference](../../reference/01-config-keys/) for valid keys per agent.

--- a/docs/content/concepts/03-hooks.md
+++ b/docs/content/concepts/03-hooks.md
@@ -1,0 +1,68 @@
+---
+title: "Lifecycle hooks"
+description: "Shell commands that fire around actor create, run, and discard events."
+weight: 3
+---
+
+Lifecycle hooks let you run shell commands around the events in an actor's life: creation, before each run, after each run, and on discard. They're declared in a top-level `hooks { }` block in `settings.kdl`, and each value is run via `/bin/sh -c` — so anything you can write in a shell line works.
+
+## The four hooks
+
+```kdl
+hooks {
+    on-start   "kubectl config use-context dev"
+    before-run "git fetch --quiet"
+    after-run  "./scripts/notify.sh"
+    on-discard "git diff --quiet && git diff --quiet --staged"
+}
+```
+
+Every hook runs with the actor's worktree as cwd, the caller's environment plus the variables `ACTOR_NAME`, `ACTOR_DIR`, `ACTOR_AGENT`, and (when the actor has a session) `ACTOR_SESSION_ID`.
+
+### `on-start` — fires once during `actor new`
+
+Runs after the actor row is recorded and the worktree is created, before `actor new` returns. A non-zero exit rolls back the actor: the database row is deleted and the worktree is torn down, so the actor never appears.
+
+Use this for one-time setup that must succeed for the actor to be viable: switching cluster contexts, copying secrets into the worktree, installing dependencies.
+
+### `before-run` — fires before every `actor run`
+
+Runs before each run, including interactive ones (`actor run -i`) and the implicit run launched by `actor new <name> "<task>"`. A non-zero exit aborts the run with no `Run` row written to the database — the agent never starts.
+
+Common uses:
+
+```kdl
+hooks {
+    before-run "git fetch --quiet"
+}
+```
+
+### `after-run` — fires after the run completes
+
+Runs once the agent process has exited and the run row has been updated with its final status. Receives three extra environment variables: `ACTOR_RUN_ID`, `ACTOR_EXIT_CODE`, `ACTOR_DURATION_MS`.
+
+Unlike the other hooks, `after-run` is **observer-only**. A non-zero exit logs a warning but does not fail the run that just completed — there's nothing to roll back. Use it for notifications, metrics, or post-run checks:
+
+```kdl
+hooks {
+    after-run "./scripts/notify.sh \"$ACTOR_NAME finished with $ACTOR_EXIT_CODE\""
+}
+```
+
+### `on-discard` — fires during `actor discard`
+
+Runs after any active agent has been stopped, before the database row is deleted. A non-zero exit aborts the discard unless the user passes `actor discard --force` (CLI) or `force=True` (MCP).
+
+If the worktree directory is already gone (deleted out from under actor.sh), the hook still runs — from `$HOME` instead of the missing path — and `ACTOR_DIR` still reports the absent path so a script can detect it.
+
+The default-friendly check is "no uncommitted work":
+
+```kdl
+hooks {
+    on-discard "git diff --quiet && git diff --quiet --staged"
+}
+```
+
+## Precedence
+
+If both `~/.actor/settings.kdl` and `<repo>/.actor/settings.kdl` define a hook, the project value wins **per event**. A user-level `after-run` plus a project-level `before-run` coexist; both fire.

--- a/docs/content/concepts/03-hooks.md
+++ b/docs/content/concepts/03-hooks.md
@@ -2,6 +2,7 @@
 title: "Lifecycle hooks"
 description: "Shell commands that fire around actor create, run, and discard events."
 weight: 3
+slug: "hooks"
 ---
 
 Lifecycle hooks let you run shell commands around the events in an actor's life: creation, before each run, after each run, and on discard. They're declared in a top-level `hooks { }` block in `settings.kdl`, and each value is run via `/bin/sh -c` — so anything you can write in a shell line works.

--- a/docs/content/concepts/04-ask-blocks.md
+++ b/docs/content/concepts/04-ask-blocks.md
@@ -1,0 +1,55 @@
+---
+title: "Ask blocks"
+description: "Customize when the orchestrator asks the user before spawning, running, or discarding actors."
+weight: 4
+---
+
+The `ask { }` block in `settings.kdl` lets you tune the orchestrator's "should I ask the user a question first?" behavior for the three lifecycle MCP tools that take meaningful parameters: `new_actor`, `run_actor`, and `discard_actor`. The strings you write are appended to the tools' descriptions at MCP-server startup, so they show up directly in the orchestrator's tool catalog.
+
+## Shape
+
+```kdl
+ask {
+    on-start   "Always confirm the agent kind for risky tasks."
+    before-run "Skip questions; assume per-run config never changes."
+    on-discard null
+}
+```
+
+Three keys are recognized — and only three:
+
+- `on-start` — appended to the description of `new_actor`.
+- `before-run` — appended to the description of `run_actor`.
+- `on-discard` — appended to the description of `discard_actor`.
+
+There is intentionally **no** `after-run` — the run has already finished, there's nothing for the orchestrator to ask before doing.
+
+## Per-key resolution
+
+For each key, the lookup is:
+
+- **Key absent** — fall through to the hardcoded default (the orchestrator's baseline guidance for that tool).
+- **String value** — append that string verbatim to the tool description.
+- **`null` or `""`** — opt out. Append nothing; the tool's description has no behavioral guidance about when to ask.
+
+This means you can both tighten the defaults (give the orchestrator stricter rules) and loosen them (silence the default with `null` for tools where you want the model to act without asking).
+
+## What the defaults look like
+
+The hardcoded defaults live in `ASK_DEFAULTS` in `src/actor/config.py`. The `on-start` default reads, in part:
+
+> Before calling `new_actor`, use `AskUserQuestion` to surface any parameter choices that would meaningfully affect the actor's behavior. […] Only ask when the user's request leaves the choice genuinely ambiguous — skip questions whose answer is already clear from context or whose default is fine.
+
+The `before-run` default tells the orchestrator to default to proceeding without asking unless the prompt is genuinely vague or the user signals per-run config tweaks. The `on-discard` default tells it to ask only when the target is ambiguous or there's a running session worth inspecting first.
+
+In each case, the user can write a string to override and steer in either direction.
+
+## When edits take effect
+
+Tool descriptions are computed once at MCP-server startup and stay static for the server's lifetime. After editing `settings.kdl`, re-exec the orchestrator (`actor main`) so the new descriptions are picked up. There's no hot reload.
+
+## Precedence
+
+User and project `ask` blocks merge **per key**, not per block. A project file that sets only `before-run` leaves the user's `on-start` and `on-discard` intact; a project file that sets `on-start null` silences whatever the user (or the default) had there.
+
+See [hooks](../03-hooks/) for the related `hooks { }` block, which uses the same `on-start` / `before-run` / `on-discard` vocabulary but for shell commands rather than orchestrator guidance.

--- a/docs/content/concepts/04-ask-blocks.md
+++ b/docs/content/concepts/04-ask-blocks.md
@@ -2,6 +2,7 @@
 title: "Ask blocks"
 description: "Customize when the orchestrator asks the user before spawning, running, or discarding actors."
 weight: 4
+slug: "ask-blocks"
 ---
 
 The `ask { }` block in `settings.kdl` lets you tune the orchestrator's "should I ask the user a question first?" behavior for the three lifecycle MCP tools that take meaningful parameters: `new_actor`, `run_actor`, and `discard_actor`. The strings you write are appended to the tools' descriptions at MCP-server startup, so they show up directly in the orchestrator's tool catalog.

--- a/docs/content/concepts/05-channel-notifications.md
+++ b/docs/content/concepts/05-channel-notifications.md
@@ -2,6 +2,7 @@
 title: "Channel notifications"
 description: "How actor completion events flow back into the orchestrator's conversation."
 weight: 5
+slug: "channel-notifications"
 ---
 
 When you spawn an actor with `new_actor` or `run_actor`, the MCP tool returns immediately — the agent runs in a background thread. The orchestrator doesn't poll for completion; it gets a push notification when each actor finishes. That mechanism is the **actor channel**.

--- a/docs/content/concepts/05-channel-notifications.md
+++ b/docs/content/concepts/05-channel-notifications.md
@@ -1,0 +1,49 @@
+---
+title: "Channel notifications"
+description: "How actor completion events flow back into the orchestrator's conversation."
+weight: 5
+---
+
+When you spawn an actor with `new_actor` or `run_actor`, the MCP tool returns immediately — the agent runs in a background thread. The orchestrator doesn't poll for completion; it gets a push notification when each actor finishes. That mechanism is the **actor channel**.
+
+## The capability
+
+The actor MCP server declares an experimental capability called `claude/channel` during its initialization handshake. When an actor's run finishes, the server emits a `notifications/claude/channel` JSON-RPC notification through the same MCP session that started the run:
+
+```python
+# src/actor/server.py
+notification = JSONRPCNotification(
+    jsonrpc="2.0",
+    method="notifications/claude/channel",
+    params={"content": f"[{name}] {body}", "meta": {"actor": name, "status": status}},
+)
+```
+
+The `meta` dict carries the actor name and final status (`done`, `error`, `stopped`, or the special string `discarded` if the actor row was removed before the run could record a status). The orchestrator receives the event as a `<channel source="actor" ...>` block in its conversation and reads the result inline.
+
+## Claude Code only — for now
+
+This wiring depends on the host forwarding custom MCP notifications into the model's conversation. Today, that's Claude Code.
+
+Codex does **not** forward MCP server notifications to the model — tracked in [openai/codex#17543](https://github.com/openai/codex/issues/17543) and [#18056](https://github.com/openai/codex/issues/18056). Codex actors still run, but a Codex orchestrator never learns when they finish; it would have to poll with `list_actors` or `show_actor` instead. For now, run your orchestrator on Claude Code; Codex is fine as an actor agent (`agent="codex"`), just not as the orchestrator.
+
+## Each spawn must be its own tool call
+
+There is one mechanical rule for using these tools: **each `new_actor` or `run_actor` MUST be its own tool call.** Never batch multiple in a single combined tool use. Completion notifications are routed by session; batching them in one call mis-routes the events and the orchestrator loses track of which actor finished.
+
+This is why the skill instructions tell the orchestrator to spawn three actors as three separate tool uses, not one.
+
+## Sub-claudes inherit the channel
+
+Actors are themselves Claude sessions, and they can spawn their own actors. To make nested orchestration work, `ClaudeAgent` automatically forwards the channel flag to every sub-claude it launches:
+
+```python
+# src/actor/agents/claude.py
+_CHANNEL_ARGS = ["--dangerously-load-development-channels", "server:actor"]
+```
+
+Both `start` and `resume` prepend these args to the `claude` invocation, so a child actor's session sees the same `claude/channel` capability as the top-level orchestrator. Grandchild actors then notify their parents, recursively.
+
+## CLI fallback has no notifications
+
+`actor new` and `actor run` from a regular shell (no MCP) work the same way — they spawn the agent in the background and return — but there's no push channel back to anywhere. You'd have to `actor show <name>` or `actor logs <name>` to see whether the actor finished. The CLI is a strict subset of the MCP path; for orchestrated work, use `actor main` and let the channel notifications drive the conversation.

--- a/docs/content/concepts/_index.md
+++ b/docs/content/concepts/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Concepts"
+description: "The mental model: actors, roles, hooks, ask blocks, and channel notifications."
+weight: 2
+---
+
+These pages explain the moving parts of actor.sh — what each piece is, why it exists, and how the parts fit together. They're the layer above the [reference](../reference/) docs: less "what flag does what" and more "what is this thing, conceptually."
+
+- [Actors and worktrees](01-actors-and-worktrees/) — what an actor is, the isolated-worktree model, lifecycle from `new` through `discard`, and parent/child tracking.
+- [Roles](02-roles/) — named presets in `settings.kdl` that bundle an agent, a system prompt, and config defaults.
+- [Lifecycle hooks](03-hooks/) — shell commands that fire around create, run, and discard events.
+- [Ask blocks](04-ask-blocks/) — customize when the orchestrator asks the user a question before key MCP calls.
+- [Channel notifications](05-channel-notifications/) — how completion events flow from sub-actors back to the orchestrator without polling.
+
+The [Guides](../guides/) section turns these concepts into task-shaped recipes (configuring agents, writing settings.kdl, theming the watch TUI).

--- a/docs/content/getting-started/01-introduction.md
+++ b/docs/content/getting-started/01-introduction.md
@@ -1,0 +1,19 @@
+---
+title: "Introduction"
+description: "What actor.sh is and why it exists."
+slug: "introduction"
+weight: 1
+---
+
+actor.sh manages multiple Claude/Codex coding agents running in parallel,
+each in its own isolated git worktree. You talk to one main actor — the
+session you launch with `actor main` — and it spawns specialized peer
+actors to handle the actual work, verifies their output, and reports
+back.
+
+Each actor runs in its own worktree on its own branch, so parallel work
+doesn't collide. Completion notifications flow back to the main actor
+via a channel, so it knows when work is done without polling.
+
+This documentation covers installation, the conceptual model, and
+reference material for the CLI and configuration.

--- a/docs/content/getting-started/02-installation.md
+++ b/docs/content/getting-started/02-installation.md
@@ -2,6 +2,7 @@
 title: "Installation"
 description: "Get actor.sh installed and registered with Claude Code."
 weight: 2
+slug: "installation"
 ---
 
 actor.sh ships as a Python package that exposes the `actor` CLI and an MCP server. The recommended path is to install with `uv`, register the bundled skill with Claude Code, and verify that the orchestrator session can see the `mcp__actor__*` tools.

--- a/docs/content/getting-started/02-installation.md
+++ b/docs/content/getting-started/02-installation.md
@@ -1,0 +1,92 @@
+---
+title: "Installation"
+description: "Get actor.sh installed and registered with Claude Code."
+weight: 2
+---
+
+actor.sh ships as a Python package that exposes the `actor` CLI and an MCP server. The recommended path is to install with `uv`, register the bundled skill with Claude Code, and verify that the orchestrator session can see the `mcp__actor__*` tools.
+
+## Prerequisites
+
+You need two things on your `PATH` before starting:
+
+- **`uv`** — Astral's Python package manager. It's the cleanest way to install Python CLI tools system-wide. If you don't have it yet:
+
+  ```bash
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  ```
+
+- **`claude`** — the Claude Code CLI. actor.sh's orchestrator session is a Claude Code session with a system prompt and channel flag layered on top, so the binary needs to be installed and authenticated first. See the [Claude Code install docs](https://claude.com/claude-code) if you don't have it.
+
+You can use `pip install actor-sh` instead of `uv` if that's already your workflow, but the rest of this guide assumes `uv`.
+
+## Install the actor package
+
+```bash
+uv tool install actor-sh
+```
+
+This installs the `actor` command globally (in `~/.local/bin` by default). Verify it landed:
+
+```bash
+actor --version
+```
+
+You should see something like `actor-sh 0.1.x`. If the command isn't found, make sure `~/.local/bin` is on your `PATH`.
+
+## Register with Claude Code
+
+Installing the package isn't enough on its own — Claude Code needs to know about the bundled skill and the MCP server. One command wires both up:
+
+```bash
+actor setup --for claude-code
+```
+
+This is **idempotent**, so re-running it is safe.
+
+"Registered" means two things happened:
+
+1. The bundled `_skill/` directory (the skill that teaches Claude how to drive actor.sh) is deployed to Claude Code's skill directory.
+2. The MCP server is added to Claude Code's MCP config under the name `actor`, so any new Claude Code session — and `actor main` in particular — sees the `mcp__actor__*` tools in its tool list.
+
+### Scope: user vs project
+
+By default `actor setup` installs **user-wide** (the skill and MCP are available in every Claude Code session you start). If you want the integration scoped to a single repository instead, pass `--scope project`:
+
+```bash
+actor setup --for claude-code --scope project
+```
+
+Project-scoped installs write into the current repo's local Claude Code config and only activate when you launch Claude Code from inside that repo.
+
+### Renaming the registration
+
+If you already have an `actor` MCP registered (for example, a development build alongside the published one), use `--name` to register under a different identifier:
+
+```bash
+actor setup --for claude-code --name actor-dev
+```
+
+The skill itself still calls the tools `mcp__<name>__*`, so a different name means the deployed skill references that name throughout.
+
+## Verify the install
+
+The simplest verification is to launch the orchestrator and check that the actor tools show up:
+
+```bash
+actor main
+```
+
+Inside the session, ask "what actor tools do you have available?" — Claude Code should list `mcp__actor__list_actors`, `mcp__actor__new_actor`, `mcp__actor__run_actor`, and the rest. If those tools are missing, the MCP server isn't connected; re-run `actor setup --for claude-code` and start a fresh Claude Code session.
+
+## Updating after upgrades
+
+When you bump `actor-sh` to a new version, the package upgrade alone doesn't refresh the deployed skill files — those were copied at setup time. Run:
+
+```bash
+actor update
+```
+
+`actor update` rewrites the deployed skill files in place so they match the version of `actor-sh` you just installed. Use `--scope project` if your install was project-scoped, and `--name <id>` if you registered under a non-default name. There's a built-in version check inside the skill that warns when the deployed copy drifts from the installed package, so you'll usually notice when it's time to run this.
+
+You're now ready to launch your first actor — see [your first actor](../first-actor/).

--- a/docs/content/getting-started/03-first-actor.md
+++ b/docs/content/getting-started/03-first-actor.md
@@ -1,0 +1,91 @@
+---
+title: "Your first actor"
+description: "Launch the orchestrator, spawn an actor, and inspect the work it did."
+weight: 3
+---
+
+This walk-through takes you from a fresh shell to a finished actor. You'll launch the main actor, ask it to spin up a sub-actor in natural language, then inspect the work and clean up.
+
+## Open the orchestrator
+
+Change into the repository you want to work on and run:
+
+```bash
+cd ~/work/myapp
+actor main
+```
+
+`actor main` execs `claude` with two pieces layered on:
+
+- The built-in `main` role's prompt (the main actor brief) is appended as a system prompt.
+- The actor channel is enabled, so completion notifications from sub-actors flow back into the conversation.
+
+You're now in a normal Claude Code session — the only difference is that this one knows how to manage actors and learns about their completion in real time.
+
+## Ask for an actor
+
+Talk to the orchestrator in plain English. For example:
+
+> Spin up an actor to refactor the auth module. Simplify the token validation logic and make sure the tests still pass.
+
+What happens under the hood:
+
+1. The orchestrator picks a descriptive lowercase-with-hyphens name — say `refactor-auth`.
+2. It calls `mcp__actor__new_actor` with that name and a prompt derived from your request.
+3. actor.sh creates a new git branch and a worktree at `~/.actor/worktrees/refactor-auth/`, then launches a Claude Code sub-agent inside it.
+4. The orchestrator returns control to you immediately. The sub-actor keeps working in the background.
+5. When the sub-actor finishes, a channel notification arrives in your orchestrator session as a `<channel source="actor" ...>` event. The orchestrator reads it and reports the result.
+
+You can keep talking to the orchestrator while sub-actors are running. Spawn more (`also start a reviewer to look at the API once that's done`), ask about progress, or work on something unrelated. Each `new_actor` and `run_actor` call goes through its own tool invocation so completion events route correctly.
+
+## Inspect from the shell
+
+Sometimes you want to look at the raw state without going through the orchestrator. The CLI mirrors the MCP tools.
+
+### List actors
+
+```bash
+actor list
+actor list --status running
+```
+
+This prints a table with each actor's name, agent, status, and a short status line. Useful as a quick check that something is actually running.
+
+### Show details for one
+
+```bash
+actor show refactor-auth
+actor show refactor-auth --runs 20
+```
+
+`actor show` prints metadata (worktree path, branch, agent, session ID, stored config) plus the most recent runs. `--runs N` controls how many run rows are included; `--runs 0` shows just the metadata.
+
+### Read the agent's session log
+
+```bash
+actor logs refactor-auth
+actor logs refactor-auth --verbose
+actor logs refactor-auth --watch
+```
+
+The plain output color-codes user prompts and assistant responses. `--verbose` adds tool calls, thinking, and timestamps — that's the form to use when something went wrong and you need to see exactly what the agent tried. `--watch` streams output live as the agent works.
+
+### See the diff
+
+The actor's branch lives in `~/.actor/worktrees/<name>/`, so you can `cd` there and run normal `git` commands, or use the watch dashboard's Diff tab (see [the watch dashboard](../watch-dashboard/)).
+
+## Discard when you're done
+
+Once you've reviewed the actor's work and either merged its branch or decided to throw it away, drop the actor with:
+
+```bash
+actor discard refactor-auth
+```
+
+Discard removes the worktree directory and the actor's row from the database. It runs the configured `on-discard` hook first; the default hook checks that there are no uncommitted changes, so committed work or merged branches discard cleanly. If the hook fails (uncommitted edits, for example) and you really do want to discard anyway, pass `--force` / `-f`.
+
+A note on what discard does **not** touch: the underlying git branch stays in place. If you want to reuse the same actor name later, delete the branch in the source repo first (`git branch -D refactor-auth`) or pick a different name.
+
+## The dashboard alternative
+
+Everything above also has a TUI form: [the watch dashboard](../watch-dashboard/) shows the actor list, logs, diffs, and runs in a live master-detail view, and lets you drop into a live Claude or Codex session for any actor. Most users keep `actor watch` open in one window while working with the orchestrator in another.

--- a/docs/content/getting-started/03-first-actor.md
+++ b/docs/content/getting-started/03-first-actor.md
@@ -2,6 +2,7 @@
 title: "Your first actor"
 description: "Launch the orchestrator, spawn an actor, and inspect the work it did."
 weight: 3
+slug: "first-actor"
 ---
 
 This walk-through takes you from a fresh shell to a finished actor. You'll launch the main actor, ask it to spin up a sub-actor in natural language, then inspect the work and clean up.

--- a/docs/content/getting-started/04-watch-dashboard.md
+++ b/docs/content/getting-started/04-watch-dashboard.md
@@ -2,6 +2,7 @@
 title: "The watch dashboard"
 description: "Tour the Textual TUI for live actor status, logs, diffs, and embedded sessions."
 weight: 4
+slug: "watch-dashboard"
 ---
 
 `actor watch` opens a live dashboard for everything you have in flight. It's a Textual app — runs in your terminal by default, or in a browser via textual-serve. Most workflows keep it open in one pane while the orchestrator runs in another.

--- a/docs/content/getting-started/04-watch-dashboard.md
+++ b/docs/content/getting-started/04-watch-dashboard.md
@@ -1,0 +1,88 @@
+---
+title: "The watch dashboard"
+description: "Tour the Textual TUI for live actor status, logs, diffs, and embedded sessions."
+weight: 4
+---
+
+`actor watch` opens a live dashboard for everything you have in flight. It's a Textual app — runs in your terminal by default, or in a browser via textual-serve. Most workflows keep it open in one pane while the orchestrator runs in another.
+
+```bash
+actor watch
+```
+
+## Layout
+
+The dashboard is a master-detail split:
+
+- **Left:** a tree of all actors. Top-level actors are sorted with running first, then by creation time. Children (actors spawned by other actors) are indented under their parent with tree characters.
+- **Right:** a tabbed detail panel for whichever actor is selected.
+- **Header / footer:** aggregate counts (`4 actors: 2 running, 1 done, 1 error`) and key hints.
+
+### Status icons
+
+Each row in the tree starts with one of:
+
+- `●` running
+- `○` done
+- `✗` error
+- `◌` idle
+- `■` stopped
+
+The selected actor is shown with reverse video so it's easy to spot.
+
+### Detail tabs
+
+Four tabs, each switchable by a single letter (case-insensitive, regardless of which pane has focus):
+
+- **L** — Logs. The agent's session output, color-coded by role. Auto-scrolls for running actors. Press `f` to toggle follow mode, `v` to toggle verbose (tool calls, thinking, timestamps).
+- **D** — Diff. `git diff` against the actor's base branch, syntax-highlighted. If the actor changed multiple files, a file list appears at the top.
+- **R** — Runs. A table of every run for this actor — index, status, exit code, prompt, started-at, duration.
+- **I** — Info. Metadata: agent kind, worktree path, source repo, base branch, parent, session ID, created-at, stored config.
+
+When an actor transitions from running to done or error, the dashboard auto-switches you to the Diff tab if you're viewing that actor — so the result of the work lands in front of you without an extra keystroke.
+
+## Navigation
+
+Three navigation schemes work everywhere — pick whichever matches your muscle memory:
+
+| Action          | Vim | Arrow | Emacs    |
+| --------------- | --- | ----- | -------- |
+| Previous actor  | `k` | up    | `Ctrl+P` |
+| Next actor      | `j` | down  | `Ctrl+N` |
+| Focus actor list| `h` | left  | —        |
+| Focus detail    | `l` | right | —        |
+
+Plus the global keys: `Ctrl+P` opens Textual's built-in command palette (filter by status, jump to actor by name, toggle log verbosity), `/` is search, and `q` quits.
+
+## Interactive sessions
+
+You don't have to leave the dashboard to talk to a sub-actor. Select one in the tree and press **Enter**: the detail pane swaps to an embedded terminal running `claude --resume <session_id>` (or `codex resume <session_id>`) inside the actor's worktree. You're typing directly into a live Claude or Codex session.
+
+A few things to know:
+
+- The actor must not currently be running, and it must already have a session (i.e. it's been run at least once).
+- **Ctrl+Z** leaves the embedded widget but keeps the subprocess alive — you can navigate around the dashboard, look at other actors, then come back. Selecting a different actor while a session is parked just shows that actor's logs.
+- Quitting watch (`q`) sends SIGTERM to all live subprocesses and marks their runs as `STOPPED`.
+- Each interactive session is recorded as a Run with prompt `*interactive*`, so it shows up in the Runs tab and `actor show` alongside normal runs.
+
+## Browser mode
+
+If you'd rather have the dashboard in a browser tab — easier to keep visible alongside other windows, or to share over SSH port-forwarding — pass `--serve`:
+
+```bash
+actor watch --serve
+```
+
+This starts textual-serve on `localhost:2204` and opens the same Textual app there. Same keys, same layout.
+
+## SSH-friendly mode
+
+The dashboard plays a brief splash animation on startup. Over a slow connection it can stutter; disable it with:
+
+```bash
+actor watch --no-animation
+```
+
+## Diagnostics
+
+If an embedded interactive session does something weird — keys not registering, ANSI sequences mis-rendering, the widget appearing to hang — press **Ctrl+Shift+D** to dump the I/O ring buffer for the active session to stderr. The buffer holds the recent stream of bytes read from and written to the PTY plus the events the widget handled, which is usually enough to figure out where the loop went sideways. Useful when filing a bug.

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Getting started"
+description: "Install actor.sh, register it with Claude Code, and spawn your first actor."
+weight: 1
+---
+
+The pages here walk you from a fresh machine to a running orchestrator session with verified actors. Read them in order the first time — each builds on the previous one.
+
+- [Introduction](01-introduction/) — what actor.sh is, the problem it solves, and the shape of an orchestrator session.
+- [Installation](02-installation/) — install the `actor` package, register the skill and MCP server with Claude Code, and verify the wiring.
+- [Your first actor](03-first-actor/) — launch `actor main`, ask it to spawn a sub-actor, and inspect the result end-to-end.
+- [The watch dashboard](04-watch-dashboard/) — tour the `actor watch` TUI: master-detail layout, status icons, navigation, and embedded interactive sessions.
+
+Once you're comfortable, the [Concepts](../concepts/) section explains the underlying model — actors and worktrees, roles, hooks, ask blocks, and channel notifications.

--- a/docs/content/guides/01-claude-config.md
+++ b/docs/content/guides/01-claude-config.md
@@ -2,6 +2,7 @@
 title: "Configuring the Claude Agent"
 description: "Every config key the Claude agent accepts, with CLI and settings.kdl examples."
 weight: 1
+slug: "claude-config"
 ---
 
 The Claude agent is configured through key-value pairs that you pass on the CLI, define inside a [Role](../../concepts/02-roles/), or set as defaults in [settings.kdl](../03-settings-kdl/). All three paths use the same key names — what changes is how the value is layered into the final config.

--- a/docs/content/guides/01-claude-config.md
+++ b/docs/content/guides/01-claude-config.md
@@ -1,0 +1,154 @@
+---
+title: "Configuring the Claude Agent"
+description: "Every config key the Claude agent accepts, with CLI and settings.kdl examples."
+weight: 1
+---
+
+The Claude agent is configured through key-value pairs that you pass on the CLI, define inside a [Role](../../concepts/02-roles/), or set as defaults in [settings.kdl](../03-settings-kdl/). All three paths use the same key names — what changes is how the value is layered into the final config.
+
+This page lists every key the Claude agent recognizes and shows both the per-actor CLI form and the role / settings.kdl form for each.
+
+## How keys are routed
+
+Two categories of keys exist:
+
+- **Actor-sh interpreted keys** are consumed by actor.sh itself and never reach the `claude` binary. The whitelist lives on `ClaudeAgent.ACTOR_DEFAULTS`. Today this is just `use-subscription`.
+- **Everything else** is forwarded to `claude` verbatim as `--<key> <value>`. Claude uses semantic long flags, so the key you write is the flag Claude receives. Unknown keys are passed through and `claude` decides whether they're valid.
+
+Set keys per-actor with `--config`:
+
+```bash
+actor new my-feature --config model=opus --config permission-mode=acceptEdits "Refactor auth module"
+```
+
+Or as defaults in `~/.actor/settings.kdl`:
+
+```kdl
+defaults "claude" {
+    model "opus"
+    permission-mode "acceptEdits"
+}
+```
+
+Or as part of a role:
+
+```kdl
+role "reviewer" {
+    agent "claude"
+    model "opus"
+    permission-mode "plan"
+    prompt "You are a senior code reviewer. Report findings only."
+}
+```
+
+The merge order, lowest to highest, is: class defaults → user kdl → project kdl → role → CLI `--config`. See [settings.kdl](../03-settings-kdl/) for the full breakdown.
+
+## use-subscription
+
+Actor-sh interpreted. When `true` (the default), actor.sh strips `ANTHROPIC_API_KEY` from the agent's environment so Claude uses your logged-in `claude` subscription. Set to `false` to keep the API key and bill against it instead.
+
+```bash
+actor new my-feature --config use-subscription=false
+```
+
+```kdl
+defaults "claude" {
+    use-subscription false
+}
+```
+
+## model
+
+Selects which Claude model to use. You can also set this with the dedicated `--model` flag on `actor new`, which is equivalent to `--config model=<value>`.
+
+```bash
+actor new my-feature --model opus
+actor new my-feature --config model=sonnet
+```
+
+Accepts `sonnet`, `opus`, `haiku`, or a full model ID like `claude-sonnet-4-6`. Default: Claude's own default model.
+
+## permission-mode
+
+Controls how the agent handles permission checks. Default: `auto`, which in an isolated actor worktree is effectively autonomous.
+
+```bash
+actor new my-feature --config permission-mode=acceptEdits
+```
+
+Options:
+
+- `auto` (default) — agent decides when to ask for approval
+- `bypassPermissions` — skip all permission checks
+- `acceptEdits` — auto-approve file edits, ask for other actions
+- `default` — standard permission prompts
+- `dontAsk` — never ask, skip actions that need approval
+- `plan` — plan mode, no edits
+
+## effort
+
+Controls the thinking effort level. Options: `low`, `medium`, `high`, `max`. Default: `high`.
+
+```bash
+actor new my-feature --config effort=max
+```
+
+## system-prompt
+
+Replaces Claude Code's default system prompt entirely. Use this for highly specialized agents where you don't want Claude Code's standard tooling guidance.
+
+```bash
+actor new auditor --config system-prompt="You are a senior security engineer. Review all code for vulnerabilities."
+```
+
+## append-system-prompt
+
+Layers extra instructions on top of the default system prompt. This is the same key roles use under the hood — a role's `prompt` field is injected as `--append-system-prompt`, so role identity stacks with Claude Code's standard behavior.
+
+```bash
+actor new my-feature --config append-system-prompt="Always write tests. Use pytest."
+```
+
+## allowed-tools / disallowed-tools
+
+Restrict which tools the agent can use. Values are a single string of tool names; quote it on the shell.
+
+```bash
+actor new my-feature --config allowed-tools="Read Edit Grep Glob"
+actor new my-feature --config disallowed-tools="Bash"
+```
+
+## add-dir
+
+Grants the agent access to directories outside its worktree.
+
+```bash
+actor new my-feature --config add-dir=/path/to/shared/lib
+```
+
+## mcp-config
+
+Loads MCP servers from a JSON config file, giving the actor access to external tools.
+
+```bash
+actor new my-feature --config mcp-config=/path/to/mcp.json
+```
+
+## Built-in defaults
+
+Even without a settings.kdl, every Claude actor starts with:
+
+```kdl
+defaults "claude" {
+    use-subscription "true"
+    permission-mode "auto"
+}
+```
+
+These come from `ClaudeAgent.AGENT_DEFAULTS` and `ClaudeAgent.ACTOR_DEFAULTS`. Cancel a built-in by setting it to `null` in your kdl:
+
+```kdl
+defaults "claude" {
+    permission-mode null
+}
+```

--- a/docs/content/guides/02-codex-config.md
+++ b/docs/content/guides/02-codex-config.md
@@ -1,0 +1,128 @@
+---
+title: "Configuring the Codex Agent"
+description: "Every config key the Codex agent accepts, with CLI and settings.kdl examples."
+weight: 2
+---
+
+The Codex agent is configured the same way as Claude — `--config` on the CLI, inside a [Role](../../concepts/02-roles/), or as defaults in [settings.kdl](../03-settings-kdl/). The difference is that Codex uses its native flag names verbatim: there's no semantic translation layer between what you write and what `codex` receives.
+
+This page lists every Codex config key and shows both the CLI form and the kdl form.
+
+## How keys are routed
+
+Two categories of keys exist:
+
+- **Actor-sh interpreted keys** are consumed by actor.sh itself and never reach the `codex` binary. The whitelist lives on `CodexAgent.ACTOR_DEFAULTS`. Today this is just `use-subscription`.
+- **Everything else** is forwarded to `codex` as a CLI flag. One-character keys become short flags (`m` → `-m`, `a` → `-a`); longer keys become long flags (`sandbox` → `--sandbox`, `add-dir` → `--add-dir`). Unknown keys are passed through and `codex` decides whether they're valid.
+
+Set keys per-actor with `--config`:
+
+```bash
+actor new my-feature --agent codex --config m=o3 --config sandbox=workspace-write "Investigate failing tests"
+```
+
+Or as defaults in `~/.actor/settings.kdl`:
+
+```kdl
+defaults "codex" {
+    m "o3"
+    sandbox "workspace-write"
+}
+```
+
+The full merge order, lowest to highest, is: class defaults → user kdl → project kdl → role → CLI `--config`. See [settings.kdl](../03-settings-kdl/) for the breakdown.
+
+## use-subscription
+
+Actor-sh interpreted. When `true` (the default), actor.sh strips `OPENAI_API_KEY` from the agent's environment so Codex uses your logged-in `codex` subscription. Set to `false` to keep the API key and bill against it.
+
+```bash
+actor new my-feature --agent codex --config use-subscription=false
+```
+
+```kdl
+defaults "codex" {
+    use-subscription false
+}
+```
+
+## m (model)
+
+Selects the model. The key is `m` because that's Codex's own short flag — actor.sh emits `-m <value>`. You can also set this with the dedicated `--model` flag on `actor new`, which routes to the same `m` key.
+
+```bash
+actor new my-feature --agent codex --config m=o3
+actor new my-feature --agent codex --model o3
+```
+
+Default: Codex's own default model.
+
+## sandbox
+
+Controls the sandbox policy for shell commands. Default: `danger-full-access` — actor.sh ships this as a class-level default because actors already run in isolated worktrees.
+
+```bash
+actor new my-feature --agent codex --config sandbox=workspace-write
+```
+
+Options:
+
+- `danger-full-access` (default) — no filesystem sandboxing
+- `workspace-write` — allow writes only in the workspace
+- `read-only` — no writes allowed
+
+## a (approval)
+
+Controls when the agent asks for approval before running commands. The key is `a` because that's Codex's short flag. Default: `never`.
+
+```bash
+actor new my-feature --agent codex --config a=on-request
+```
+
+Options:
+
+- `never` (default) — never ask, execute everything
+- `on-request` — agent decides when to ask
+- `untrusted` — auto-approve only trusted commands (`ls`, `cat`, etc.)
+
+## add-dir
+
+Grants the agent write access to directories outside its worktree. Codex receives `--add-dir <path>`.
+
+```bash
+actor new my-feature --agent codex --config add-dir=/path/to/shared/lib
+```
+
+## search
+
+Enables live web search. Codex receives `--search true`.
+
+```bash
+actor new my-feature --agent codex --config search=true
+```
+
+## Built-in defaults
+
+Without any settings.kdl, every Codex actor starts with:
+
+```kdl
+defaults "codex" {
+    use-subscription "true"
+    sandbox "danger-full-access"
+    a "never"
+}
+```
+
+These come from `CodexAgent.AGENT_DEFAULTS` and `CodexAgent.ACTOR_DEFAULTS`. Cancel any of them by setting the key to `null` in your kdl.
+
+## Codex compatibility note
+
+actor.sh works for Codex agents driven from the CLI — `actor new`, `actor run`, `actor watch` all behave the same regardless of agent kind. However, **the orchestrator integration (Claude Code via the actor MCP server) is the recommended driver, not Codex.**
+
+Codex does not currently forward MCP server notifications into the model's conversation, which means actors spawned from a Codex orchestrator finish silently — the model never sees the completion event. Tracked upstream in [openai/codex#17543](https://github.com/openai/codex/issues/17543) and [openai/codex#18056](https://github.com/openai/codex/issues/18056).
+
+Until Codex ships notification forwarding, use Claude Code as the orchestrator and let it spawn Codex actors as needed.
+
+## Roles and Codex
+
+Roles can bundle Codex config keys exactly like Claude — `m`, `sandbox`, `a`, etc. — but they cannot supply a system prompt for a Codex actor. Codex has no `--append-system-prompt`-style flag (instructions live in `AGENTS.md` / `config.toml`), so a role with both `agent "codex"` and a `prompt` field is rejected at `actor new` time with a clear error rather than silently dropped.

--- a/docs/content/guides/02-codex-config.md
+++ b/docs/content/guides/02-codex-config.md
@@ -2,6 +2,7 @@
 title: "Configuring the Codex Agent"
 description: "Every config key the Codex agent accepts, with CLI and settings.kdl examples."
 weight: 2
+slug: "codex-config"
 ---
 
 The Codex agent is configured the same way as Claude — `--config` on the CLI, inside a [Role](../../concepts/02-roles/), or as defaults in [settings.kdl](../03-settings-kdl/). The difference is that Codex uses its native flag names verbatim: there's no semantic translation layer between what you write and what `codex` receives.

--- a/docs/content/guides/03-settings-kdl.md
+++ b/docs/content/guides/03-settings-kdl.md
@@ -2,6 +2,7 @@
 title: "settings.kdl Tour"
 description: "Roles, per-agent defaults, hooks, and ask blocks — every top-level node explained."
 weight: 3
+slug: "settings-kdl"
 ---
 
 `settings.kdl` is where you teach actor.sh about the roles, defaults, hooks, and orchestrator guidance specific to your environment. This tour walks through every top-level block and explains how the user-wide and project-local files combine.

--- a/docs/content/guides/03-settings-kdl.md
+++ b/docs/content/guides/03-settings-kdl.md
@@ -1,0 +1,140 @@
+---
+title: "settings.kdl Tour"
+description: "Roles, per-agent defaults, hooks, and ask blocks — every top-level node explained."
+weight: 3
+---
+
+`settings.kdl` is where you teach actor.sh about the roles, defaults, hooks, and orchestrator guidance specific to your environment. This tour walks through every top-level block and explains how the user-wide and project-local files combine.
+
+## File locations
+
+Two paths are read, in order:
+
+- `~/.actor/settings.kdl` — user-wide.
+- `<repo>/.actor/settings.kdl` — project-local. Discovered by walking up from your current working directory; the closest one wins.
+
+Project values override user values per-key. Missing files are skipped silently. There is no `actor init` — create the file by hand. The `.actor/` directory typically already exists since actor.sh uses it for worktrees and the SQLite database.
+
+Load the merged config programmatically with `actor.config.load_config(cwd=..., home=...)`; both arguments default to `Path.cwd()` and `$HOME` so tests can inject temp dirs.
+
+## role "<name>" { ... }
+
+A role is a named preset for `actor new`. See the [Roles](../../concepts/02-roles/) concept page for the full story; the short version is that a role bundles an agent kind, a system prompt that shapes the actor's identity, and any number of config keys.
+
+```kdl
+role "reviewer" {
+    description "Concise code review; flag bugs and style issues."
+    agent "claude"
+    model "opus"
+    prompt "You are a senior code reviewer. Be concise; flag bugs, security issues, and style violations. Don't fix anything — report findings only."
+}
+
+role "qa" {
+    description "Run the test suite and triage failures."
+    agent "claude"
+    permission-mode "acceptEdits"
+    prompt "You are a QA engineer. Run the test suite, triage failures, and report root causes."
+}
+
+role "designer" {
+    description "Frontend / UX work."
+    agent "claude"
+    model "opus"
+    allowed-tools "Read Edit Grep Glob Bash"
+    prompt "You are a senior frontend engineer. Prioritize accessibility and visual polish."
+}
+```
+
+`agent`, `prompt`, and `description` are promoted to top-level fields on the role. Every other child becomes a config key for the actor.
+
+A built-in `main` role exists by default — it's the main actor preset used by `actor main`. Override it by adding your own `role "main" { ... }` block; the override replaces the built-in wholesale (no per-field merge for roles).
+
+## defaults "<agent>" { ... }
+
+Per-agent defaults that apply to every actor of that kind. There's one block per agent — `defaults "claude" { ... }` and `defaults "codex" { ... }`.
+
+```kdl
+defaults "claude" {
+    use-subscription true
+    permission-mode "acceptEdits"
+    model "opus"
+}
+
+defaults "codex" {
+    m "o3"
+    sandbox "workspace-write"
+}
+```
+
+All keys live in one flat namespace. Each key is routed at parse time by checking the agent class's `ACTOR_DEFAULTS` whitelist:
+
+- **Whitelisted keys** (e.g. `use-subscription`) are actor-sh interpreted and never forwarded to the agent binary.
+- **Everything else** becomes a CLI flag on the agent binary. Claude uses semantic long flags (`permission-mode "auto"` → `--permission-mode auto`); Codex uses native flag names (`m "o3"` → `-m o3`, `sandbox "workspace-write"` → `--sandbox workspace-write`).
+
+A `null` value cancels a lower-precedence default:
+
+```kdl
+defaults "claude" {
+    permission-mode null   # drop the built-in "auto" default
+}
+```
+
+### Merge precedence
+
+At `actor new` time, lowest to highest:
+
+1. Class defaults baked into the agent (`AGENT_DEFAULTS` + `ACTOR_DEFAULTS`).
+2. User `~/.actor/settings.kdl` `defaults` block.
+3. Project `<repo>/.actor/settings.kdl` `defaults` block.
+4. The role chosen with `--role`.
+5. Per-call CLI `--config key=value`.
+
+The resolved merge is **snapshotted into the database at creation**. Later edits to settings.kdl don't retroactively change existing actors — use `actor config <name> key=value` to mutate an actor's stored config. At `actor run` time the stored config is the base and per-run `--config` arguments layer on top for that single run only. `null` at a higher layer cancels lower defaults; the emitter drops keys whose final value is `None`.
+
+For per-agent details, see [Configuring the Claude Agent](../01-claude-config/) and [Configuring the Codex Agent](../02-codex-config/).
+
+### Built-in class defaults
+
+Without any settings.kdl, you inherit:
+
+- **Claude** — `use-subscription "true"`, `permission-mode "auto"`.
+- **Codex** — `use-subscription "true"`, `sandbox "danger-full-access"`, `a "never"`.
+
+## hooks { ... }
+
+Shell commands that fire around lifecycle events. See [Lifecycle hooks](../../concepts/03-hooks/) for the full event reference.
+
+```kdl
+hooks {
+    on-start   "kubectl config use-context dev"
+    before-run "git fetch --quiet"
+    after-run  "./scripts/notify.sh"
+    on-discard "git diff --quiet && git diff --quiet --staged"
+}
+```
+
+Each value is run via `/bin/sh -c` in the actor's worktree, with `ACTOR_NAME`, `ACTOR_DIR`, `ACTOR_AGENT`, and (when set) `ACTOR_SESSION_ID` exported into the environment.
+
+## ask { ... }
+
+Free-form natural-language guidance appended to the orchestrator's MCP tool descriptions at server startup. See [Ask blocks](../../concepts/04-ask-blocks/) for the full key reference.
+
+```kdl
+ask {
+    on-start   "Always confirm the agent kind for risky tasks."
+    before-run "Skip questions; assume per-run config never changes."
+    on-discard null   # silence the default — discard never asks
+}
+```
+
+Valid keys are `on-start` (appended to `new_actor`), `before-run` (appended to `run_actor`), and `on-discard` (appended to `discard_actor`). A `null` or empty-string value silences the hardcoded default for that key.
+
+Tool descriptions are static for the lifetime of the MCP server, so edits to the `ask` block apply on the next `actor main` invocation.
+
+## Forward compatibility
+
+Unknown top-level nodes — for example, `alias` — are silently ignored at parse time. This keeps existing settings.kdl files compatible with future blocks introduced by follow-up tickets.
+
+## When KDL is malformed
+
+If the parser cannot read a settings file, actor.sh raises `ConfigError` with the offending path included so you can find and fix the syntax. Missing files are not errors; only malformed ones halt the run.

--- a/docs/content/guides/04-watch-theme.md
+++ b/docs/content/guides/04-watch-theme.md
@@ -2,6 +2,7 @@
 title: "Theming the Watch Dashboard"
 description: "Built-in claude-dark / claude-light themes plus omarchy desktop integration."
 weight: 4
+slug: "watch-theme"
 ---
 
 `actor watch` ships with two built-in themes — `claude-dark` and `claude-light` — and an opt-in omarchy integration that reflavors whichever one is active so the TUI matches your desktop palette. This guide covers both, plus the live-reload hook that keeps the dashboard in sync when you change desktop themes.

--- a/docs/content/guides/04-watch-theme.md
+++ b/docs/content/guides/04-watch-theme.md
@@ -1,0 +1,59 @@
+---
+title: "Theming the Watch Dashboard"
+description: "Built-in claude-dark / claude-light themes plus omarchy desktop integration."
+weight: 4
+---
+
+`actor watch` ships with two built-in themes — `claude-dark` and `claude-light` — and an opt-in omarchy integration that reflavors whichever one is active so the TUI matches your desktop palette. This guide covers both, plus the live-reload hook that keeps the dashboard in sync when you change desktop themes.
+
+## Built-in themes
+
+Out of the box you get `claude-dark` (the default) and `claude-light`. Both define the full slot palette the TUI uses — foreground, background, surface and panel chrome, primary and accent for focus rings, secondary for branding, and the semantic warning / error / success slots.
+
+If you don't run omarchy, that's the whole story: the dashboard uses the base theme as defined.
+
+## Omarchy flavoring
+
+If actor.sh detects omarchy on your machine — specifically, the file `~/.config/omarchy/current/theme/colors.toml` — the active built-in theme is **flavored** at startup with the desktop's palette so the TUI reads as part of your environment rather than a foreign island.
+
+The flavoring rules are:
+
+- `foreground` ← omarchy `colors.toml`'s `foreground`
+- `background` ← omarchy `colors.toml`'s `background`
+- `surface`, `panel` ← `background` lifted ~8% toward `foreground` so panels stay subtly distinct from the desktop background while still being palette-derived
+- `secondary` ← omarchy `colors.toml`'s `accent` (the brand / logo slot)
+- `primary`, `accent` ← `hyprland.conf`'s `$activeBorderColor`, so focus rings match your active-window border
+
+Semantic slots — `warning`, `error`, `success` — stay as the base theme defines them. `colors.toml` carries no semantic meaning, so there's nothing reasonable to override them with.
+
+The flavor logic lives in `src/actor/watch/omarchy_theme.py`.
+
+### Malformed input
+
+If `colors.toml` can't be parsed, actor.sh logs a warning and keeps whatever theme is currently active rather than crashing the TUI. The same applies to `hyprland.conf` — the dashboard always renders.
+
+## Live reload
+
+Every 3 seconds, `actor watch` re-stats the resolved-target mtime of `colors.toml`. If it has changed — for example, because you ran `omarchy theme set <name>` — the flavor is rebuilt and re-registered under the same theme name. You don't need to restart the dashboard.
+
+## Instant updates with the omarchy hook
+
+3-second polling is fine for most use, but for instant theme switches actor.sh can hook into omarchy's own theme-set event:
+
+```bash
+actor setup --for omarchy
+```
+
+This installs a one-line fragment into `~/.config/omarchy/hooks/theme-set` that sends `SIGUSR2` to any running `actor watch` process. The watch process has the SIGUSR2 handler wired unconditionally — installation only adds the hook that sends the signal. As soon as you switch desktop themes, your dashboard reflavors immediately.
+
+To remove the hook fragment:
+
+```bash
+actor setup --for omarchy --uninstall
+```
+
+The `--scope` and `--name` flags accepted by `actor setup` are ignored when `--for omarchy` is used; they're specific to the Claude Code MCP integration.
+
+## Picking a base theme
+
+The flavoring system overlays an omarchy palette on top of an existing theme — it does not pick the base theme for you. Choose `claude-dark` or `claude-light` from the dashboard's theme picker the same way you would on a non-omarchy machine, and the flavoring will follow.

--- a/docs/content/guides/_index.md
+++ b/docs/content/guides/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Guides"
+description: "Task-shaped walkthroughs: configuring agents, writing settings.kdl, theming the dashboard."
+weight: 3
+---
+
+Guides take a single task and walk you through it end-to-end — what to write, where to write it, and what happens when you do. They sit between the [concepts](../concepts/) (the "why") and the [reference](../reference/) docs (the "what flag does what").
+
+- [Configuring the Claude agent](01-claude-config/) — every config key the Claude agent accepts, with CLI and `settings.kdl` forms.
+- [Configuring the Codex agent](02-codex-config/) — the same, for Codex, plus notes on the current orchestrator-compatibility limitation.
+- [The settings.kdl tour](03-settings-kdl/) — a top-to-bottom walkthrough of the user / project config file: roles, per-agent defaults, hooks, ask blocks.
+- [Theming the watch dashboard](04-watch-theme/) — built-in themes and the omarchy desktop integration with live reload.
+
+If you're looking for a quick lookup rather than a walkthrough, jump to the [Reference](../reference/) section.

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -1,0 +1,229 @@
+---
+title: "CLI Reference"
+description: "Every actor subcommand with its flags and a worked example."
+weight: 1
+---
+
+Complete reference for the `actor` CLI. Each section covers one subcommand: its flags, defaults, and a minimal example. Run `actor --help` or `actor <cmd> --help` for the in-terminal version.
+
+## actor main
+
+Launch the orchestrator session. Resolves the `main` role from settings.kdl, takes its `prompt` as `--append-system-prompt`, and execs `claude` with the actor channel enabled. Trailing arguments are forwarded to the agent CLI verbatim.
+
+The built-in `main` role ships as the main actor. Override it with a `role "main" { ... }` block in settings.kdl to swap in your own prompt or agent. Today only `agent "claude"` is supported on this command; other agents fail with a clear error.
+
+```bash
+actor main                                # open an interactive orchestrator session
+actor main "kick off the refactor"        # one-shot
+actor main --model opus                   # forward flags to claude
+```
+
+## actor new
+
+Create a new actor. If a prompt is given (positional or piped via stdin), the actor is also run immediately after creation.
+
+| Flag | Description |
+| --- | --- |
+| `name` | Actor name. Becomes the git branch and worktree directory name. |
+| `prompt` | Optional task prompt. If omitted and stdin is piped, stdin is read. |
+| `--dir PATH` | Base directory for the worktree. Defaults to the current working directory. |
+| `--no-worktree` | Skip worktree creation; run in the directory directly. |
+| `--base BRANCH` | Branch to create the worktree from. Defaults to the current branch. |
+| `--agent NAME` | Coding agent (`claude` or `codex`). Defaults to the role's agent or `claude`. |
+| `--role NAME` | Apply a role from settings.kdl. See `actor roles` for available names. |
+| `--model NAME` | Shorthand for `--config model=<name>`. |
+| `--use-subscription` / `--no-use-subscription` | Force or disable subscription auth. Strips the agent's API key env var when on. |
+| `--config KEY=VALUE` | Agent-arg override. Repeatable. Saved as the actor's default. |
+
+```bash
+actor new my-feature                                      # create worktree, no run
+actor new my-feature "fix the nav bar"                    # create and run
+actor new my-feature --role qa                            # apply a saved role
+actor new my-feature --no-use-subscription                # pass API keys through
+actor new my-feature --no-worktree                        # use current directory
+actor new my-feature --base develop                       # branch off develop
+actor new my-feature --config effort=max --model opus     # set agent config at creation
+echo "fix it" | actor new my-feature                      # piped prompt
+```
+
+`--config` keys collide-check against the agent's `ACTOR_DEFAULTS` whitelist; passing an actor-key (e.g. `use-subscription`) through `--config` is rejected with a hint pointing at the dedicated flag.
+
+## actor run
+
+Run an existing actor with a prompt.
+
+| Flag | Description |
+| --- | --- |
+| `name` | Actor name. |
+| `prompt` | The task. If omitted and stdin is piped, stdin is read. Required unless `-i`. |
+| `-i`, `--interactive` | Resume the actor in interactive mode (TTY passthrough). |
+| `--config KEY=VALUE` | Per-run override only — not saved. Repeatable. |
+
+```bash
+actor run fix-nav "continue fixing"                       # one-shot
+actor run fix-nav --config model=opus "one-off"           # temporary config
+actor run fix-nav -i                                      # resume interactively
+echo "fix it" | actor run fix-nav                         # piped prompt
+```
+
+The CLI prints the agent's response to stdout and propagates a non-zero exit code if the run failed.
+
+## actor list
+
+List actors. Optional status filter.
+
+| Flag | Description |
+| --- | --- |
+| `--status STATUS` | Filter by status (`running`, `done`, `error`, etc.). |
+
+```bash
+actor list                                                # all actors
+actor list --status running                               # only running
+```
+
+## actor roles
+
+List roles defined in settings.kdl (built-in `main` plus user-level and project-level roles).
+
+```bash
+actor roles
+```
+
+## actor show
+
+Show full details for an actor, including recent runs.
+
+| Flag | Description |
+| --- | --- |
+| `name` | Actor name. |
+| `--runs N` | Number of recent runs to display. Default `5`. Pass `0` to omit. |
+
+```bash
+actor show my-feature
+actor show my-feature --runs 20
+actor show my-feature --runs 0
+```
+
+## actor logs
+
+View agent session output.
+
+| Flag | Description |
+| --- | --- |
+| `name` | Actor name. |
+| `-v`, `--verbose` | Include tool calls, thinking, and timestamps. |
+| `--watch` | Stream output live as it's written. |
+
+```bash
+actor logs my-feature
+actor logs my-feature --verbose
+actor logs my-feature --watch
+```
+
+## actor stop
+
+Kill the running agent for an actor. The actor row stays; only the live process is terminated.
+
+```bash
+actor stop my-feature
+```
+
+## actor config
+
+View or update an actor's saved config. With no pairs, prints the current config; with one or more `KEY=VALUE` pairs, updates those keys. Updates take effect on the next run.
+
+```bash
+actor config my-feature                                   # view
+actor config my-feature model=opus                        # update one key
+actor config my-feature model=sonnet effort=max           # update several
+```
+
+## actor mcp
+
+Start the MCP server over stdio. This is the entrypoint Claude Code uses to spawn the actor MCP — you typically don't run it by hand.
+
+| Flag | Description |
+| --- | --- |
+| `--for HOST` | Coding-agent host this server is serving (e.g. `claude-code`). |
+
+```bash
+actor mcp --for claude-code
+```
+
+## actor watch
+
+Open the dashboard TUI. Animated splash by default; use `--no-animation` over slow links.
+
+| Flag | Description |
+| --- | --- |
+| `--serve` | Serve in a browser via textual-serve on port 2204. |
+| `--no-animation` | Disable splash animation. |
+
+```bash
+actor watch                                               # local TUI
+actor watch --serve                                       # browser-served on :2204
+actor watch --no-animation                                # skip splash
+```
+
+## actor discard
+
+Remove an actor from the database. The worktree directory stays on disk and the underlying git branch is left in place — recover the name later by running `git branch -D <name>` in the source repo if needed.
+
+| Flag | Description |
+| --- | --- |
+| `name` | Actor name. |
+| `-f`, `--force` | Bypass `on-discard` hook failure. |
+
+```bash
+actor discard my-feature
+actor discard my-feature --force
+```
+
+## actor setup
+
+Install (or reinstall) an integration. Idempotent — safe to re-run.
+
+| Flag | Description |
+| --- | --- |
+| `--for HOST` | Required. Currently `claude-code` (skill + MCP) or `omarchy` (theme-set hook). |
+| `--scope SCOPE` | `user` (default), `project`, or `local`. Ignored for `--for omarchy`. |
+| `--name NAME` | MCP registration name. Default `actor`. Ignored for `--for omarchy`. |
+| `--uninstall` | Remove a previously installed integration (currently only supported for `--for omarchy`). |
+
+```bash
+actor setup --for claude-code                             # user-wide install
+actor setup --for claude-code --scope project             # project-local
+actor setup --for claude-code --name actor-dev            # alternate MCP name
+actor setup --for omarchy                                 # theme-set hook
+actor setup --for omarchy --uninstall                     # remove the hook
+```
+
+## actor update
+
+Refresh deployed skill files after upgrading actor-sh. Use `setup` for a fresh install; `update` is a lightweight refresh that keeps existing registration in place.
+
+| Flag | Description |
+| --- | --- |
+| `--for HOST` | Coding-agent host. Default `claude-code`. |
+| `--scope SCOPE` | Which install to refresh. Default `user`. |
+| `--name NAME` | MCP name used at setup time. Default `actor`. |
+
+```bash
+actor update                                              # refresh user-wide install
+actor update --scope project                              # refresh project-local
+```
+
+## actor --version
+
+Print the installed actor-sh version.
+
+```bash
+actor --version
+actor -V
+```
+
+## See also
+
+- [MCP tool reference](../02-mcp-tools/) — the surface the orchestrator sees.
+- [Config keys](../03-config-keys/) — every key per agent.
+- [Roles](../../concepts/02-roles/) — how roles wire into `actor new` and `actor main`.

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -2,6 +2,7 @@
 title: "CLI Reference"
 description: "Every actor subcommand with its flags and a worked example."
 weight: 1
+slug: "cli"
 ---
 
 Complete reference for the `actor` CLI. Each section covers one subcommand: its flags, defaults, and a minimal example. Run `actor --help` or `actor <cmd> --help` for the in-terminal version.

--- a/docs/content/reference/02-mcp-tools.md
+++ b/docs/content/reference/02-mcp-tools.md
@@ -1,0 +1,119 @@
+---
+title: "MCP Tool Reference"
+description: "Every tool the actor MCP exposes, with arguments, defaults, and behavior."
+weight: 2
+---
+
+The actor MCP server exposes nine tools to the orchestrator. From a Claude Code perspective each one is named `mcp__actor__<tool>`. This page is the contract: arguments, defaults, return shape, and any constraints.
+
+## How runs report back
+
+`new_actor` and `run_actor` both return immediately. The actual run executes in a background thread; when it finishes the server pushes a `notifications/claude/channel` event through the live MCP session. The orchestrator sees that event as `<channel source="actor" ...>` and reports the result to the user.
+
+The notification's `content` is the run's final output (or a status fallback like `Finished with status: error.`). The `meta` dict carries `{actor: <name>, status: <resolved-status>}`. When the actor was discarded mid-run the row no longer exists, so `status` reports the literal string `discarded` — it isn't a regular status enum value.
+
+See [Channel notifications](../../concepts/05-channel-notifications/) for the full event shape and the orchestrator's contract.
+
+### Tool-call constraints
+
+Each `new_actor` and `run_actor` invocation MUST be its own tool call. Do not batch multiple actor launches into a single call — the channel notification stream pairs one notification with one call, so batching loses the per-actor wiring the orchestrator depends on.
+
+Read-only tools (`list_actors`, `show_actor`, `logs_actor`, `list_roles`, `config_actor` with no pairs) can be called freely.
+
+## list_actors
+
+List all actors and their statuses.
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `status` | string | `null` | Optional filter, e.g. `"running"`, `"done"`, `"error"`. |
+
+Returns the same text table the CLI's `actor list` prints.
+
+## list_roles
+
+List the roles defined in settings.kdl. Includes the built-in `main` role plus any user-level and project-level overrides.
+
+No arguments. Returns text. Use this before calling `new_actor` with a `role` argument so the choice is grounded in what's actually defined.
+
+## show_actor
+
+Full detail for one actor: agent, dir, status, saved config, recent runs.
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | string | required | Actor name. |
+| `runs` | int | `5` | Number of recent runs to include. `0` to omit run history. |
+
+## logs_actor
+
+Agent session output. The terse view (default) shows prompts and assistant responses; verbose adds tool calls, thinking blocks, and timestamps.
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | string | required | Actor name. |
+| `verbose` | bool | `false` | Include tool calls, thinking, and timestamps. |
+
+## stop_actor
+
+Kill the running agent for an actor. The actor row stays in place — only the live process is terminated.
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | string | required | Actor name. |
+
+## discard_actor
+
+Remove an actor from the database. Stops it first if running, then runs the `on-discard` hook, then deletes the row. The worktree stays on disk and the git branch is left in place; clean those up by hand if you want the name back.
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | string | required | Actor name. |
+| `force` | bool | `false` | Bypass `on-discard` hook failure (discard even if the hook exits non-zero). |
+
+## config_actor
+
+View or update an actor's saved config.
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | string | required | Actor name. |
+| `pairs` | string[] | `[]` | Config `KEY=VALUE` pairs to set. Omit to view. |
+
+Updates take effect on the next run.
+
+## new_actor
+
+Create a new actor. If `prompt` is given, also runs it in the background.
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | string | required | Actor name (becomes the git branch). Lowercase with hyphens. |
+| `prompt` | string | `null` | Optional **task** prompt. Distinct from the role's `prompt`, which is the system prompt — omit this to create the actor idle and run it later. |
+| `agent` | `"claude"` \| `"codex"` | role's agent or `"claude"` | Coding agent. |
+| `role` | string | `null` | Apply a named role from settings.kdl. Use `list_roles` to see what's defined. |
+| `dir` | string | orchestrator cwd | Base directory for the worktree. **Use absolute paths.** Relative paths resolve against the MCP server's cwd, which is fragile across sessions. |
+| `base` | string | current branch | Branch to create the worktree from. |
+| `no_worktree` | bool | `false` | Skip worktree creation. |
+| `config` | string[] | `[]` | Agent-arg `KEY=VALUE` pairs (e.g. `["model=opus", "effort=max"]`). Saved as actor defaults. Actor-keys like `use-subscription` are rejected here — use the dedicated parameter. |
+| `use_subscription` | bool | `null` | When `true`, strip the agent's API key env var. When `false`, pass it through. When omitted, defer to lower-precedence layers (role / kdl defaults / class default). |
+
+If a `prompt` is supplied, the run kicks off in a background thread and a channel notification fires when it completes. Without a prompt, the actor is created idle.
+
+## run_actor
+
+Run an existing actor. Returns immediately; the channel notification fires on completion.
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | string | required | Actor name. |
+| `prompt` | string | required | The task. Stripped before use; an empty/whitespace prompt errors. |
+| `config` | string[] | `[]` | Per-run agent-arg overrides. **Not saved** — use `config_actor` to change defaults. Actor-keys are rejected here. |
+| `use_subscription` | bool | `null` | Per-run actor-key override. When omitted, use the actor's stored value. |
+
+## See also
+
+- [CLI reference](../01-cli/) — the same surface from the terminal side.
+- [Config keys](../03-config-keys/) — what's legal in `config=[...]`.
+- [Channel notifications](../../concepts/05-channel-notifications/) — how completion events get back to the orchestrator.
+- [Ask blocks](../../concepts/04-ask-blocks/) — how `new_actor`, `run_actor`, and `discard_actor` tool descriptions get extra guidance from settings.kdl.

--- a/docs/content/reference/02-mcp-tools.md
+++ b/docs/content/reference/02-mcp-tools.md
@@ -2,6 +2,7 @@
 title: "MCP Tool Reference"
 description: "Every tool the actor MCP exposes, with arguments, defaults, and behavior."
 weight: 2
+slug: "mcp-tools"
 ---
 
 The actor MCP server exposes nine tools to the orchestrator. From a Claude Code perspective each one is named `mcp__actor__<tool>`. This page is the contract: arguments, defaults, return shape, and any constraints.

--- a/docs/content/reference/03-config-keys.md
+++ b/docs/content/reference/03-config-keys.md
@@ -1,0 +1,102 @@
+---
+title: "Config Keys"
+description: "Every config key per agent — actor-keys, agent-args, defaults, and valid values."
+weight: 3
+---
+
+Every config key actor-sh recognizes, grouped by agent. Use this page when you need to look up what a key does, what its default is, or what values it accepts.
+
+## actor-key vs agent-arg
+
+actor-sh routes each config key into one of two buckets at parse time:
+
+- **actor-keys** are interpreted by actor-sh and are never forwarded to the agent binary. The whitelist is `ACTOR_DEFAULTS` on the agent class — currently just `use-subscription` for both Claude and Codex.
+- **agent-args** are forwarded to the agent CLI as flags. Claude uses semantic long flags: `permission-mode "auto"` becomes `--permission-mode auto`. Codex uses native flag names verbatim — one-character keys become short flags (`m "o3"` → `-m o3`), longer keys become long flags (`sandbox "workspace-write"` → `--sandbox workspace-write`).
+
+Anything not in the actor-key whitelist is treated as an agent-arg and forwarded to the agent binary. The agent decides whether the flag is valid; unknown keys can fail at run time.
+
+A `null` value in a kdl `defaults` block cancels a lower-precedence default — useful for dropping a built-in default without replacing it. Empty-string values emit a bare flag with no argument.
+
+## Setting config
+
+Three entry points cover every workflow. They share validation logic; an actor-key passed through `--config` (or MCP `config=[...]`) is rejected with a hint pointing at the dedicated entrypoint.
+
+```bash
+actor new my-feature --config model=opus --config effort=max
+actor config my-feature model=sonnet
+```
+
+```kdl
+defaults "claude" {
+    permission-mode "auto"
+    model "opus"
+}
+```
+
+Merge precedence at actor creation, lowest to highest: class `AGENT_DEFAULTS` + `ACTOR_DEFAULTS` → user kdl `defaults` block → project kdl `defaults` block → role config → CLI `--config`. The resolved merge is snapshotted into the DB; later edits to settings.kdl don't retroactively change existing actors. At run time the stored config is the base and per-run `--config` layers on top for that one run.
+
+## Claude
+
+| Key | Kind | Default | Valid values | Description |
+| --- | --- | --- | --- | --- |
+| `use-subscription` | actor-key | `true` | `true`, `false` | When `true`, strips `ANTHROPIC_API_KEY` from the agent's env so Claude uses the logged-in subscription. Set to `false` to bill against the API key. |
+| `permission-mode` | agent-arg | `auto` | `auto`, `bypassPermissions`, `acceptEdits`, `default`, `dontAsk`, `plan` | How the agent handles permission checks. `auto` is effectively autonomous inside a worktree. |
+| `model` | agent-arg | (agent's default) | `sonnet`, `opus`, `haiku`, or a full model ID | Which Claude model to use. Also settable via `--model` on `actor new`. |
+| `effort` | agent-arg | (none) | `low`, `medium`, `high`, `max` | Thinking effort level. actor.sh sets no default; the agent's own default applies if unset. |
+| `system-prompt` | agent-arg | (none) | string | Replace the default system prompt entirely. |
+| `append-system-prompt` | agent-arg | (none) | string | Add instructions on top of the default system prompt. This is also where roles inject their `prompt`. |
+| `allowed-tools` | agent-arg | (none) | space-separated tool names | Whitelist the tools the agent may use, e.g. `"Read Edit Grep Glob"`. |
+| `disallowed-tools` | agent-arg | (none) | space-separated tool names | Blacklist tools, e.g. `"Bash"`. |
+| `add-dir` | agent-arg | (none) | path | Grant the agent access to a directory outside the worktree. |
+| `mcp-config` | agent-arg | (none) | path to JSON | Load MCP servers from a JSON config, giving the agent access to external tools. |
+
+The class-level baseline is `AGENT_DEFAULTS = {"permission-mode": "auto"}` and `ACTOR_DEFAULTS = {"use-subscription": "true"}`. The role's `prompt` field is injected as `--append-system-prompt` (the `SYSTEM_PROMPT_KEY` for Claude).
+
+```kdl
+defaults "claude" {
+    use-subscription true
+    permission-mode "auto"
+    model "opus"
+}
+```
+
+## Codex
+
+| Key | Kind | Default | Valid values | Description |
+| --- | --- | --- | --- | --- |
+| `use-subscription` | actor-key | `true` | `true`, `false` | When `true`, strips `OPENAI_API_KEY` from the agent's env so Codex uses the logged-in subscription. Set to `false` to bill against the API key. |
+| `sandbox` | agent-arg | `danger-full-access` | `danger-full-access`, `workspace-write`, `read-only` | Sandbox policy for shell commands. `danger-full-access` is unsandboxed; `workspace-write` allows writes only inside the workspace; `read-only` blocks all writes. |
+| `a` | agent-arg | `never` | `never`, `on-request`, `untrusted` | Approval policy. `never` auto-approves everything; `on-request` lets the agent decide when to ask; `untrusted` only auto-approves a small set of trusted commands. |
+| `m` | agent-arg | (agent's default) | model name | Codex model. Also settable via `--model` on `actor new`. |
+| `add-dir` | agent-arg | (none) | path | Grant the agent write access outside the worktree. |
+| `search` | agent-arg | (none) | `true` | Enable live web search. |
+
+The class-level baseline is `AGENT_DEFAULTS = {"sandbox": "danger-full-access", "a": "never"}` and `ACTOR_DEFAULTS = {"use-subscription": "true"}`. Codex has no first-class system-prompt CLI flag, so `SYSTEM_PROMPT_KEY` is `None` and roles with a `prompt` field combined with `agent "codex"` are rejected at `actor new` time.
+
+```kdl
+defaults "codex" {
+    use-subscription true
+    m "o3"
+    sandbox "workspace-write"
+    a "on-request"
+}
+```
+
+## Cancelling a default
+
+A higher-precedence layer can drop a key with `null`:
+
+```kdl
+defaults "claude" {
+    permission-mode null   # drop the built-in "auto" default
+}
+```
+
+The emitter skips keys whose final resolved value is `None`, so the flag never reaches the agent binary.
+
+## See also
+
+- [Claude agent config guide](../../guides/01-claude-config/) — fuller examples and notes per key.
+- [Codex agent config guide](../../guides/02-codex-config/) — same, for Codex.
+- [CLI reference](../01-cli/) — `actor new`, `actor config`, and `actor run` flag surfaces.
+- [MCP tool reference](../02-mcp-tools/) — `config=[...]` argument shape on the MCP side.

--- a/docs/content/reference/03-config-keys.md
+++ b/docs/content/reference/03-config-keys.md
@@ -2,6 +2,7 @@
 title: "Config Keys"
 description: "Every config key per agent — actor-keys, agent-args, defaults, and valid values."
 weight: 3
+slug: "config-keys"
 ---
 
 Every config key actor-sh recognizes, grouped by agent. Use this page when you need to look up what a key does, what its default is, or what values it accepts.

--- a/docs/content/reference/_index.md
+++ b/docs/content/reference/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Reference"
+description: "Flat lookup: every CLI subcommand, every MCP tool, every config key."
+weight: 4
+---
+
+Reference pages are terse — assume you already know roughly what you're looking for and just want to confirm flag names, defaults, and shapes.
+
+- [CLI reference](01-cli/) — every `actor` subcommand with its flags and a worked example.
+- [MCP tool reference](02-mcp-tools/) — every `mcp__actor__*` tool the server exposes, with arguments and the channel notification shape.
+- [Config keys](03-config-keys/) — every config key per agent (Claude / Codex), as actor-keys vs forwarded agent flags.
+
+If you want narrative explanations rather than lookup tables, see [Concepts](../concepts/) for the model and [Guides](../guides/) for task-shaped walkthroughs.

--- a/site/archetypes/default.md
+++ b/site/archetypes/default.md
@@ -1,0 +1,6 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+description: ""
+slug: "{{ .Name | replaceRE `^[0-9]+-` `` }}"
+weight: 0
+---

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -1,0 +1,18 @@
+baseURL = "/"
+locale = "en-us"
+title = "actor.sh"
+contentDir = "../docs/content"
+enableRobotsTXT = true
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+  [markup.highlight]
+    style = "github"
+    noClasses = false
+    lineNos = false
+    tabWidth = 2
+
+[params]
+  description = "actor.sh manages parallel Claude/Codex coding agents in isolated git worktrees."

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  {{ partial "head.html" . }}
+</head>
+<body>
+  {{ partial "sidebar.html" . }}
+  <main class="main">
+    <article class="article">
+      {{ block "main" . }}{{ end }}
+    </article>
+    {{ partial "footer.html" . }}
+  </main>
+</body>
+</html>

--- a/site/layouts/_default/list.html
+++ b/site/layouts/_default/list.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+<header class="page-header">
+  <h1>{{ .Title }}</h1>
+  {{ with .Description }}<p class="lede">{{ . }}</p>{{ end }}
+</header>
+{{ with .Content }}
+  <div class="prose">{{ . }}</div>
+{{ end }}
+{{ with .Pages.ByWeight }}
+  <ul class="page-list">
+    {{ range . }}
+      <li>
+        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        {{ with .Description }}<span class="page-list-desc">{{ . }}</span>{{ end }}
+      </li>
+    {{ end }}
+  </ul>
+{{ end }}
+{{ end }}

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -1,0 +1,39 @@
+{{ define "main" }}
+<header class="page-header">
+  <h1>{{ .Title }}</h1>
+  {{ with .Description }}<p class="lede">{{ . }}</p>{{ end }}
+</header>
+<div class="prose">
+  {{ .Content }}
+</div>
+{{ $section := .CurrentSection }}
+{{ if $section }}
+  {{ $pages := $section.Pages.ByWeight }}
+  {{ $idx := -1 }}
+  {{ range $i, $p := $pages }}
+    {{ if eq $p.RelPermalink $.RelPermalink }}{{ $idx = $i }}{{ end }}
+  {{ end }}
+  {{ if ge $idx 0 }}
+    {{ $prev := false }}
+    {{ $next := false }}
+    {{ if gt $idx 0 }}{{ $prev = index $pages (sub $idx 1) }}{{ end }}
+    {{ if lt $idx (sub (len $pages) 1) }}{{ $next = index $pages (add $idx 1) }}{{ end }}
+    {{ if or $prev $next }}
+      <nav class="pager">
+        {{ if $prev }}
+          <a class="pager-prev" href="{{ $prev.RelPermalink }}">
+            <span class="pager-label">← Previous</span>
+            <span class="pager-title">{{ $prev.Title }}</span>
+          </a>
+        {{ else }}<span></span>{{ end }}
+        {{ if $next }}
+          <a class="pager-next" href="{{ $next.RelPermalink }}">
+            <span class="pager-label">Next →</span>
+            <span class="pager-title">{{ $next.Title }}</span>
+          </a>
+        {{ else }}<span></span>{{ end }}
+      </nav>
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ end }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{ site.Title }}</title>
+<meta http-equiv="refresh" content="0; url={{ "/getting-started/introduction/" | relURL }}">
+<link rel="canonical" href="{{ "/getting-started/introduction/" | relURL }}">
+<style>
+  body { font: 14px/1.6 system-ui, -apple-system, sans-serif; color: #57534e; padding: 2rem; max-width: 40rem; margin: 0 auto; }
+  a { color: #1c1917; }
+</style>
+</head>
+<body>
+<p>Loading documentation… <a href="{{ "/getting-started/introduction/" | relURL }}">continue →</a></p>
+</body>
+</html>

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -1,0 +1,5 @@
+<footer class="footer">
+  <span>{{ site.Title }}</span>
+  <span class="sep">·</span>
+  <a href="https://github.com/mme/actor.sh">GitHub</a>
+</footer>

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -1,0 +1,13 @@
+{{- $title := .Title | default site.Title -}}
+{{- $desc := .Description | default site.Params.description -}}
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{ if eq .Kind "home" }}{{ site.Title }}{{ else }}{{ $title }} — {{ site.Title }}{{ end }}</title>
+{{ with $desc }}<meta name="description" content="{{ . }}">{{ end }}
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600&display=swap">
+
+<link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+<link rel="canonical" href="{{ .Permalink }}">

--- a/site/layouts/partials/sidebar.html
+++ b/site/layouts/partials/sidebar.html
@@ -1,0 +1,20 @@
+{{- $current := . -}}
+<aside class="sidebar">
+  <div class="sidebar-inner">
+    <a class="brand" href="{{ "/" | relURL }}">actor.sh</a>
+    <nav class="nav">
+      {{ range site.Sections.ByWeight }}
+        {{ if .Pages }}
+          <h3 class="nav-section">{{ .Title }}</h3>
+          <ul class="nav-list">
+            {{ range .Pages.ByWeight }}
+              <li class="nav-item{{ if eq .RelPermalink $current.RelPermalink }} active{{ end }}">
+                <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+              </li>
+            {{ end }}
+          </ul>
+        {{ end }}
+      {{ end }}
+    </nav>
+  </div>
+</aside>

--- a/site/static/css/style.css
+++ b/site/static/css/style.css
@@ -1,0 +1,427 @@
+/* actor.sh — quiet editorial docs */
+
+:root {
+  --bg: #fafaf9;
+  --surface: #f5f5f4;
+  --surface-2: #ececeb;
+  --border: #e7e5e4;
+  --border-strong: #d6d3d1;
+  --fg: #1c1917;
+  --fg-muted: #57534e;
+  --fg-subtle: #78716c;
+  --fg-faint: #a8a29e;
+  --accent: #0369a1;
+  --accent-hover: #075985;
+
+  --font-serif: "Source Serif 4", "Source Serif Pro", Georgia, "Times New Roman", serif;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "Cascadia Code", "SF Mono", Menlo, monospace;
+
+  --sidebar-w: 17rem;
+  --content-w: 44rem; /* ~700px */
+  --gutter: 2rem;
+  --gutter-lg: 4rem;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  --radius: 3px;
+}
+
+* { box-sizing: border-box; }
+
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.65;
+  font-feature-settings: "kern", "liga", "calt";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* ------- layout shell ------- */
+
+.sidebar {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: var(--sidebar-w);
+  border-right: 1px solid var(--border);
+  background: var(--bg);
+  overflow-y: auto;
+  padding: var(--space-8) var(--space-6);
+  z-index: 10;
+}
+
+.sidebar-inner { display: flex; flex-direction: column; gap: var(--space-8); }
+
+.brand {
+  font-family: var(--font-serif);
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: var(--fg);
+  text-decoration: none;
+  letter-spacing: -0.01em;
+}
+
+.brand:hover { color: var(--fg); }
+
+.nav { display: flex; flex-direction: column; gap: var(--space-6); }
+
+.nav-section {
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-subtle);
+  margin: 0 0 var(--space-3);
+}
+
+.nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.nav-item a {
+  display: block;
+  padding: var(--space-1) 0;
+  color: var(--fg-muted);
+  text-decoration: none;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  border-left: 2px solid transparent;
+  padding-left: var(--space-3);
+  margin-left: calc(var(--space-3) * -1);
+  transition: color 80ms ease;
+}
+
+.nav-item a:hover { color: var(--fg); }
+
+.nav-item.active a {
+  color: var(--fg);
+  font-weight: 500;
+  border-left-color: var(--fg);
+}
+
+.main {
+  margin-left: var(--sidebar-w);
+  padding: var(--space-16) var(--gutter-lg) var(--space-16);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.article {
+  max-width: var(--content-w);
+  width: 100%;
+  margin: 0 auto;
+  flex: 1;
+}
+
+/* ------- page chrome ------- */
+
+.page-header { margin-bottom: var(--space-12); }
+
+.page-header h1 {
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin: 0 0 var(--space-3);
+  color: var(--fg);
+}
+
+.lede {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 1.15rem;
+  line-height: 1.5;
+  color: var(--fg-muted);
+  margin: 0;
+}
+
+/* ------- prose ------- */
+
+.prose { color: var(--fg); }
+
+.prose > * + * { margin-top: var(--space-6); }
+.prose > * + h2 { margin-top: var(--space-12); }
+.prose > * + h3 { margin-top: var(--space-8); }
+
+.prose h2,
+.prose h3,
+.prose h4 {
+  font-family: var(--font-serif);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+  line-height: 1.25;
+}
+
+.prose h2 { font-size: 1.5rem; margin-bottom: var(--space-3); }
+.prose h3 { font-size: 1.2rem; margin-bottom: var(--space-2); }
+.prose h4 { font-size: 1.05rem; font-weight: 600; }
+
+.prose p { margin: 0; }
+
+.prose a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+}
+
+.prose a:hover {
+  color: var(--accent-hover);
+  text-decoration-color: var(--accent-hover);
+}
+
+.prose strong { font-weight: 600; color: var(--fg); }
+.prose em { font-style: italic; }
+
+.prose ul,
+.prose ol {
+  margin: 0;
+  padding-left: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.prose ul ul,
+.prose ol ol,
+.prose ul ol,
+.prose ol ul { margin-top: var(--space-2); }
+
+.prose li::marker { color: var(--fg-faint); }
+
+.prose blockquote {
+  margin: 0;
+  padding-left: var(--space-4);
+  border-left: 2px solid var(--border-strong);
+  color: var(--fg-muted);
+  font-style: italic;
+}
+
+.prose hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: var(--space-12) 0;
+}
+
+.prose img,
+.prose video {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  border-radius: var(--radius);
+}
+
+/* ------- code ------- */
+
+.prose code,
+.prose pre {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+}
+
+.prose :not(pre) > code {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius);
+  font-size: 0.85em;
+}
+
+.prose pre {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-4) var(--space-6);
+  overflow-x: auto;
+  line-height: 1.55;
+  font-size: 0.85rem;
+}
+
+.prose pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* hugo highlight wrapper */
+.prose .highlight { margin: 0; }
+.prose .highlight pre { margin: 0; }
+
+/* ------- tables ------- */
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.prose th,
+.prose td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border);
+}
+
+.prose th {
+  font-weight: 600;
+  color: var(--fg);
+  border-bottom-color: var(--border-strong);
+}
+
+/* ------- pager ------- */
+
+.pager {
+  margin-top: var(--space-16);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-6);
+}
+
+.pager > a {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  text-decoration: none;
+  color: var(--fg-muted);
+  padding: var(--space-3) 0;
+  border: 0;
+}
+
+.pager-next { text-align: right; align-items: flex-end; }
+.pager-prev { text-align: left; align-items: flex-start; }
+
+.pager-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-faint);
+}
+
+.pager-title {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  color: var(--fg);
+}
+
+.pager > a:hover .pager-title { color: var(--accent-hover); }
+
+/* ------- list (category index) ------- */
+
+.page-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-list li {
+  padding: var(--space-4) 0;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.page-list a {
+  font-family: var(--font-serif);
+  font-size: 1.15rem;
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.page-list a:hover { color: var(--accent-hover); }
+
+.page-list-desc { color: var(--fg-muted); font-size: 0.95rem; }
+
+/* ------- footer ------- */
+
+.footer {
+  margin-top: var(--space-16);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--border);
+  font-size: 0.8rem;
+  color: var(--fg-subtle);
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  max-width: var(--content-w);
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.footer a {
+  color: var(--fg-subtle);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.footer a:hover { color: var(--fg); border-bottom-color: var(--fg-muted); }
+
+.footer .sep { color: var(--fg-faint); }
+
+/* ------- selection ------- */
+
+::selection {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--fg);
+}
+
+/* ------- responsive ------- */
+
+@media (max-width: 1024px) {
+  :root { --gutter-lg: 3rem; }
+}
+
+@media (max-width: 800px) {
+  .sidebar {
+    position: static;
+    width: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+    padding: var(--space-6);
+  }
+  .sidebar-inner { gap: var(--space-6); }
+  .nav { flex-direction: row; flex-wrap: wrap; gap: var(--space-4) var(--space-6); }
+  .nav-section { margin-bottom: var(--space-2); }
+  .main {
+    margin-left: 0;
+    padding: var(--space-12) var(--gutter) var(--space-12);
+  }
+}
+
+@media (max-width: 480px) {
+  body { font-size: 15px; }
+  .main { padding: var(--space-8) var(--space-6) var(--space-8); }
+  .page-header { margin-bottom: var(--space-8); }
+}


### PR DESCRIPTION
## Summary
- Adds Hugo-based docs site at `site/` (custom layouts, plain CSS, stone palette + serif headings; no JS/Sass/Tailwind)
- Adds 21 markdown docs pages under `docs/content/` across four categories — getting started, concepts, guides, reference
- Adds `.github/workflows/deploy-site.yml` — GitHub Pages via Actions (upload-pages-artifact + deploy-pages); no `gh-pages` branch, no build artifacts in repo
- Pinned to hugo-extended 0.161.1; uses `actions/configure-pages@v5` so `baseURL` works for both github.io subpath and any future custom domain without a workflow change
- The `Master Orchestrator` → `main actor` identity rename (from #75) is applied to the docs prose as well; the two PRs are otherwise independent

## Done end-to-end checklist
- [x] Hugo build clean (32 pages, 0 warnings/errors) at `mme.github.io/actor.sh/` baseURL
- [x] Deploy YAML valid (PyYAML safe_load)
- [x] No build artifacts staged (`site/public/`, `site/resources/`, `site/.hugo_build.lock` ignored)
- [x] All 21 docs pages have valid frontmatter; no `<!-- TODO: verify -->` markers remain
- [ ] CI green
- [ ] Merge
- [ ] **Needs decision (user-side)**: enable Pages in repo Settings → Pages → Source: **GitHub Actions**
- [ ] Verify live at `https://mme.github.io/actor.sh/getting-started/introduction/` after Pages is enabled and a push to main fires the workflow

## Test plan
- [x] Local: `cd site && hugo --minify --baseURL "https://mme.github.io/actor.sh/" --destination /tmp/test` builds clean
- [x] Local: `hugo server` serves `/` (redirects to first doc) and `/getting-started/introduction/`
- [ ] CI runs the existing test suite — should be unaffected (no Python source changed)
- [ ] After merge + Pages enabled, verify the deploy workflow runs and `https://mme.github.io/actor.sh/` resolves

## Built across three actors in parallel
- `website` — Hugo scaffold + intro stub
- `docs-content` — full markdown content via internal subagents (one per category)
- `deploy` — the workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)