### PR TITLE
docs site: 3-column layout + right-side TOC + marketing landing

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,9 +1,32 @@
 ---
 title: "actor.sh"
-description: "A main actor session backed by parallel coding sub-agents in isolated git worktrees."
+description: "Stop managing agents. Start directing outcomes. Parallel AI coding from your main Claude Code session — peer-level actors with their own context, in isolated git worktrees."
 weight: 0
 ---
 
-actor.sh manages multiple Claude Code or Codex agents running in parallel, each on its own branch in its own git worktree. You talk to one orchestrator session — `actor main` — and it spawns specialized sub-actors to handle the actual work, verifies their output, and reports back.
+# Stop managing agents. Start directing outcomes.
 
-Start with [Getting started](getting-started/) for installation and your first actor. The [Concepts](concepts/) section explains the model — what an actor is, how roles, hooks, and channel notifications fit together. [Guides](guides/) cover task-shaped configuration topics, and [Reference](reference/) is a flat lookup of every CLI subcommand, MCP tool, and config key.
+**Ten terminals, one of you. Let's fix that.**
+
+Parallel AI coding should give you leverage — not more tabs to manage. Most multi-agent setups quietly turn you into the middle manager: opening terminals, spinning up branches, copying prompts around, checking on progress, gathering results, deciding what's next.
+
+actor.sh flips that. **The conversation is the control room.**
+
+From your main Claude Code session, your agent can spin up actors, hand them focused work, let them run, and pull their results back when they finish. Because everything lands in the same conversation, your main agent can read the findings, launch follow-ups, weigh different approaches, or help you decide what to ship.
+
+## Pick up the thread.
+
+Subagents are for one-off tasks. Actors are for the conversation.
+
+An actor has its own working tree, its own context, and a thread you can keep talking to. Send a follow-up an hour later — or a week later — and it picks up where you both left off. Course-correct mid-stride. Ask for a revision. Hand it the next milestone.
+
+Subagents are short-lived helpers a single actor dispatches for parallel throughput. Actors are peer collaborators you can return to.
+
+You focus on what you want. The agent handles the wrangling.
+
+## Where to next
+
+- **[Getting started](getting-started/)** — install actor.sh, register the skill, spawn your first actor.
+- **[Concepts](concepts/)** — actors, worktrees, roles, hooks, channel notifications.
+- **[Guides](guides/)** — task-shaped configuration, agent setup, settings.kdl.
+- **[Reference](reference/)** — every CLI subcommand, MCP tool, and config key.

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -14,6 +14,7 @@
     </article>
     {{ partial "footer.html" . }}
   </main>
+  {{ if eq .Kind "page" }}{{ partial "toc.html" . }}{{ end }}
   <script src="{{ "js/theme.js" | relURL }}" defer></script>
 </body>
 </html>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,16 +1,5 @@
