### PR TITLE
deploy: self-enable Pages + add actor.sh CNAME

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -29,6 +29,8 @@ jobs:
           extended: true
       - uses: actions/configure-pages@v5
         id: pages
+        with:
+          enablement: true
       - name: Build
         working-directory: site
         run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"

--- a/site/static/CNAME
+++ b/site/static/CNAME
@@ -1,0 +1,1 @@
+actor.sh


### PR DESCRIPTION
## Summary
- `actions/configure-pages@v5` now uses `enablement: true` so it turns Pages on itself on first run (no manual click in repo Settings needed)
- Adds `site/static/CNAME` containing `actor.sh` so the deployed artifact carries the custom domain

## Context
The first deploy run after #76 merged failed because Pages wasn't yet enabled on the repo. This commit makes the workflow self-healing on that front, and pre-bakes the custom domain into the artifact so once DNS resolves to GitHub's IPs the site is reachable at `https://actor.sh/`.

User still needs to (separate channel):
1. Set Namecheap DNS records (4× A records for the apex + optional AAAA + optional CNAME for `www`)
2. Enter `actor.sh` in github.com → Settings → Pages → Custom domain (triggers DNS verification + HTTPS provisioning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)