### PR TITLE
site: render Introduction at / directly; drop redirect

### DIFF
--- a/docs/content/getting-started/01-introduction.md
+++ b/docs/content/getting-started/01-introduction.md
@@ -39,4 +39,4 @@ Actors are different. Each actor is a peer-level coding agent with its own worki
 
 ## What's next
 
-[Installation](../installation/) gets actor.sh on your machine and registered with Claude Code. Then [Your first actor](../first-actor/) walks you through spawning one end-to-end and inspecting the work it did.
+[Installation](/getting-started/installation/) gets actor.sh on your machine and registered with Claude Code. Then [Your first actor](/getting-started/first-actor/) walks you through spawning one end-to-end and inspecting the work it did.

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -14,7 +14,7 @@
     </article>
     {{ partial "footer.html" . }}
   </main>
-  {{ if eq .Kind "page" }}{{ partial "toc.html" . }}{{ end }}
+  {{ if or (eq .Kind "page") (eq .Kind "home") }}{{ partial "toc.html" . }}{{ end }}
   <script src="{{ "js/theme.js" | relURL }}" defer></script>
 </body>
 </html>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,17 +1,29 @@
-<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>actor.sh — Documentation</title>
-<meta http-equiv="refresh" content="0; url={{ "/getting-started/introduction/" | relURL }}">
-<link rel="canonical" href="{{ "/getting-started/introduction/" | relURL }}">
-<meta name="description" content="What actor.sh is and why it exists.">
-<style>
-  body { font: 14px/1.6 ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace; color: #57534e; padding: 2rem; max-width: 40rem; margin: 0 auto; background: #f5f5f4; }
-  a { color: #0369a1; text-decoration: none; border-bottom: 1px solid currentColor; }
-</style>
-</head>
-<body>
-<p>Loading documentation… <a href="{{ "/getting-started/introduction/" | relURL }}">continue →</a></p>
-</body>
-</html>
+{{ define "main" }}
+{{ $intro := site.GetPage "/getting-started/01-introduction" }}
+{{ with $intro }}
+{{ with .CurrentSection }}{{ if .Title }}<span class="eyebrow">{{ .Title }}</span>{{ end }}{{ end }}
+<h1 class="page-title">{{ .Title }}</h1>
+{{ with .Description }}<p class="page-lede">{{ . }}</p>{{ end }}
+<div class="prose">
+  {{ .Content }}
+</div>
+{{ $section := .CurrentSection }}
+{{ if $section }}
+  {{ $pages := $section.Pages.ByWeight }}
+  {{ $idx := -1 }}
+  {{ range $i, $p := $pages }}
+    {{ if eq $p.RelPermalink $intro.RelPermalink }}{{ $idx = $i }}{{ end }}
+  {{ end }}
+  {{ if and (ge $idx 0) (lt $idx (sub (len $pages) 1)) }}
+    {{ $next := index $pages (add $idx 1) }}
+    <nav class="pager">
+      <span></span>
+      <a class="pager-next" href="{{ $next.RelPermalink }}">
+        <span class="pager-label">Next →</span>
+        <span class="pager-title">{{ $next.Title }}</span>
+      </a>
+    </nav>
+  {{ end }}
+{{ end }}
+{{ end }}
+{{ end }}

--- a/site/layouts/partials/sidebar.html
+++ b/site/layouts/partials/sidebar.html
@@ -1,4 +1,10 @@
 {{- $current := . -}}
+{{- $currentLink := $current.RelPermalink -}}
+{{- if $current.IsHome -}}
+  {{- with site.GetPage "/getting-started/01-introduction" -}}
+    {{- $currentLink = .RelPermalink -}}
+  {{- end -}}
+{{- end -}}
 <aside class="sidebar" id="site-sidebar">
   <nav class="nav">
     {{ range site.Sections.ByWeight }}
@@ -7,7 +13,7 @@
           <h3 class="nav-section">{{ .Title }}</h3>
           <ul class="nav-list">
             {{ range .Pages.ByWeight }}
-              <li class="nav-item{{ if eq .RelPermalink $current.RelPermalink }} active{{ end }}">
+              <li class="nav-item{{ if eq .RelPermalink $currentLink }} active{{ end }}">
                 <a href="{{ .RelPermalink }}">{{ .Title }}</a>
               </li>
             {{ end }}

--- a/site/layouts/partials/toc.html
+++ b/site/layouts/partials/toc.html
@@ -1,5 +1,11 @@
+{{- $page := .Page -}}
+{{- if $page.IsHome -}}
+  {{- with site.GetPage "/getting-started/01-introduction" -}}
+    {{- $page = . -}}
+  {{- end -}}
+{{- end -}}
 {{- $headings := slice -}}
-{{- with .Page.Fragments -}}
+{{- with $page.Fragments -}}
   {{- range .Headings -}}
     {{- if eq .Level 2 -}}{{- $headings = $headings | append . -}}{{- end -}}
     {{- range .Headings -}}


### PR DESCRIPTION
## Summary

- `/` now renders the Introduction content inline instead of meta-refreshing to `/getting-started/introduction/`. Both URLs serve the same content (sourced once, from `01-introduction.md`).
- Sidebar and TOC highlight **Introduction** on both URLs (`/` is treated as the intro page for active-state).
- The two relative `../` links in the intro markdown become absolute so they resolve correctly when rendered at `/`.

## Test plan

- [x] `hugo --minify` clean — 32 pages, no errors
- [x] `/` renders eyebrow / H1 / lede / content / TOC / pager identical to the intro page
- [x] `/getting-started/introduction/` still renders, still highlights Introduction
- [x] Browser titles: `/` → `actor.sh`, `/getting-started/introduction/` → `Introduction — actor.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)