-<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>{{ site.Title }}</title>
-<meta http-equiv="refresh" content="0; url={{ "/getting-started/introduction/" | relURL }}">
-<link rel="canonical" href="{{ "/getting-started/introduction/" | relURL }}">
-<style>
-  body { font: 14px/1.6 ui-monospace, "JetBrains Mono", Menlo, monospace; color: #57534e; padding: 2rem; max-width: 40rem; margin: 0 auto; background: #f5f5f4; }
-  a { color: #0369a1; text-decoration: none; border-bottom: 1px solid currentColor; }
-</style>
-</head>
-<body>
-<p>Loading documentation… <a href="{{ "/getting-started/introduction/" | relURL }}">continue →</a></p>
-</body>
-</html>
+{{ define "main" }}
+<div class="prose landing">
+  {{ .Content }}
+</div>
+{{ end }}

--- a/site/layouts/partials/sidebar.html
+++ b/site/layouts/partials/sidebar.html
@@ -1,5 +1,5 @@
 {{- $current := . -}}
-<aside class="sidebar">
+<aside class="sidebar" id="site-sidebar">
   <nav class="nav">
     {{ range site.Sections.ByWeight }}
       {{ if .Pages }}

--- a/site/layouts/partials/toc.html
+++ b/site/layouts/partials/toc.html
@@ -1,0 +1,21 @@
+{{- $headings := slice -}}
+{{- with .Page.Fragments -}}
+  {{- range .Headings -}}
+    {{- if eq .Level 2 -}}{{- $headings = $headings | append . -}}{{- end -}}
+    {{- range .Headings -}}
+      {{- if eq .Level 2 -}}{{- $headings = $headings | append . -}}{{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $headings -}}
+<nav class="toc" aria-label="On this page">
+  <h3 class="toc-label">In this page</h3>
+  <ul class="toc-list">
+    {{ range $headings }}
+      <li class="toc-item">
+        <a href="#{{ .ID }}" data-toc-link="{{ .ID }}">{{ .Title }}</a>
+      </li>
+    {{ end }}
+  </ul>
+</nav>
+{{- end -}}

--- a/site/layouts/partials/topbar.html
+++ b/site/layouts/partials/topbar.html
@@ -1,4 +1,9 @@
 <header class="topbar">
+  <button type="button" class="icon-btn nav-toggle" data-sidebar-toggle aria-label="Toggle navigation" aria-controls="site-sidebar" aria-expanded="false">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M3 6h18M3 12h18M3 18h18"></path>
+    </svg>
+  </button>
   <a class="topbar-brand" href="{{ "/" | relURL }}">
     <span class="brand-mark" aria-hidden="true"></span>
     <span class="brand-name">actor.sh</span>
@@ -20,3 +25,4 @@
     </a>
   </div>
 </header>
+<div class="nav-backdrop" data-sidebar-backdrop aria-hidden="true"></div>

--- a/site/static/css/style.css
+++ b/site/static/css/style.css
@@ -34,6 +34,8 @@
 
   --header-h:    57px;
   --sidebar-w:   16rem;     /* 256px */
+  --toc-w:       14rem;     /* 224px */
+  --toc-gutter:  2.5rem;    /* gap between content and TOC */
   --content-max: 42rem;     /* ~672px */
   --gutter:      1.5rem;
   --gutter-lg:   3rem;
@@ -167,6 +169,30 @@ body {
 html[data-theme="dark"] .icon-sun { display: none; }
 html:not([data-theme="dark"]) .icon-moon { display: none; }
 
+/* nav-toggle: only visible below the sidebar breakpoint */
+.nav-toggle { display: none; margin-right: 0.5rem; margin-left: -0.5rem; }
+@media (max-width: 767.98px) {
+  .nav-toggle { display: inline-flex; }
+}
+
+/* backdrop for the mobile sidebar drawer */
+.nav-backdrop {
+  position: fixed;
+  inset: var(--header-h) 0 0 0;
+  background: color-mix(in srgb, var(--fg-strong) 35%, transparent);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms ease;
+  z-index: 30;
+}
+html[data-nav-open="true"] .nav-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+@media (min-width: 768px) {
+  .nav-backdrop { display: none; }
+}
+
 /* ----- layout ----- */
 
 .sidebar {
@@ -191,11 +217,17 @@ html:not([data-theme="dark"]) .icon-moon { display: none; }
   padding: 3rem var(--gutter-lg) 4rem;
   max-width: calc(var(--content-max) + var(--gutter-lg) * 2);
   width: 100%;
+  margin: 0 auto;     /* center column 2 within the remaining space */
   flex: 1;
 }
 
 .article-inner {
   max-width: var(--content-max);
+}
+
+/* Three-column layout at >=1280px: reserve right-side TOC slot. */
+@media (min-width: 1280px) {
+  .main { margin-right: calc(var(--toc-w) + var(--toc-gutter)); }
 }
 
 /* ----- sidebar nav ----- */
@@ -261,6 +293,63 @@ html:not([data-theme="dark"]) .icon-moon { display: none; }
 
 .nav-item.active a::before { color: var(--fg-soft); }
 
+/* ----- right-side TOC ----- */
+
+.toc {
+  display: none;          /* hidden by default; shown at >=1280px */
+  position: fixed;
+  top: calc(var(--header-h) + 2.5rem);
+  right: 2rem;
+  width: var(--toc-w);
+  max-height: calc(100vh - var(--header-h) - 4rem);
+  overflow-y: auto;
+  z-index: 5;
+}
+@media (min-width: 1280px) { .toc { display: block; } }
+
+.toc-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--fg-faint);
+  padding: 0 0 0.65rem;
+  margin: 0 0 0.65rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.toc-item a {
+  display: block;
+  padding: 0.3rem 0.85rem;
+  margin-left: -2px;
+  border-left: 2px solid transparent;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--fg-soft);
+  text-decoration: none;
+  transition: color 80ms ease, border-color 80ms ease;
+}
+
+.toc-item a:hover {
+  color: var(--fg);
+}
+
+.toc-item a[aria-current="true"] {
+  color: var(--fg-strong);
+  border-left-color: var(--link);
+  font-weight: 500;
+}
+
 /* ----- article ----- */
 
 .eyebrow {
@@ -304,13 +393,24 @@ html:not([data-theme="dark"]) .icon-moon { display: none; }
   line-height: 1.5;
 }
 
-.prose > * + * { margin-top: 1.5rem; }
-.prose > * + h2 { margin-top: 3rem; }
-.prose > * + h3 { margin-top: 2.25rem; }
-.prose > * + pre { margin-top: 1.25rem; }
-.prose > pre + * { margin-top: 1.5rem; }
+/* Reset block margins on direct prose children — sibling rules below are the sole source of vertical rhythm. */
+.prose > * { margin: 0; }
+.prose > * + * { margin-top: 1.25rem; }              /* 20px default */
+.prose > * + h2 { margin-top: 3rem; }                /* 48px before h2 */
+.prose > h1 + h2,
+.prose > .lede + h2,
+.prose > .page-lede + h2,
+.prose > :first-child:where(h2) { margin-top: 1.5rem; } /* 24px when h2 follows title/lede */
+.prose > * + h3 { margin-top: 2rem; }                /* 32px before h3 */
+.prose > h2 + * { margin-top: 1rem; }                /* 16px after h2 (matches ref ul mt=16) */
+.prose > h3 + * { margin-top: 0.75rem; }             /* 12px after h3 */
+.prose > * + ul, .prose > * + ol { margin-top: 1rem; }
+.prose > * + pre, .prose > * + .highlight { margin-top: 1.5rem; }
+.prose > h3 + pre, .prose > h3 + .highlight { margin-top: 0.75rem; }
+.prose > pre + *, .prose > .highlight + * { margin-top: 1.25rem; }
 
-/* h2 in body = small mono caps with hairline divider, like majorcontext */
+/* h2 in body = small mono caps with hairline divider, like majorcontext.
+   Spacing comes from sibling rules above; here we only style + add the divider. */
 .prose h2 {
   font-family: var(--font-mono);
   font-size: 12px;
@@ -319,10 +419,12 @@ html:not([data-theme="dark"]) .icon-moon { display: none; }
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--fg-muted);
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 1.5rem;
+  scroll-margin-top: calc(var(--header-h) + 1rem);
 }
