### PR TITLE
site: subtle separator under each sidebar section title

### DIFF
--- a/site/static/css/style.css
+++ b/site/static/css/style.css
@@ -243,8 +243,9 @@ html[data-nav-open="true"] .nav-backdrop {
   text-transform: uppercase;
   letter-spacing: 0.2em;
   color: var(--fg-muted);
-  padding: 0 1.5rem;
+  padding: 0 1.5rem 0.75rem;
   margin: 0 0 0.5rem;
+  border-bottom: 1px solid var(--border);
 }
 
 .nav-list {


### PR DESCRIPTION
## Summary

Match the sidebar divider treatment on majorcontext.com/moat — a 1px bottom border under each section title (Getting started / Concepts / Guides / Reference). Color is `--border` (stone-300 light, #3f3a36 dark), exactly the values moat uses against the same stone-200 / stone-800 sidebar background.

## Test plan

- [x] Hugo build clean
- [x] Verified visually in both light and dark modes via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)