### PR TITLE
site: align sidebar separator with link column; match moat's spacing

### DIFF
--- a/site/static/css/style.css
+++ b/site/static/css/style.css
@@ -234,17 +234,27 @@ html[data-nav-open="true"] .nav-backdrop {
 
 /* ----- sidebar nav ----- */
 
-.nav { display: flex; flex-direction: column; gap: 1.5rem; }
+/* Horizontal padding lives on .nav so all children share the same indentation;
+   the section-title border-bottom then aligns with the link column instead of
+   spanning the full sidebar width. Active items use negative margins to extend
+   their background back out to the sidebar edges. */
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 0 1.5rem;
+}
 
 .nav-section {
   font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 600;
+  line-height: 1.33;
   text-transform: uppercase;
   letter-spacing: 0.2em;
   color: var(--fg-muted);
-  padding: 0 1.5rem 0.75rem;
-  margin: 0 0 0.5rem;
+  padding: 0 0 0.75rem;
+  margin: 0 0 0.75rem;
   border-bottom: 1px solid var(--border);
 }
 
@@ -261,9 +271,9 @@ html[data-nav-open="true"] .nav-backdrop {
 
 .nav-item a {
   display: flex;
-  gap: 0.85rem;
-  align-items: baseline;
-  padding: 0.45rem 1.5rem;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem 0;
   color: var(--fg-soft);
   text-decoration: none;
   font-size: 14px;
@@ -273,28 +283,25 @@ html[data-nav-open="true"] .nav-backdrop {
 
 .nav-item a::before {
   content: counter(nav-counter, decimal-leading-zero);
+  width: 1.5rem;
   font-size: 10px;
-  color: var(--fg-fainter);
+  color: var(--fg-soft);
   letter-spacing: 0.05em;
   flex-shrink: 0;
   font-weight: 500;
   font-variant-numeric: tabular-nums;
-  position: relative;
-  top: -1px;
 }
 
 .nav-item a:hover {
-  color: var(--fg);
-  background: color-mix(in srgb, var(--fg) 4%, transparent);
+  color: var(--fg-body);
 }
 
 .nav-item.active a {
-  color: var(--fg-strong);
+  color: var(--fg-body);
   background: var(--bg);
-  border-right: 0;
+  margin: 0 -1.5rem;
+  padding: 0.5rem 1.5rem;
 }
-
-.nav-item.active a::before { color: var(--fg-soft); }
 
 /* ----- right-side TOC ----- */
 


### PR DESCRIPTION
## Summary

PR #91 added a separator under each sidebar section title, but the line spanned the full sidebar width — wider than majorcontext.com/moat's, where the line sits flush with the link column. Move horizontal padding from `.nav-section` (and `.nav-item a`) onto `.nav` so all children share the same indentation; the border-bottom now naturally aligns with the link column.

While in here, brought several other small details into parity (item link spacing, number-badge column width, active-item background extending to sidebar edges via negative margin, hover state).

Verified light + dark via DOM inspection (computed styles + bounding rects) against moat. Reference comparison from the actor:

| Aspect | Moat | Pre-fix | Post-fix |
|---|---|---|---|
| Border-bottom extent (px) | x=24→232 (208 wide) | x=0→256 | matches moat |
| Item link padding | 8px 0 | 7.2px 24px | 8px 0 |
| Item flex gap | 8px | ~13.6px | 8px |
| Item align-items | center | baseline | center |
| Number badge column | fixed 24px | no fixed width | fixed 24px |

## Test plan

- [x] Hugo build clean
- [x] Light + dark verified via Playwright DOM inspection
- [ ] Confirm GitHub Pages deploy lands on actor.sh post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)