+
+.prose h3 { scroll-margin-top: calc(var(--header-h) + 1rem); }
 
 .prose h3 {
   font-family: var(--font-serif);
@@ -331,7 +433,6 @@ html:not([data-theme="dark"]) .icon-moon { display: none; }
   line-height: 1.55;
   letter-spacing: -0.025em;
   color: var(--fg-strong);
-  margin-bottom: 0.5rem;
 }
 
 .prose h4 {
@@ -341,10 +442,9 @@ html:not([data-theme="dark"]) .icon-moon { display: none; }
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--fg-muted);
-  margin-bottom: 0.5rem;
 }
 
-.prose p { margin: 0; color: var(--fg-muted); }
+.prose p { color: var(--fg-muted); }
 
 .prose strong { color: var(--fg-strong); font-weight: 600; }
 .prose em { font-style: italic; }
@@ -362,14 +462,14 @@ html:not([data-theme="dark"]) .icon-moon { display: none; }
 
 /* lists */
 .prose ul, .prose ol {
-  margin: 0;
   padding-left: 1.4rem;
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
+  gap: 0.5rem;
 }
-.prose ul ul, .prose ol ol, .prose ul ol, .prose ol ul { margin-top: 0.55rem; }
+.prose ul ul, .prose ol ol, .prose ul ol, .prose ol ul { margin-top: 0.5rem; }
 .prose li { color: var(--fg-muted); }
+.prose li > * + * { margin-top: 0.75rem; }
 .prose li::marker { color: var(--fg-fainter); }
 
 .prose blockquote {
@@ -555,27 +655,28 @@ html:not([data-theme="dark"]) .icon-moon { display: none; }
   :root { --gutter-lg: 2rem; }
 }
 
-@media (max-width: 820px) {
+/* Below 768px: sidebar slides off-screen, opens via hamburger drawer. */
+@media (max-width: 767.98px) {
   .sidebar {
-    position: static;
-    width: auto;
-    inset: auto;
-    border-right: 0;
-    border-bottom: 1px solid var(--border);
-    padding: 1rem 0;
+    transform: translateX(-100%);
+    transition: transform 200ms ease;
+    border-right: 1px solid var(--border);
+    z-index: 40;
+  }
+  html[data-nav-open="true"] .sidebar {
+    transform: translateX(0);
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.18);
   }
   .main { margin-left: 0; padding-top: var(--header-h); }
-  .article { padding: 2rem var(--gutter); }
-  .nav { gap: 1rem; }
-  .nav-section { padding: 0 var(--gutter); }
-  .nav-item a { padding: 0.4rem var(--gutter); }
-  .page-title { font-size: 36px; }
-  .page-lede { font-size: 18px; }
+  .article { padding: 2.5rem var(--gutter) 3rem; }
+  .page-title { font-size: 40px; }
+  .page-lede { font-size: 20px; }
+  html[data-nav-open="true"] body { overflow: hidden; }
 }
 
 @media (max-width: 480px) {
   body { font-size: 14px; }
-  .article { padding: 1.5rem var(--gutter); }
+  .article { padding: 2rem var(--gutter) 2.5rem; }
   .page-title { font-size: 32px; }
   .topbar { padding: 0 var(--gutter); }
 }

--- a/site/static/js/theme.js
+++ b/site/static/js/theme.js
@@ -1,32 +1,117 @@
-// Tiny theme toggle: light/dark, persisted in localStorage.
-// The pre-paint init lives inline in head.html to avoid FOUC.
+// Theme toggle (persisted) + responsive sidebar drawer + TOC scroll-spy.
+// The pre-paint theme init lives inline in head.html to avoid FOUC.
 (function () {
   const STORAGE_KEY = 'actor-theme';
   const root = document.documentElement;
 
-  function apply(theme) {
-    if (theme === 'dark') root.dataset.theme = 'dark';
-    else delete root.dataset.theme;
-  }
-
-  function current() {
+  function currentTheme() {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === 'light' || stored === 'dark') return stored;
     return matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
-  function init() {
+  function applyTheme(theme) {
+    if (theme === 'dark') root.dataset.theme = 'dark';
+    else delete root.dataset.theme;
+  }
+
+  function initThemeToggle() {
     const btn = document.querySelector('[data-theme-toggle]');
     if (!btn) return;
     btn.addEventListener('click', () => {
-      const next = current() === 'dark' ? 'light' : 'dark';
+      const next = currentTheme() === 'dark' ? 'light' : 'dark';
       localStorage.setItem(STORAGE_KEY, next);
-      apply(next);
+      applyTheme(next);
     });
-
     matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-      if (!localStorage.getItem(STORAGE_KEY)) apply(e.matches ? 'dark' : 'light');
+      if (!localStorage.getItem(STORAGE_KEY)) applyTheme(e.matches ? 'dark' : 'light');
     });
+  }
+
+  function initSidebarDrawer() {
+    const toggle = document.querySelector('[data-sidebar-toggle]');
+    const backdrop = document.querySelector('[data-sidebar-backdrop]');
+    const sidebar = document.getElementById('site-sidebar');
+    if (!toggle || !sidebar) return;
+
+    function setOpen(open) {
+      if (open) root.dataset.navOpen = 'true';
+      else delete root.dataset.navOpen;
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+
+    toggle.addEventListener('click', () => setOpen(root.dataset.navOpen !== 'true'));
+    if (backdrop) backdrop.addEventListener('click', () => setOpen(false));
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && root.dataset.navOpen === 'true') setOpen(false);
+    });
+    sidebar.addEventListener('click', (e) => {
+      if (e.target.closest('a')) setOpen(false);
+    });
+    matchMedia('(min-width: 768px)').addEventListener('change', (e) => {
+      if (e.matches) setOpen(false);
+    });
+  }
+
+  function initTocScrollSpy() {
+    const links = document.querySelectorAll('[data-toc-link]');
+    if (!links.length) return;
+
+    const byId = new Map();
+    links.forEach((a) => byId.set(a.dataset.tocLink, a));
+
+    const targets = [];
+    byId.forEach((_a, id) => {
+      const el = document.getElementById(id);
+      if (el) targets.push(el);
+    });
+    if (!targets.length) return;
+
+    let current = null;
+    function setActive(id) {
+      if (id === current) return;
+      current = id;
+      links.forEach((a) => {
+        if (a.dataset.tocLink === id) a.setAttribute('aria-current', 'true');
+        else a.removeAttribute('aria-current');
+      });
+    }
+
+    // rootMargin top: 64px (just below topbar) + a generous bottom buffer so
+    // the section that's actually being read wins over the next one entering.
+    const io = new IntersectionObserver(
+      (entries) => {
+        // Build the list of currently-intersecting sections, sorted by document order.
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .map((e) => e.target);
+        if (visible.length) {
+          visible.sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top);
+          setActive(visible[0].id);
+        }
+      },
+      { rootMargin: '-72px 0px -65% 0px', threshold: 0 }
+    );
+    targets.forEach((t) => io.observe(t));
+
+    // Fallback: pick the heading whose top is closest above the viewport top.
+    function pickByScroll() {
+      const probe = 80;
+      let best = targets[0];
+      for (const t of targets) {
+        if (t.getBoundingClientRect().top - probe <= 0) best = t;
+        else break;
+      }
+      setActive(best.id);
+    }
+    window.addEventListener('scroll', pickByScroll, { passive: true });
+    pickByScroll();
+  }
+
+  function init() {
+    initThemeToggle();
+    initSidebarDrawer();
+    initTocScrollSpy();
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary

Three coupled changes to the docs site:

### 1. 3-column layout (≥1280px)
Sidebar (16rem) │ centered content (max 42rem) │ right-side TOC (14rem). Below 1280px the TOC hides and content uses the centered column. Below 768px the hamburger drawer takes over.

### 2. Right-side TOC + scroll-spy
- New `site/layouts/partials/toc.html` renders "In this page" with anchor links per page H2.
- Wired in `baseof.html` only on `Kind=page` (list pages don't get an empty third column).
- `theme.js` gains a tiny IntersectionObserver that flips `aria-current` on the active link as the user scrolls.
- `scroll-margin-top` so anchor jumps don't tuck under the topbar.

### 3. Marketing landing on `/`
- `docs/content/_index.md` rewritten with the "Stop managing agents. Start directing outcomes." copy, including the **Pick up the thread** section that names the contrast between short-lived subagents and continuing-collaborator actors.
- `site/layouts/index.html` rewritten to render `_index.md` content (was previously a meta-refresh to the intro page). `/` now serves the landing as intended, with the standard sidebar + topbar around it.

## Verification
- [x] `hugo --minify --baseURL https://actor.sh/` — 32 pages, 0 warnings, 0 errors
- [x] All 21 site URLs serve 200 locally
- [x] TOC populated, sticky, active-state updates on scroll, hidden at <1280px
- [x] Hamburger drawer still works at <768px (open/ESC/backdrop/nav-link all close)
- [x] Theme toggle still works and persists
- [x] Landing renders marketing copy at `/` (no redirect)

## Test plan
- [ ] CI test job
- [ ] After merge, deploy workflow runs → site updates at https://actor.sh
- [ ] Verify `/` shows the new landing copy (hard reload to bust cache)
- [ ] Verify a per-page TOC appears on, e.g., https://actor.sh/getting-started/installation/ at desktop width

🤖 Generated with [Claude Code](https://claude.com/claude-code)